### PR TITLE
map til hjemmelnavn basert på tittelen til hjemmelen

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/KlageMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/KlageMediator.kt
@@ -17,6 +17,7 @@ import no.nav.dagpenger.saksbehandling.hendelser.KlageMottattHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.ManuellKlageMottattHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.OversendtKlageinstansHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.SettOppgaveAnsvarHendelse
+import no.nav.dagpenger.saksbehandling.klage.Hjemler
 import no.nav.dagpenger.saksbehandling.klage.KlageBehandling
 import no.nav.dagpenger.saksbehandling.klage.KlageBehandling.KlageTilstand.Type.BEHANDLES
 import no.nav.dagpenger.saksbehandling.klage.KlageTilstandsendring
@@ -358,5 +359,7 @@ fun KlageBehandling.hjemler(): List<String> {
     val verdi =
         this.synligeOpplysninger()
             .singleOrNull { it.type == OpplysningType.HJEMLER }?.verdi() as Verdi.Flervalg?
-    return verdi?.value?.map { it }.orEmpty()
+    return verdi?.value?.mapNotNull {
+        Hjemler.values().find { hjemmel -> hjemmel.tittel == it }?.name
+    }.orEmpty()
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
@@ -197,6 +197,7 @@ class KlageMediatorTest {
             }
 
             klageMediator.registrerUtfallOpprettholdelseOpplysninger(behandlingId, saksbehandler)
+
             klageMediator.ferdigstill(
                 hendelse =
                     KlageFerdigbehandletHendelse(
@@ -213,6 +214,7 @@ class KlageMediatorTest {
                 )
             klageBehandling.tilstand().type shouldBe OVERSEND_KLAGEINSTANS
             klageBehandling.behandlendeEnhet() shouldBe behandlerDTO.enhet.enhetNr
+            klageBehandling.hjemler() shouldBe listOf("FTRL_4_5_REGISTRERING", "FTRL_4_2")
 
             OversendtKlageinstansMottak(
                 rapidsConnection = testRapid,


### PR DESCRIPTION
frem til nå har vi sendt hjemmeltitler til Kabal (f.eks. `"§ 4-3 Krav til tap av arbeidstid"`), men disse kan ikke de forstå. de ønsker seg "enum"-navnet til hjemmelen (altså `"FTRL_4_3_2"`).

med denne fiksen vil hjemmeltitler bli mappes om til "hjemmelnavn", dog veldig løst koblet.

hjemler som ikke fins vil bli ignorerte, men kanskje det burde kaste en exception og ikke sendes til KA før vi har fått fikset det eventuelle problemet?

på sikt burde vi heller sende en liste av nøkkel og tittel til frontend, slik at valg i hjemmellisten kan returnere hjemmelnavnet i stedet for tittelen, men dette krever nok mer refaktorering enn denne fiksen. :sweat_smile: 