### PR TITLE
Fjerner utsending av `vedtak_fattet_til_arena` som er erstattet etter…

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/ApplicationBuilder.kt
@@ -123,7 +123,7 @@ internal class ApplicationBuilder(configuration: Map<String, String>) : RapidsCo
         }.also { rapidsConnection ->
             utsendingMediator.setRapidsConnection(rapidsConnection)
             oppgaveMediator.setRapidsConnection(rapidsConnection)
-            VedtakFattetMottak(rapidsConnection, oppgaveMediator, utsendingMediator)
+            VedtakFattetMottak(rapidsConnection, oppgaveMediator)
             BehandlingOpprettetMottak(rapidsConnection, oppgaveMediator, pdlKlient, skjermingKlient)
             BehandlingAvbruttMottak(rapidsConnection, oppgaveMediator)
             ForslagTilVedtakMottak(rapidsConnection, oppgaveMediator)

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/VedtakFattetMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/VedtakFattetMottak.kt
@@ -11,15 +11,12 @@ import mu.withLoggingContext
 import no.nav.dagpenger.saksbehandling.OppgaveMediator
 import no.nav.dagpenger.saksbehandling.Sak
 import no.nav.dagpenger.saksbehandling.hendelser.VedtakFattetHendelse
-import no.nav.dagpenger.saksbehandling.utsending.UtsendingMediator
-import java.util.UUID
 
 private val logger = KotlinLogging.logger {}
 
 internal class VedtakFattetMottak(
     rapidsConnection: RapidsConnection,
     private val oppgaveMediator: OppgaveMediator,
-    private val utsendingMediator: UtsendingMediator,
 ) : River.PacketListener {
     companion object {
         val rapidFilter: River.() -> Unit = {
@@ -58,20 +55,8 @@ internal class VedtakFattetMottak(
                     sak = sak,
                 ),
             )
-            packet["@event_name"] = "vedtak_fattet_til_arena"
-            packet["meldingOmVedtakProdusent"] = vedtakProdusent(behandlingId)
-            context.publish(packet.toJson())
-            logger.info {
-                "Publiserte vedtak_fattet_til_arena hendelse for søknadId $søknadId og behandlingId $behandlingId"
-            }
         }
     }
-
-    private fun vedtakProdusent(behandlingId: UUID): String =
-        when (utsendingMediator.utsendingFinnesForBehandling(behandlingId)) {
-            true -> "Dagpenger"
-            false -> "Arena"
-        }
 }
 
 private fun JsonMessage.sak(): Sak = Sak(id = this["fagsakId"].asText())

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
@@ -1052,10 +1052,9 @@ class OppgaveMediatorTest {
             ).also {
                 it.setRapidsConnection(testRapid)
             }
-        val utsendingMediator = mockk<UtsendingMediator>(relaxed = true)
 
         BehandlingOpprettetMottak(testRapid, oppgaveMediator, pdlKlientMock, skjermingKlientMock)
-        VedtakFattetMottak(testRapid, oppgaveMediator, utsendingMediator)
+        VedtakFattetMottak(testRapid, oppgaveMediator)
 
         val søknadId = UUIDv7.ny()
         val behandlingId = UUIDv7.ny()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/helper/Testdata.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/helper/Testdata.kt
