### PR TITLE
Sørge for å sette en partisjonsnøkkel på "søknad_behandlet_hendelse" …

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/Mediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/Mediator.kt
@@ -5,6 +5,7 @@ import no.nav.dagpenger.behandling.hendelser.SøknadBehandletHendelse
 import no.nav.dagpenger.behandling.hendelser.SøknadHendelse
 import no.nav.dagpenger.behandling.persistence.BehandlingRepository
 import no.nav.dagpenger.behandling.persistence.Inmemory
+import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.RapidsConnection
 
 class Mediator(
@@ -29,6 +30,10 @@ class Mediator(
         )
 
         behandling.håndter(søknadBehandletHendelse)
-        rapidsConnection.publish(søknadBehandletHendelse.toJson())
+        val søknadBehandletMessage = JsonMessage.newMessage(
+            eventName = "søknad_behandlet_hendelse",
+            map = søknadBehandletHendelse.toJsonMessageMap(),
+        )
+        rapidsConnection.publish(behandling.person.ident, søknadBehandletMessage.toJson())
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/MediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/MediatorTest.kt
@@ -13,6 +13,7 @@ import java.util.UUID
 class MediatorTest {
     private val testRapid = TestRapid()
     private lateinit var mediator: Mediator
+    private val ident = "123"
 
     @BeforeEach
     fun setup() {
@@ -26,7 +27,7 @@ class MediatorTest {
     fun `Behandle BehandlingSvar hendelse`() {
         mediator.behandle(
             BehandlingSvar(
-                ident = "123",
+                ident = ident,
                 behandlingUUID = mockPersistence.behandlingId,
                 stegUUID = mockPersistence.finnStegId("vilkår1"),
                 verdi = false,
@@ -35,7 +36,7 @@ class MediatorTest {
 
         mediator.behandle(
             BehandlingSvar(
-                ident = "123",
+                ident = ident,
                 behandlingUUID = mockPersistence.behandlingId,
                 stegUUID = mockPersistence.finnStegId("vilkår 1 dato"),
                 verdi = LocalDate.now(),
@@ -44,7 +45,7 @@ class MediatorTest {
 
         mediator.behandle(
             BehandlingSvar(
-                ident = "123",
+                ident = ident,
                 behandlingUUID = mockPersistence.behandlingId,
                 stegUUID = mockPersistence.finnStegId("fastsettelse1"),
                 verdi = 3,
@@ -64,7 +65,9 @@ class MediatorTest {
         testRapid.inspektør.size shouldBe 1
 
         val event = testRapid.inspektør.message(0)
+        val partitionKey = testRapid.inspektør.key(0)
 
+        partitionKey shouldBe ident
         event["@event_name"].asText() shouldBe "søknad_behandlet_hendelse"
     }
 

--- a/modell/build.gradle.kts
+++ b/modell/build.gradle.kts
@@ -10,5 +10,4 @@ dependencies {
     api("ch.qos.logback:logback-classic:1.4.6")
     api(Kotlin.Logging.kotlinLogging)
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
-
 }

--- a/modell/src/main/kotlin/no/nav/dagpenger/behandling/hendelser/SøknadBehandletHendelse.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/behandling/hendelser/SøknadBehandletHendelse.kt
@@ -1,24 +1,16 @@
 package no.nav.dagpenger.behandling.hendelser
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import no.nav.dagpenger.behandling.Behandling
 
 class SøknadBehandletHendelse(
     val behandling: Behandling,
     val innvilget: Boolean,
 ) : Hendelse(behandling.person.ident) {
-
-    companion object {
-        private val objectmapper = jacksonObjectMapper()
-    }
-
-    fun toJson(): String {
-        val event = mapOf(
-            "@event_name" to "søknad_behandlet_hendelse",
+    fun toJsonMessageMap(): Map<String, Any> {
+        return mapOf(
             "behandlingId" to behandling.uuid,
             "innvilget" to innvilget,
             "ident" to behandling.person.ident,
         ) + behandling.fastsettelser()
-        return objectmapper.writeValueAsString(event)
     }
 }

--- a/modell/src/test/kotlin/no/nav/dagpenger/behandling/hendelser/SøknadBehandletHendelseTest.kt
+++ b/modell/src/test/kotlin/no/nav/dagpenger/behandling/hendelser/SøknadBehandletHendelseTest.kt
@@ -1,6 +1,6 @@
 package no.nav.dagpenger.behandling.hendelser
 
-import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.maps.shouldContainAll
 import no.nav.dagpenger.behandling.Behandling
 import no.nav.dagpenger.behandling.Person
 import no.nav.dagpenger.behandling.Steg
@@ -25,16 +25,13 @@ class SøknadBehandletHendelseTest {
             innvilget = true,
         )
 
-        //language=JSON
-        val expectedJson = """{
-        "@event_name": "søknad_behandlet_hendelse",
-        "behandlingId": "${behandling.uuid}",
-        "virkningsdato": "2023-02-01",
-        "innvilget": true,
-        "ident" : "${behandling.person.ident}"
-    }
-        """.trimIndent()
+        val expectedJsonMessageMap = mapOf(
+            "behandlingId" to behandling.uuid,
+            "virkningsdato" to "2023-02-01",
+            "innvilget" to true,
+            "ident" to behandling.person.ident,
+        )
 
-        søknadBehandletHendelse.toJson() shouldEqualJson expectedJson
+        søknadBehandletHendelse.toJsonMessageMap() shouldContainAll expectedJsonMessageMap
     }
 }


### PR DESCRIPTION
…til å være ident.

Refaktorerte SøknadBehandletHendelse til å gi ut en parameter map i stedet for å serialisere json. Bruker heller `JsonMessage.newMessage` som inkluderer en del "gratis" felter som `@opprettet` dato og `@id` blant annet.