### PR TITLE
feature/auditlogg

### DIFF
--- a/mediator/build.gradle.kts
+++ b/mediator/build.gradle.kts
@@ -39,6 +39,9 @@ dependencies {
     implementation("de.slub-dresden:urnlib:2.0.1")
     implementation("dev.hsbrysk:caffeine-coroutines:2.0.2")
 
+    implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.1.0")
+    implementation("io.opentelemetry:opentelemetry-api:1.36.0")
+
     api("com.fasterxml.uuid:java-uuid-generator:5.1.0")
 
     testImplementation(libs.mockk)

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/AktivitetsloggMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/AktivitetsloggMediator.kt
@@ -1,0 +1,29 @@
+package no.nav.dagpenger.saksbehandling
+
+import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
+import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageContext
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.instrumentation.annotations.WithSpan
+import no.nav.dagpenger.aktivitetslogg.AktivitetsloggEventMapper
+import no.nav.dagpenger.aktivitetslogg.AktivitetsloggHendelse
+
+internal class AktivitetsloggMediator {
+    private val aktivitetsloggEventMapper = AktivitetsloggEventMapper()
+
+    @WithSpan
+    fun håndter(
+        context: MessageContext,
+        hendelse: AktivitetsloggHendelse,
+    ) {
+        Span.current().addEvent("Publiserer aktivitetslogg")
+        aktivitetsloggEventMapper.håndter(hendelse) { aktivitetLoggMelding ->
+            context.publish(
+                JsonMessage
+                    .newMessage(
+                        aktivitetLoggMelding.eventNavn,
+                        aktivitetLoggMelding.innhold,
+                    ).toJson(),
+            )
+        }
+    }
+}

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/ApplicationBuilder.kt
@@ -14,6 +14,7 @@ import no.nav.dagpenger.saksbehandling.api.OppgaveHistorikkDTOMapper
 import no.nav.dagpenger.saksbehandling.api.Oppslag
 import no.nav.dagpenger.saksbehandling.api.RelevanteJournalpostIdOppslag
 import no.nav.dagpenger.saksbehandling.api.installerApis
+import no.nav.dagpenger.saksbehandling.audit.ApiAuditlogg
 import no.nav.dagpenger.saksbehandling.behandling.BehandlingHttpKlient
 import no.nav.dagpenger.saksbehandling.db.PostgresDataSourceBuilder.dataSource
 import no.nav.dagpenger.saksbehandling.db.PostgresDataSourceBuilder.runMigration
@@ -182,6 +183,7 @@ internal class ApplicationBuilder(configuration: Map<String, String>) : RapidsCo
             utsendingMediator.setRapidsConnection(rapidsConnection)
             oppgaveMediator.setRapidsConnection(rapidsConnection)
             klageMediator.setRapidsConnection(rapidsConnection)
+            klageMediator.setAuditlogg(ApiAuditlogg(AktivitetsloggMediator(), rapidsConnection))
             BehandlingOpprettetMottak(rapidsConnection, sakMediator)
             BehandlingAvbruttMottak(rapidsConnection, oppgaveMediator)
             VedtakFattetMottak(rapidsConnection, oppgaveMediator)

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/KlageMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/KlageMediator.kt
@@ -64,7 +64,7 @@ class KlageMediator(
             saksbehandler = saksbehandler,
         )
         val klageBehandling = klageRepository.hentKlageBehandling(behandlingId)
-        // auditlogg.les("Så en klagebehandling", /* ident her? */, saksbehandler.navIdent)
+        auditlogg.les("Så en klagebehandling", klageBehandling.personIdent(), saksbehandler.navIdent)
         return klageBehandling
     }
 
@@ -170,7 +170,7 @@ class KlageMediator(
         klageRepository.hentKlageBehandling(behandlingId).let { klageBehandling ->
             klageBehandling.svar(opplysningId, verdi)
             klageRepository.lagre(klageBehandling = klageBehandling)
-            // auditlogg.oppdater("Oppdaterte en klageopplysning", /* ident her? */, saksbehandler.navIdent)
+            auditlogg.oppdater("Oppdaterte en klageopplysning", klageBehandling.personIdent(), saksbehandler.navIdent)
         }
     }
 