@@ -25,23 +25,6 @@ internal fun vedtakFattetHendelse(
     }"""
 }
 
-internal fun vedtakFattetHendelseMedMeldingOmVedtakProdusent(
-    ident: String,
-    søknadId: UUID,
-    behandlingId: UUID,
-    sakId: Int,
-): String {
-    //language=JSON
-    return """{
-      "@event_name": "vedtak_fattet",
-      "søknadId": "$søknadId",
-      "meldingOmVedtakProdusent": "Arena",
-      "behandlingId": "$behandlingId",
-      "ident": "$ident",
-      "fagsakId": $sakId,
-    }"""
-}
-
 internal fun distribuertDokumentBehovLøsning(
     oppgaveId: UUID,
     journalpostId: String,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/VedtakFattetMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/VedtakFattetMottakTest.kt
@@ -1,7 +1,6 @@
 package no.nav.dagpenger.saksbehandling.mottak
 
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
-import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -13,9 +12,7 @@ import no.nav.dagpenger.saksbehandling.Person
 import no.nav.dagpenger.saksbehandling.Sak
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.helper.vedtakFattetHendelse
-import no.nav.dagpenger.saksbehandling.helper.vedtakFattetHendelseMedMeldingOmVedtakProdusent
 import no.nav.dagpenger.saksbehandling.hendelser.VedtakFattetHendelse
-import no.nav.dagpenger.saksbehandling.utsending.UtsendingMediator
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 import java.util.UUID
@@ -46,16 +43,14 @@ internal class VedtakFattetMottakTest {
 
     private val testRapid = TestRapid()
     private val oppgaveMediatorMock = mockk<OppgaveMediator>(relaxed = true)
-    private val utsendingMediatorMock = mockk<UtsendingMediator>()
 
     init {
-        VedtakFattetMottak(testRapid, oppgaveMediatorMock, utsendingMediatorMock)
+        VedtakFattetMottak(testRapid, oppgaveMediatorMock)
     }
 
     @Test
     fun `Skal behandle vedtak fattet hendelse når utsending ikke finnes`() {
         every { oppgaveMediatorMock.ferdigstillOppgave(any<VedtakFattetHendelse>()) } returns oppgave
-        every { utsendingMediatorMock.utsendingFinnesForBehandling(behandlingId = oppgave.behandling.behandlingId) } returns false
         testRapid.sendTestMessage(
             vedtakFattetHendelse(
                 ident = testIdent,
@@ -74,19 +69,12 @@ internal class VedtakFattetMottakTest {
             )
         verify(exactly = 1) {
             oppgaveMediatorMock.ferdigstillOppgave(vedtakFattetHendelse)
-        }
-
-        testRapid.inspektør.size shouldBe 1
-        testRapid.inspektør.message(0).apply {
-            this["@event_name"].asText() shouldBe "vedtak_fattet_til_arena"
-            this["meldingOmVedtakProdusent"].asText() shouldBe "Arena"
         }
     }
 
     @Test
     fun `Skal behandle vedtak fattet hendelse når utsending finnes`() {
         every { oppgaveMediatorMock.ferdigstillOppgave(any<VedtakFattetHendelse>()) } returns oppgave
-        every { utsendingMediatorMock.utsendingFinnesForBehandling(behandlingId = oppgave.behandling.behandlingId) } returns true
         testRapid.sendTestMessage(
             vedtakFattetHendelse(
                 ident = testIdent,
@@ -106,42 +94,17 @@ internal class VedtakFattetMottakTest {
         verify(exactly = 1) {
             oppgaveMediatorMock.ferdigstillOppgave(vedtakFattetHendelse)
         }
-
-        testRapid.inspektør.size shouldBe 1
-        testRapid.inspektør.message(0).apply {
-            this["@event_name"].asText() shouldBe "vedtak_fattet_til_arena"
-            this["meldingOmVedtakProdusent"].asText() shouldBe "Dagpenger"
-        }
-    }
-
-    @Test
-    fun `Skal ikke behandle vedtak fattet hendelser allerede beriket med meldingOmVedtakProdusent`() {
-        every { oppgaveMediatorMock.ferdigstillOppgave(any<VedtakFattetHendelse>()) } returns oppgave
-        testRapid.sendTestMessage(
-            vedtakFattetHendelseMedMeldingOmVedtakProdusent(
-                ident = testIdent,
-                søknadId = søknadId,
-                behandlingId = behandlingId,
-                sakId = sak.id.toInt(),
-            ),
-        )
-        verify(exactly = 0) {
-            oppgaveMediatorMock.ferdigstillOppgave(any<VedtakFattetHendelse>())
-        }
     }
 
     @Test
     fun `Leser ny versjon av vedtak_fattet innhold`() {
         every { oppgaveMediatorMock.ferdigstillOppgave(any<VedtakFattetHendelse>()) } returns oppgave
-        every { utsendingMediatorMock.utsendingFinnesForBehandling(any()) } returns true
         val vedtakFattetFil = "/vedtak_fattet.json"
         val vedtakFattet = this.javaClass.getResource(vedtakFattetFil)?.readText() ?: throw AssertionError("Fant ikke fil $vedtakFattetFil")
         testRapid.sendTestMessage(vedtakFattet)
 
-        testRapid.inspektør.size shouldBe 1
-        testRapid.inspektør.message(0).apply {
-            this["@event_name"].asText() shouldBe "vedtak_fattet_til_arena"
-            this["meldingOmVedtakProdusent"].asText() shouldBe "Dagpenger"
+        verify(exactly = 1) {
+            oppgaveMediatorMock.ferdigstillOppgave(any<VedtakFattetHendelse>())
         }
     }
 }


### PR DESCRIPTION
… omskrivning av dp-arena-sink. dp-arena-sink sender behov om `MeldingOmVedtakProdusent` som blir løst av dp-saksbehandling. (i MeldingOmVedtakProdusentBehovløser)