@@ -321,7 +321,7 @@ class KlageMediator(
 
         klageRepository.lagre(klageBehandling)
         oppgaveMediator.ferdigstillOppgave(avbruttHendelse = hendelse)
-        // auditlogg.oppdater("Avbrutte en klage", /* ident her? */, hendelse.utførtAv.navIdent)
+        auditlogg.oppdater("Avbrutte en klage", klageBehandling.personIdent(), hendelse.utførtAv.navIdent)
     }
 
     fun oversendtTilKlageinstans(hendelse: OversendtKlageinstansHendelse) {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/KlageMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/KlageMediator.kt
@@ -63,7 +63,9 @@ class KlageMediator(
             behandlingId = behandlingId,
             saksbehandler = saksbehandler,
         )
-        return klageRepository.hentKlageBehandling(behandlingId)
+        val klageBehandling = klageRepository.hentKlageBehandling(behandlingId)
+        // auditlogg.les("Så en klagebehandling", /* ident her? */, saksbehandler.navIdent)
+        return klageBehandling
     }
 
     fun opprettKlage(klageMottattHendelse: KlageMottattHendelse): Oppgave {
@@ -132,6 +134,12 @@ class KlageMediator(
             )
         sakMediator.knyttTilSak(behandlingOpprettetHendelse = behandlingOpprettetHendelse)
 
+        auditlogg.opprett(
+            "Opprettet en manuell klage",
+            manuellKlageMottattHendelse.ident,
+            utførtAv.navIdent,
+        )
+
         return kotlin.runCatching {
             oppgaveMediator.opprettOppgaveForBehandling(
                 behandlingOpprettetHendelse = behandlingOpprettetHendelse,
@@ -162,6 +170,7 @@ class KlageMediator(
         klageRepository.hentKlageBehandling(behandlingId).let { klageBehandling ->
             klageBehandling.svar(opplysningId, verdi)
             klageRepository.lagre(klageBehandling = klageBehandling)
+            // auditlogg.oppdater("Oppdaterte en klageopplysning", /* ident her? */, saksbehandler.navIdent)
         }
     }
 
@@ -251,6 +260,7 @@ class KlageMediator(
 
             val saksbehandler = saksbehandlerDeferred.await()
             if (klageBehandling.utfall() == UtfallType.OPPRETTHOLDELSE) {
+                auditlogg.oppdater("Ferdigstilte en klage", oppgave.personIdent(), saksbehandler.ident)
                 val body =
                     mutableMapOf(
                         "behandlingId" to klageBehandling.behandlingId.toString(),
@@ -311,6 +321,7 @@ class KlageMediator(
 
         klageRepository.lagre(klageBehandling)
         oppgaveMediator.ferdigstillOppgave(avbruttHendelse = hendelse)
+        // auditlogg.oppdater("Avbrutte en klage", /* ident her? */, hendelse.utførtAv.navIdent)
     }
 
     fun oversendtTilKlageinstans(hendelse: OversendtKlageinstansHendelse) {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/KlageMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/KlageMediator.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 import no.nav.dagpenger.saksbehandling.api.Oppslag
+import no.nav.dagpenger.saksbehandling.audit.Auditlogg
 import no.nav.dagpenger.saksbehandling.db.klage.KlageRepository
 import no.nav.dagpenger.saksbehandling.hendelser.AvbruttHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingOpprettetHendelse
@@ -44,9 +45,14 @@ class KlageMediator(
     private val sakMediator: SakMediator,
 ) {
     private lateinit var rapidsConnection: RapidsConnection
+    private lateinit var auditlogg: Auditlogg
 
     fun setRapidsConnection(rapidsConnection: RapidsConnection) {
         this.rapidsConnection = rapidsConnection
+    }
+
+    fun setAuditlogg(auditlogg: Auditlogg) {
+        this.auditlogg = auditlogg
     }
 
     fun hentKlageBehandling(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/audit/ApiAuditlogg.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/audit/ApiAuditlogg.kt
@@ -1,0 +1,93 @@
+package no.nav.dagpenger.saksbehandling.audit
+
+import com.github.navikt.tbd_libs.rapids_and_rivers_api.FailedMessage
+import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageContext
+import com.github.navikt.tbd_libs.rapids_and_rivers_api.OutgoingMessage
+import com.github.navikt.tbd_libs.rapids_and_rivers_api.SentMessage
+import no.nav.dagpenger.aktivitetslogg.Aktivitetslogg
+import no.nav.dagpenger.aktivitetslogg.AktivitetsloggHendelse
+import no.nav.dagpenger.aktivitetslogg.AuditOperasjon
+import no.nav.dagpenger.aktivitetslogg.IAktivitetslogg
+import no.nav.dagpenger.aktivitetslogg.SpesifikkKontekst
+import no.nav.dagpenger.saksbehandling.AktivitetsloggMediator
+import no.nav.dagpenger.saksbehandling.UUIDv7
+
+internal class ApiAuditlogg(
+    private val aktivitetsloggMediator: AktivitetsloggMediator,
+    private val rapidsConnection: MessageContext,
+) : Auditlogg {
+    override fun les(
+        melding: String,
+        ident: String,
+        saksbehandler: String,
+    ) = aktivitetslogg(ident) {
+        info(melding, ident, saksbehandler, AuditOperasjon.READ)
+    }
+
+    override fun opprett(
+        melding: String,
+        ident: String,
+        saksbehandler: String,
+    ) = aktivitetslogg(ident) {
+        info(melding, ident, saksbehandler, AuditOperasjon.CREATE)
+    }
+
+    override fun oppdater(
+        melding: String,
+        ident: String,
+        saksbehandler: String,
+    ) = aktivitetslogg(ident) {
+        info(melding, ident, saksbehandler, AuditOperasjon.UPDATE)
+    }
+
+    override fun slett(
+        melding: String,
+        ident: String,
+        saksbehandler: String,
+    ) = aktivitetslogg(ident) {
+        info(melding, ident, saksbehandler, AuditOperasjon.DELETE)
+    }
+
+    private fun aktivitetslogg(
+        ident: String,
+        block: AuditLoggHendelse.() -> Unit,
+    ) {
+        val aktivitetslogg = AuditLoggHendelse(ident)
+        block(aktivitetslogg)
+        aktivitetsloggMediator.håndter(KlageAuditContext(rapidsConnection, ident), aktivitetslogg)
+    }
+
+    private class KlageAuditContext(
+        val rapid: MessageContext,
+        val ident: String,
+    ) : MessageContext {
+        override fun publish(message: String) {
+            publish(ident, message)
+        }
+
+        override fun publish(
+            key: String,
+            message: String,
+        ) {
+            rapid.publish(ident, message)
+        }
+
+        override fun publish(messages: List<OutgoingMessage>): Pair<List<SentMessage>, List<FailedMessage>> {
+            return rapid.publish(messages)
+        }
+
+        override fun rapidName() = "apiAuditlogg"
+    }
+
+    private class AuditLoggHendelse(
+        val ident: String,
+        private val aktivitetslogg: Aktivitetslogg = Aktivitetslogg(),
+    ) : AktivitetsloggHendelse,
+        IAktivitetslogg by aktivitetslogg {
+        override fun ident() = ident
+
+        override fun meldingsreferanseId() = UUIDv7.ny()
+
+        override fun toSpesifikkKontekst() = SpesifikkKontekst("Auditlogg", mapOf("ident" to ident))
+    }
+}

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/audit/Auditlogg.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/audit/Auditlogg.kt
@@ -1,0 +1,27 @@
+package no.nav.dagpenger.saksbehandling.audit
+
+interface Auditlogg {
+    fun les(
+        melding: String,
+        ident: String,
+        saksbehandler: String,
+    )
+
+    fun opprett(
+        melding: String,
+        ident: String,
+        saksbehandler: String,
+    )
+
+    fun oppdater(
+        melding: String,
+        ident: String,
+        saksbehandler: String,
+    )
+
+    fun slett(
+        melding: String,
+        ident: String,
+        saksbehandler: String,
+    )
+}

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
@@ -7,6 +7,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
+import io.mockk.verify
 import no.nav.dagpenger.pdl.PDLPerson
 import no.nav.dagpenger.saksbehandling.AdressebeskyttelseGradering.UGRADERT
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.Type.FERDIG_BEHANDLET
@@ -250,6 +251,12 @@ class KlageMediatorTest {
             testRapid.inspektør.size shouldBe 2
             testRapid.inspektør.message(0).behovNavn() shouldBe "SaksbehandlingPdfBehov"
             testRapid.inspektør.message(1).behovNavn() shouldBe "OversendelseKlageinstans"
+
+            // i hver /registrer\w+?Opplysninger/-funksjon leses klagebehandlingen for hver opplysning som legges på.
+            // dermed blir tallene for både lesing og oppdatering sykt store.
+            verify(exactly = 21) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
+            verify(exactly = 21) { auditloggMock.oppdater("Oppdaterte en klageopplysning", testPersonIdent, saksbehandler.navIdent) }
+            verify(exactly = 1) { auditloggMock.oppdater("Ferdigstilte en klage", testPersonIdent, saksbehandler.navIdent) }
         }
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
@@ -866,9 +866,4 @@ class KlageMediatorTest {
         require(this["@event_name"].asText() == "behov") { "Forventet behov som event_name" }
         return this["@behov"].single().asText()
     }
-
-    private fun JsonNode.aktivitetsloggMelding(): String {
-        require(this["@event_name"].asText() == "aktivitetslogg") { "Forventet behov som aktivitetslogg" }
-        return this["melding"].single().asText()
-    }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
@@ -15,6 +15,7 @@ import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.Type.UNDER_BEHANDLING
 import no.nav.dagpenger.saksbehandling.api.Oppslag
 import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTO
 import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTOEnhetDTO
+import no.nav.dagpenger.saksbehandling.audit.ApiAuditlogg
 import no.nav.dagpenger.saksbehandling.db.Postgres.withMigratedDb
 import no.nav.dagpenger.saksbehandling.db.klage.PostgresKlageRepository
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
@@ -118,6 +119,23 @@ class KlageMediatorTest {
                     behandlingType = BehandlingType.KLAGE,
                 )
             } returns Result.success(html)
+        }
+    private val auditloggMock =
+        mockk<ApiAuditlogg>().also {
+            coEvery {
+                it.opprett(
+                    melding = any(),
+                    ident = any(),
+                    saksbehandler = any(),
+                )
+            } returns Unit
+            coEvery {
+                it.oppdater(
+                    melding = any(),
+                    ident = any(),
+                    saksbehandler = any(),
+                )
+            } returns Unit
         }
 
     @Test
@@ -799,7 +817,10 @@ class KlageMediatorTest {
                     oppslag = oppslagMock,
                     meldingOmVedtakKlient = meldingOmVedtakKlientMock,
                     sakMediator = sakMediator,
-                ).also { it.setRapidsConnection(rapidsConnection = testRapid) }
+                ).also {
+                    it.setAuditlogg(auditlogg = auditloggMock)
+                    it.setRapidsConnection(rapidsConnection = testRapid)
+                }
             personRepository.lagre(
                 Person(
                     ident = testPersonIdent,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
@@ -7,7 +7,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
-import io.mockk.verify
 import no.nav.dagpenger.pdl.PDLPerson
 import no.nav.dagpenger.saksbehandling.AdressebeskyttelseGradering.UGRADERT
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.Type.FERDIG_BEHANDLET
@@ -168,7 +167,6 @@ class KlageMediatorTest {
                 ).behandlingId
 
             klageMediator.hentKlageBehandling(behandlingId, saksbehandler).tilstand().type shouldBe BEHANDLES
-            verify(exactly = 1) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
 
             val oppgave = oppgaveMediator.hentOppgaveFor(behandlingId = behandlingId, saksbehandler = saksbehandler)
 
@@ -185,8 +183,6 @@ class KlageMediatorTest {
             )
 
             klageMediator.registrerKlageBehandlingOpplysninger(behandlingId, saksbehandler)
-            verify(exactly = 7) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
-            verify(exactly = 9) { auditloggMock.oppdater("Oppdaterte en klageopplysning", testPersonIdent, saksbehandler.navIdent) }
 
             shouldThrow<IllegalStateException> {
                 klageMediator.ferdigstill(
@@ -198,11 +194,8 @@ class KlageMediatorTest {
                     saksbehandlerToken = "token",
                 )
             }
-            verify(exactly = 0) { auditloggMock.oppdater("Ferdigstilte en klage", testPersonIdent, saksbehandler.navIdent) }
 
             klageMediator.registrerUtfallOpprettholdelseOpplysninger(behandlingId, saksbehandler)
-            verify(exactly = 19) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
-            verify(exactly = 21) { auditloggMock.oppdater("Oppdaterte en klageopplysning", testPersonIdent, saksbehandler.navIdent) }
             klageMediator.ferdigstill(
                 hendelse =
                     KlageFerdigbehandletHendelse(
@@ -211,14 +204,12 @@ class KlageMediatorTest {
                     ),
                 saksbehandlerToken = "token",
             )
-            verify(exactly = 1) { auditloggMock.oppdater("Ferdigstilte en klage", testPersonIdent, saksbehandler.navIdent) }
 
             val klageBehandling =
                 klageMediator.hentKlageBehandling(
                     behandlingId = behandlingId,
                     saksbehandler = saksbehandler,
                 )
-            verify(exactly = 20) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
             klageBehandling.tilstand().type shouldBe OVERSEND_KLAGEINSTANS
             klageBehandling.behandlendeEnhet() shouldBe behandlerDTO.enhet.enhetNr
 
@@ -251,7 +242,6 @@ class KlageMediatorTest {
             klageMediator.hentKlageBehandling(behandlingId = behandlingId, saksbehandler = saksbehandler)
                 .tilstand().type shouldBe FERDIGSTILT
 
-            verify(exactly = 21) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
             oppgaveMediator.hentOppgaveFor(
                 behandlingId = behandlingId,
                 saksbehandler = saksbehandler,
@@ -278,10 +268,7 @@ class KlageMediatorTest {
                     ),
                 ).behandlingId
 
-            verify(exactly = 1) { auditloggMock.opprett("Opprettet en manuell klage", testPersonIdent, saksbehandler.navIdent) }
-
             klageMediator.hentKlageBehandling(behandlingId, saksbehandler).tilstand().type shouldBe BEHANDLES
-            verify(exactly = 1) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
 
             val oppgave = oppgaveMediator.hentOppgaveFor(behandlingId = behandlingId, saksbehandler = saksbehandler)
 
@@ -291,8 +278,6 @@ class KlageMediatorTest {
             oppgave.sisteSaksbehandler() shouldBe saksbehandler.navIdent
 
             klageMediator.registrerKlageBehandlingOpplysninger(behandlingId, saksbehandler)
-            verify(exactly = 7) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
-            verify(exactly = 9) { auditloggMock.oppdater("Oppdaterte en klageopplysning", testPersonIdent, saksbehandler.navIdent) }
 
             shouldThrow<IllegalStateException> {
                 klageMediator.ferdigstill(
@@ -304,11 +289,8 @@ class KlageMediatorTest {
                     saksbehandlerToken = "token",
                 )
             }
-            verify(exactly = 0) { auditloggMock.oppdater("Ferdigstilte en klage", testPersonIdent, saksbehandler.navIdent) }
 
             klageMediator.registrerUtfallOpprettholdelseOpplysninger(behandlingId, saksbehandler)
-            verify(exactly = 19) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
-            verify(exactly = 21) { auditloggMock.oppdater("Oppdaterte en klageopplysning", testPersonIdent, saksbehandler.navIdent) }
             klageMediator.ferdigstill(
                 hendelse =
                     KlageFerdigbehandletHendelse(
@@ -317,13 +299,11 @@ class KlageMediatorTest {
                     ),
                 saksbehandlerToken = "token",
             )
-            verify(exactly = 1) { auditloggMock.oppdater("Ferdigstilte en klage", testPersonIdent, saksbehandler.navIdent) }
             val klageBehandling =
                 klageMediator.hentKlageBehandling(
                     behandlingId = behandlingId,
                     saksbehandler = saksbehandler,
                 )
-            verify(exactly = 20) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
             klageBehandling.tilstand().type shouldBe OVERSEND_KLAGEINSTANS
             klageBehandling.behandlendeEnhet() shouldBe behandlerDTO.enhet.enhetNr
 
@@ -355,7 +335,6 @@ class KlageMediatorTest {
 
             klageMediator.hentKlageBehandling(behandlingId = behandlingId, saksbehandler = saksbehandler)
                 .tilstand().type shouldBe FERDIGSTILT
-            verify(exactly = 21) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
             oppgaveMediator.hentOppgaveFor(
                 behandlingId = behandlingId,
                 saksbehandler = saksbehandler,
@@ -879,5 +858,10 @@ class KlageMediatorTest {
     private fun JsonNode.behovNavn(): String {
         require(this["@event_name"].asText() == "behov") { "Forventet behov som event_name" }
         return this["@behov"].single().asText()
+    }
+
+    private fun JsonNode.aktivitetsloggMelding(): String {
+        require(this["@event_name"].asText() == "aktivitetslogg") { "Forventet behov som aktivitetslogg" }
+        return this["melding"].single().asText()
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
@@ -7,6 +7,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
+import io.mockk.verify
 import no.nav.dagpenger.pdl.PDLPerson
 import no.nav.dagpenger.saksbehandling.AdressebeskyttelseGradering.UGRADERT
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.Type.FERDIG_BEHANDLET
@@ -136,6 +137,20 @@ class KlageMediatorTest {
                     saksbehandler = any(),
                 )
             } returns Unit
+            coEvery {
+                it.les(
+                    melding = any(),
+                    ident = any(),
+                    saksbehandler = any(),
+                )
+            } returns Unit
+            coEvery {
+                it.slett(
+                    melding = any(),
+                    ident = any(),
+                    saksbehandler = any(),
+                )
+            } returns Unit
         }
 
     @Test
@@ -153,6 +168,7 @@ class KlageMediatorTest {
                 ).behandlingId
 
             klageMediator.hentKlageBehandling(behandlingId, saksbehandler).tilstand().type shouldBe BEHANDLES
+            verify(exactly = 1) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
 
             val oppgave = oppgaveMediator.hentOppgaveFor(behandlingId = behandlingId, saksbehandler = saksbehandler)
 
@@ -169,6 +185,8 @@ class KlageMediatorTest {
             )
 
             klageMediator.registrerKlageBehandlingOpplysninger(behandlingId, saksbehandler)
+            verify(exactly = 7) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
+            verify(exactly = 9) { auditloggMock.oppdater("Oppdaterte en klageopplysning", testPersonIdent, saksbehandler.navIdent) }
 
             shouldThrow<IllegalStateException> {
                 klageMediator.ferdigstill(
@@ -180,8 +198,11 @@ class KlageMediatorTest {
                     saksbehandlerToken = "token",
                 )
             }
+            verify(exactly = 0) { auditloggMock.oppdater("Ferdigstilte en klage", testPersonIdent, saksbehandler.navIdent) }
 
             klageMediator.registrerUtfallOpprettholdelseOpplysninger(behandlingId, saksbehandler)
+            verify(exactly = 19) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
+            verify(exactly = 21) { auditloggMock.oppdater("Oppdaterte en klageopplysning", testPersonIdent, saksbehandler.navIdent) }
             klageMediator.ferdigstill(
                 hendelse =
                     KlageFerdigbehandletHendelse(
@@ -190,12 +211,14 @@ class KlageMediatorTest {
                     ),
                 saksbehandlerToken = "token",
             )
+            verify(exactly = 1) { auditloggMock.oppdater("Ferdigstilte en klage", testPersonIdent, saksbehandler.navIdent) }
 
             val klageBehandling =
                 klageMediator.hentKlageBehandling(
                     behandlingId = behandlingId,
                     saksbehandler = saksbehandler,
                 )
+            verify(exactly = 20) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
             klageBehandling.tilstand().type shouldBe OVERSEND_KLAGEINSTANS
             klageBehandling.behandlendeEnhet() shouldBe behandlerDTO.enhet.enhetNr
 
@@ -228,6 +251,7 @@ class KlageMediatorTest {
             klageMediator.hentKlageBehandling(behandlingId = behandlingId, saksbehandler = saksbehandler)
                 .tilstand().type shouldBe FERDIGSTILT
 
+            verify(exactly = 21) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
             oppgaveMediator.hentOppgaveFor(
                 behandlingId = behandlingId,
                 saksbehandler = saksbehandler,
@@ -254,7 +278,10 @@ class KlageMediatorTest {
                     ),
                 ).behandlingId
 
+            verify(exactly = 1) { auditloggMock.opprett("Opprettet en manuell klage", testPersonIdent, saksbehandler.navIdent) }
+
             klageMediator.hentKlageBehandling(behandlingId, saksbehandler).tilstand().type shouldBe BEHANDLES
+            verify(exactly = 1) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
 
             val oppgave = oppgaveMediator.hentOppgaveFor(behandlingId = behandlingId, saksbehandler = saksbehandler)
 
@@ -264,6 +291,8 @@ class KlageMediatorTest {
             oppgave.sisteSaksbehandler() shouldBe saksbehandler.navIdent
 
             klageMediator.registrerKlageBehandlingOpplysninger(behandlingId, saksbehandler)
+            verify(exactly = 7) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
+            verify(exactly = 9) { auditloggMock.oppdater("Oppdaterte en klageopplysning", testPersonIdent, saksbehandler.navIdent) }
 
             shouldThrow<IllegalStateException> {
                 klageMediator.ferdigstill(
@@ -275,8 +304,11 @@ class KlageMediatorTest {
                     saksbehandlerToken = "token",
                 )
             }
+            verify(exactly = 0) { auditloggMock.oppdater("Ferdigstilte en klage", testPersonIdent, saksbehandler.navIdent) }
 
             klageMediator.registrerUtfallOpprettholdelseOpplysninger(behandlingId, saksbehandler)
+            verify(exactly = 19) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
+            verify(exactly = 21) { auditloggMock.oppdater("Oppdaterte en klageopplysning", testPersonIdent, saksbehandler.navIdent) }
             klageMediator.ferdigstill(
                 hendelse =
                     KlageFerdigbehandletHendelse(
@@ -285,11 +317,13 @@ class KlageMediatorTest {
                     ),
                 saksbehandlerToken = "token",
             )
+            verify(exactly = 1) { auditloggMock.oppdater("Ferdigstilte en klage", testPersonIdent, saksbehandler.navIdent) }
             val klageBehandling =
                 klageMediator.hentKlageBehandling(
                     behandlingId = behandlingId,
                     saksbehandler = saksbehandler,
                 )
+            verify(exactly = 20) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
             klageBehandling.tilstand().type shouldBe OVERSEND_KLAGEINSTANS
             klageBehandling.behandlendeEnhet() shouldBe behandlerDTO.enhet.enhetNr
 
@@ -321,7 +355,7 @@ class KlageMediatorTest {
 
             klageMediator.hentKlageBehandling(behandlingId = behandlingId, saksbehandler = saksbehandler)
                 .tilstand().type shouldBe FERDIGSTILT
-
+            verify(exactly = 21) { auditloggMock.les("Så en klagebehandling", testPersonIdent, saksbehandler.navIdent) }
             oppgaveMediator.hentOppgaveFor(
                 behandlingId = behandlingId,
                 saksbehandler = saksbehandler,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/audit/ApiAuditloggTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/audit/ApiAuditloggTest.kt
@@ -1,0 +1,54 @@
+package no.nav.dagpenger.saksbehandling.audit
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
+import io.kotest.matchers.shouldBe
+import no.nav.dagpenger.saksbehandling.AktivitetsloggMediator
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ApiAuditloggTest {
+    private val testRapid = TestRapid()
+    private val testIdent = "12345678901"
+    private val testSaksbehandlerIdent = "12345678902"
+
+    private val auditlogg =
+        ApiAuditlogg(
+            aktivitetsloggMediator = AktivitetsloggMediator(),
+            rapidsConnection = testRapid,
+        )
+
+    @BeforeEach
+    fun setup() {
+        testRapid.reset()
+    }
+
+    @Test
+    fun les() {
+        auditlogg.les("Så en klagebehandling", testIdent, testSaksbehandlerIdent)
+        testRapid.inspektør.size shouldBe 1
+    }
+
+    @Test
+    fun opprett() {
+        auditlogg.opprett("Opprettet en klagebehandling", testIdent, testSaksbehandlerIdent)
+        testRapid.inspektør.size shouldBe 1
+    }
+
+    @Test
+    fun oppdater() {
+        auditlogg.opprett("Oppdaterte en klagebehandling", testIdent, testSaksbehandlerIdent)
+        testRapid.inspektør.size shouldBe 1
+    }
+
+    @Test
+    fun slett() {
+        auditlogg.opprett("Slettet en klagebehandling", testIdent, testSaksbehandlerIdent)
+        testRapid.inspektør.size shouldBe 1
+    }
+
+    private fun JsonNode.aktivitetsloggMelding(): String {
+        require(this["@event_name"].asText() == "aktivitetslogg") { "Forventet behov som aktivitetslogg" }
+        return "TODO: Jeg har lyst å bruke denne for å hente ut meldingen som sendes inn til auditloggen, men jeg vet ikke hvordan! "
+    }
+}


### PR DESCRIPTION
mer eller mindre kopiert rått fra dp-behandling.

arkitekturen følger deres, hvor auditlogg-meldinger blir sendt ut på kafka, og en eller annen app plukker de opp (og batcher og alt det der?), og sender det til arcsight.

jeg har ikke gjort noen endringer på meldingsformatet, slik at vi har høyest sjanse til at det bare funker :)