### PR TITLE
feat: Legg til observer pattern for utsending og refaktorer klage mottak

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/ApplicationBuilder.kt
@@ -33,9 +33,12 @@ import no.nav.dagpenger.saksbehandling.job.Job.Companion.Minutt
 import no.nav.dagpenger.saksbehandling.job.Job.Companion.getNextOccurrence
 import no.nav.dagpenger.saksbehandling.job.Job.Companion.now
 import no.nav.dagpenger.saksbehandling.journalpostid.MottakHttpKlient
+import no.nav.dagpenger.saksbehandling.klage.KlageBehandlingUtførtMottakForOppgave
+import no.nav.dagpenger.saksbehandling.klage.KlageBehandlingUtførtMottakForUtsending
 import no.nav.dagpenger.saksbehandling.klage.OversendKlageinstansAlarmJob
 import no.nav.dagpenger.saksbehandling.klage.OversendKlageinstansAlarmRepository
 import no.nav.dagpenger.saksbehandling.klage.OversendtKlageinstansMottak
+import no.nav.dagpenger.saksbehandling.klage.UtsendingDistribuertMottakForKlage
 import no.nav.dagpenger.saksbehandling.metrikker.MetrikkJob
 import no.nav.dagpenger.saksbehandling.mottak.ArenaSinkVedtakOpprettetMottak
 import no.nav.dagpenger.saksbehandling.mottak.BehandlingAvbruttMottak
@@ -60,6 +63,7 @@ import no.nav.dagpenger.saksbehandling.streams.leesah.adressebeskyttetStream
 import no.nav.dagpenger.saksbehandling.streams.skjerming.skjermetPersonStatus
 import no.nav.dagpenger.saksbehandling.utsending.UtsendingAlarmJob
 import no.nav.dagpenger.saksbehandling.utsending.UtsendingAlarmRepository
+import no.nav.dagpenger.saksbehandling.utsending.UtsendingDistribuertObserver
 import no.nav.dagpenger.saksbehandling.utsending.UtsendingMediator
 import no.nav.dagpenger.saksbehandling.utsending.db.PostgresUtsendingRepository
 import no.nav.dagpenger.saksbehandling.utsending.mottak.BehandlingsresultatMottakForUtsending
@@ -223,6 +227,7 @@ internal class ApplicationBuilder(
             }.also { rapidsConnection ->
                 sakMediator.setRapidsConnection(rapidsConnection)
                 utsendingMediator.setRapidsConnection(rapidsConnection)
+                utsendingMediator.addObserver(UtsendingDistribuertObserver(rapidsConnection))
                 oppgaveMediator.setRapidsConnection(rapidsConnection)
                 klageMediator.setRapidsConnection(rapidsConnection)
                 klageMediator.setAuditlogg(ApiAuditlogg(AktivitetsloggMediator(), rapidsConnection))
@@ -258,6 +263,18 @@ internal class ApplicationBuilder(
                 OversendtKlageinstansMottak(
                     rapidsConnection = rapidsConnection,
                     klageMediator = klageMediator,
+                )
+                UtsendingDistribuertMottakForKlage(
+                    rapidsConnection = rapidsConnection,
+                    klageMediator = klageMediator,
+                )
+                KlageBehandlingUtførtMottakForUtsending(
+                    rapidsConnection = rapidsConnection,
+                    utsendingMediator = utsendingMediator,
+                )
+                KlageBehandlingUtførtMottakForOppgave(
+                    rapidsConnection = rapidsConnection,
+                    oppgaveMediator = oppgaveMediator,
                 )
                 utsendingAlarmJob =
                     UtsendingAlarmJob(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/klage/UtsendingDistribuertMottakForKlage.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/klage/UtsendingDistribuertMottakForKlage.kt
@@ -4,14 +4,12 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
 import com.github.navikt.tbd_libs.rapids_and_rivers.River
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageContext
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageMetadata
-import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageProblems
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micrometer.core.instrument.MeterRegistry
 import no.nav.dagpenger.saksbehandling.KlageMediator
 import no.nav.dagpenger.saksbehandling.hendelser.UtsendingDistribuert
 import no.nav.dagpenger.saksbehandling.mottak.asUUID
-import no.nav.dagpenger.saksbehandling.utsending.DistribueringBehov
 import no.nav.dagpenger.saksbehandling.utsending.UtsendingType
 
 internal class UtsendingDistribuertMottakForKlage(
@@ -23,12 +21,10 @@ internal class UtsendingDistribuertMottakForKlage(
         private val sikkerlogger = KotlinLogging.logger("tjenestekall")
         val rapidFilter: River.() -> Unit = {
             precondition {
-                it.requireValue("@event_name", "behov")
-                it.requireAll("@behov", listOf(DistribueringBehov.BEHOV_NAVN))
-                it.requireKey("@løsning")
-                it.requireValue("utsendingType", UtsendingType.KLAGEMELDING.name)
+                it.requireValue("@event_name", "utsending_distribuert")
+                it.requireValue("type", UtsendingType.KLAGEMELDING.name)
             }
-            validate { it.requireKey("behandlingId", "ident", "utsendingId", "journalpostId") }
+            validate { it.requireKey("behandlingId", "ident", "utsendingId", "journalpostId", "distribusjonId") }
         }
     }
 
@@ -43,7 +39,7 @@ internal class UtsendingDistribuertMottakForKlage(
         meterRegistry: MeterRegistry,
     ) {
         val behandlingId = packet["behandlingId"].asUUID()
-        val distribusjonId = packet["@løsning"][DistribueringBehov.BEHOV_NAVN]["distribueringId"].asText()
+        val distribusjonId = packet["distribusjonId"].asText()
         val journalpostId = packet["journalpostId"].asText()
         val utsendingId = packet["utsendingId"].asUUID()
         val ident = packet["ident"].asText()

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/utsending/UtsendingDistribuertObserver.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/utsending/UtsendingDistribuertObserver.kt
@@ -1,0 +1,39 @@
+package no.nav.dagpenger.saksbehandling.utsending
+
+import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
+import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
+import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.dagpenger.saksbehandling.utsending.hendelser.DistribuertHendelse
+
+private val logger = KotlinLogging.logger {}
+private val sikkerlogg = KotlinLogging.logger("tjenestekall")
+
+class UtsendingDistribuertObserver(
+    private val rapidsConnection: RapidsConnection,
+) : UtsendingHendelseObserver {
+    override fun onDistribuert(
+        hendelse: DistribuertHendelse,
+        utsending: Utsending,
+    ) {
+        val message =
+            JsonMessage
+                .newMessage(
+                    eventName = "utsending_distribuert",
+                    mapOf(
+                        "behandlingId" to hendelse.behandlingId.toString(),
+                        "utsendingId" to utsending.id.toString(),
+                        "distribusjonId" to hendelse.distribusjonId,
+                        "journalpostId" to hendelse.journalpostId,
+                        "ident" to utsending.ident,
+                        "type" to utsending.type.name,
+                    ),
+                ).toJson()
+
+        logger.info {
+            "Publiserer utsending_distribuert for behandlingId: ${hendelse.behandlingId}, distribusjonId: ${hendelse.distribusjonId}"
+        }
+        sikkerlogg.info { "Publiserer melding: $message" }
+
+        rapidsConnection.publish(key = utsending.ident, message = message)
+    }
+}

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/utsending/UtsendingHendelseObserver.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/utsending/UtsendingHendelseObserver.kt
@@ -1,0 +1,28 @@
+package no.nav.dagpenger.saksbehandling.utsending
+
+import no.nav.dagpenger.saksbehandling.utsending.hendelser.ArkiverbartBrevHendelse
+import no.nav.dagpenger.saksbehandling.utsending.hendelser.DistribuertHendelse
+import no.nav.dagpenger.saksbehandling.utsending.hendelser.JournalførtHendelse
+import no.nav.dagpenger.saksbehandling.utsending.hendelser.StartUtsendingHendelse
+
+interface UtsendingHendelseObserver {
+    fun onStartUtsending(
+        hendelse: StartUtsendingHendelse,
+        utsending: Utsending,
+    ) {}
+
+    fun onArkiverbartBrev(
+        hendelse: ArkiverbartBrevHendelse,
+        utsending: Utsending,
+    ) {}
+
+    fun onJournalført(
+        hendelse: JournalførtHendelse,
+        utsending: Utsending,
+    ) {}
+
+    fun onDistribuert(
+        hendelse: DistribuertHendelse,
+        utsending: Utsending,
+    ) {}
+}

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/utsending/UtsendingMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/utsending/UtsendingMediator.kt
@@ -27,9 +27,14 @@ class UtsendingMediator(
     private val brevProdusent: BrevProdusent,
 ) : UtsendingRepository by utsendingRepository {
     private lateinit var rapidsConnection: RapidsConnection
+    private val observers = mutableListOf<UtsendingHendelseObserver>()
 
     fun setRapidsConnection(rapidsConnection: RapidsConnection) {
         this.rapidsConnection = rapidsConnection
+    }
+
+    fun addObserver(observer: UtsendingHendelseObserver) {
+        observers.add(observer)
     }
 
     fun opprettUtsending(
@@ -53,24 +58,28 @@ class UtsendingMediator(
         val utsending = utsendingRepository.hentUtsendingForBehandlingId(startUtsendingHendelse.behandlingId)
         utsending.startUtsending(startUtsendingHendelse)
         lagreOgPubliserBehov(utsending)
+        observers.forEach { it.onStartUtsending(startUtsendingHendelse, utsending) }
     }
 
     fun mottaUrnTilArkiverbartFormatAvBrev(arkiverbartBrevHendelse: ArkiverbartBrevHendelse) {
         val utsending = utsendingRepository.hentUtsendingForBehandlingId(arkiverbartBrevHendelse.behandlingId)
         utsending.mottaUrnTilArkiverbartFormatAvBrev(arkiverbartBrevHendelse)
         lagreOgPubliserBehov(utsending)
+        observers.forEach { it.onArkiverbartBrev(arkiverbartBrevHendelse, utsending) }
     }
 
     fun mottaJournalførtKvittering(journalførtHendelse: JournalførtHendelse) {
         val utsending = utsendingRepository.hentUtsendingForBehandlingId(journalførtHendelse.behandlingId)
         utsending.mottaJournalførtKvittering(journalførtHendelse)
         lagreOgPubliserBehov(utsending)
+        observers.forEach { it.onJournalført(journalførtHendelse, utsending) }
     }
 
     fun mottaDistribuertKvittering(distribuertHendelse: DistribuertHendelse) {
         val utsending = utsendingRepository.hentUtsendingForBehandlingId(distribuertHendelse.behandlingId)
         utsending.mottaDistribuertKvittering(distribuertHendelse)
         lagreOgPubliserBehov(utsending)
+        observers.forEach { it.onDistribuert(distribuertHendelse, utsending) }
     }
 
     private fun lagreOgPubliserBehov(utsending: Utsending) {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/klage/UtsendingDistribuertMottakForKlageTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/klage/UtsendingDistribuertMottakForKlageTest.kt
@@ -40,18 +40,13 @@ class UtsendingDistribuertMottakForKlageTest {
         val melding =
             """
             {
-              "@event_name": "behov",
-              "@behov": ["DistribueringBehov"],
-              "@løsning": {
-                "DistribueringBehov": {
-                  "distribueringId": "${forVentetHendelse.distribusjonId}"
-                }
-              },
-              "utsendingType": "KLAGEMELDING",
+              "@event_name": "utsending_distribuert",
               "behandlingId": "${forVentetHendelse.behandlingId}",
-              "journalpostId": "${forVentetHendelse.journalpostId}",
               "utsendingId": "${forVentetHendelse.utsendingId}",
-              "ident": "${forVentetHendelse.ident}"
+              "distribusjonId": "${forVentetHendelse.distribusjonId}",
+              "journalpostId": "${forVentetHendelse.journalpostId}",
+              "ident": "${forVentetHendelse.ident}",
+              "type": "KLAGEMELDING"
             }
             """.trimIndent()
         testRapid.sendTestMessage(melding)

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/utsending/UtsendingDistribuertObserverTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/utsending/UtsendingDistribuertObserverTest.kt
@@ -1,0 +1,136 @@
+package no.nav.dagpenger.saksbehandling.utsending
+
+import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
+import io.kotest.assertions.json.shouldEqualSpecifiedJson
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import no.nav.dagpenger.saksbehandling.Behandling
+import no.nav.dagpenger.saksbehandling.TestHelper
+import no.nav.dagpenger.saksbehandling.UUIDv7
+import no.nav.dagpenger.saksbehandling.UtløstAvType
+import no.nav.dagpenger.saksbehandling.UtsendingSak
+import no.nav.dagpenger.saksbehandling.db.DBTestHelper
+import no.nav.dagpenger.saksbehandling.helper.arkiverbartDokumentBehovLøsning
+import no.nav.dagpenger.saksbehandling.helper.distribuertDokumentBehovLøsning
+import no.nav.dagpenger.saksbehandling.helper.journalføringBehovLøsning
+import no.nav.dagpenger.saksbehandling.hendelser.TomHendelse
+import no.nav.dagpenger.saksbehandling.toUrn
+import no.nav.dagpenger.saksbehandling.utsending.db.PostgresUtsendingRepository
+import no.nav.dagpenger.saksbehandling.utsending.hendelser.StartUtsendingHendelse
+import no.nav.dagpenger.saksbehandling.utsending.mottak.UtsendingBehovLøsningMottak
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class UtsendingDistribuertObserverTest {
+    private val rapid = TestRapid()
+
+    @Test
+    fun `skal publisere melding når utsending er distribuert`() {
+        val behandling =
+            Behandling(
+                behandlingId = UUIDv7.ny(),
+                utløstAv = UtløstAvType.SØKNAD,
+                opprettet = LocalDateTime.now(),
+                hendelse = TomHendelse,
+            )
+        val person = TestHelper.testPerson
+
+        DBTestHelper.withBehandling(behandling = behandling, person = person) { ds ->
+            val behandlingId = behandling.behandlingId
+            val sakId = DBTestHelper.sakId.toString()
+            val utsendingSak = UtsendingSak(sakId, "Dagpenger")
+            val htmlBrev = "<H1>Hei</H1><p>Her er et brev</p>"
+            val utsendingRepository = PostgresUtsendingRepository(ds)
+            val utsendingMediator =
+                UtsendingMediator(
+                    utsendingRepository = utsendingRepository,
+                    brevProdusent =
+                        mockk<UtsendingMediator.BrevProdusent>().also {
+                            coEvery {
+                                it.lagBrev(
+                                    ident = person.ident,
+                                    behandlingId = behandlingId,
+                                    sakId = sakId,
+                                )
+                            } returns htmlBrev
+                        },
+                ).also {
+                    it.setRapidsConnection(rapid)
+                    it.addObserver(UtsendingDistribuertObserver(rapid))
+                }
+
+            UtsendingBehovLøsningMottak(
+                utsendingMediator = utsendingMediator,
+                rapidsConnection = rapid,
+            )
+
+            val utsendingId =
+                utsendingMediator.opprettUtsending(
+                    behandlingId = behandlingId,
+                    brev = null,
+                    ident = person.ident,
+                    type = UtsendingType.VEDTAK_DAGPENGER,
+                )
+
+            // Start utsending
+            utsendingMediator.mottaStartUtsending(
+                StartUtsendingHendelse(
+                    behandlingId = behandlingId,
+                    ident = person.ident,
+                    brev = htmlBrev,
+                    utsendingSak = utsendingSak,
+                ),
+            )
+
+            // Arkiverbart brev
+            val pdfUrn = "urn:vedlegg:123".toUrn()
+            rapid.sendTestMessage(
+                arkiverbartDokumentBehovLøsning(
+                    behandlingId = behandlingId,
+                    pdfUrnString = pdfUrn.toString(),
+                ),
+            )
+
+            // Journalført
+            val journalpostId = "123456"
+            rapid.sendTestMessage(
+                journalføringBehovLøsning(
+                    behandlingId = behandlingId,
+                    journalpostId = journalpostId,
+                ),
+            )
+
+            rapid.reset()
+
+            // Distribuert
+            val distribusjonId = "789012"
+            rapid.sendTestMessage(
+                distribuertDokumentBehovLøsning(
+                    behandlingId = behandlingId,
+                    journalpostId = journalpostId,
+                    distribusjonId = distribusjonId,
+                    ident = person.ident,
+                    utsendingId = utsendingId,
+                ),
+            )
+
+            rapid.inspektør.size shouldBe 1
+
+            val expectedMessage =
+                """
+                {
+                  "@event_name": "utsending_distribuert",
+                  "behandlingId": "$behandlingId",
+                  "utsendingId": "$utsendingId",
+                  "distribusjonId": "$distribusjonId",
+                  "journalpostId": "$journalpostId",
+                  "ident": "${person.ident}",
+                  "type": "VEDTAK_DAGPENGER"
+                }
+                """.trimIndent()
+
+            rapid.inspektør.message(0).toString() shouldEqualSpecifiedJson expectedMessage
+        }
+    }
+}

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/utsending/UtsendingHendelseObserverTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/utsending/UtsendingHendelseObserverTest.kt
@@ -1,0 +1,165 @@
+package no.nav.dagpenger.saksbehandling.utsending
+
+import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import no.nav.dagpenger.saksbehandling.Behandling
+import no.nav.dagpenger.saksbehandling.TestHelper
+import no.nav.dagpenger.saksbehandling.UUIDv7
+import no.nav.dagpenger.saksbehandling.UtløstAvType
+import no.nav.dagpenger.saksbehandling.UtsendingSak
+import no.nav.dagpenger.saksbehandling.db.DBTestHelper
+import no.nav.dagpenger.saksbehandling.helper.arkiverbartDokumentBehovLøsning
+import no.nav.dagpenger.saksbehandling.helper.distribuertDokumentBehovLøsning
+import no.nav.dagpenger.saksbehandling.helper.journalføringBehovLøsning
+import no.nav.dagpenger.saksbehandling.hendelser.TomHendelse
+import no.nav.dagpenger.saksbehandling.toUrn
+import no.nav.dagpenger.saksbehandling.utsending.db.PostgresUtsendingRepository
+import no.nav.dagpenger.saksbehandling.utsending.hendelser.ArkiverbartBrevHendelse
+import no.nav.dagpenger.saksbehandling.utsending.hendelser.DistribuertHendelse
+import no.nav.dagpenger.saksbehandling.utsending.hendelser.JournalførtHendelse
+import no.nav.dagpenger.saksbehandling.utsending.hendelser.StartUtsendingHendelse
+import no.nav.dagpenger.saksbehandling.utsending.mottak.UtsendingBehovLøsningMottak
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class UtsendingHendelseObserverTest {
+    private val rapid = TestRapid()
+
+    @Test
+    fun `observer skal få beskjed om alle hendelser i utsendingsprosessen`() {
+        val behandling =
+            Behandling(
+                behandlingId = UUIDv7.ny(),
+                utløstAv = UtløstAvType.SØKNAD,
+                opprettet = LocalDateTime.now(),
+                hendelse = TomHendelse,
+            )
+        val person = TestHelper.testPerson
+
+        DBTestHelper.withBehandling(behandling = behandling, person = person) { ds ->
+            val behandlingId = behandling.behandlingId
+            val sakId = DBTestHelper.sakId.toString()
+            val utsendingSak = UtsendingSak(sakId, "Dagpenger")
+            val htmlBrev = "<H1>Hei</H1><p>Her er et brev</p>"
+            val utsendingRepository = PostgresUtsendingRepository(ds)
+            val utsendingMediator =
+                UtsendingMediator(
+                    utsendingRepository = utsendingRepository,
+                    brevProdusent =
+                        mockk<UtsendingMediator.BrevProdusent>().also {
+                            coEvery {
+                                it.lagBrev(
+                                    ident = person.ident,
+                                    behandlingId = behandlingId,
+                                    sakId = sakId,
+                                )
+                            } returns htmlBrev
+                        },
+                ).also {
+                    it.setRapidsConnection(rapid)
+                }
+
+            UtsendingBehovLøsningMottak(
+                utsendingMediator = utsendingMediator,
+                rapidsConnection = rapid,
+            )
+
+            val testObserver = TestUtsendingObserver()
+            utsendingMediator.addObserver(testObserver)
+
+            utsendingMediator.opprettUtsending(
+                behandlingId = behandlingId,
+                brev = null,
+                ident = person.ident,
+                type = UtsendingType.VEDTAK_DAGPENGER,
+            )
+
+            // Start utsending
+            utsendingMediator.mottaStartUtsending(
+                StartUtsendingHendelse(
+                    behandlingId = behandlingId,
+                    ident = person.ident,
+                    brev = htmlBrev,
+                    utsendingSak = utsendingSak,
+                ),
+            )
+
+            testObserver.startUtsendingHendelser shouldHaveSize 1
+            testObserver.startUtsendingHendelser.first().behandlingId shouldBe behandlingId
+
+            // Arkiverbart brev
+            val pdfUrn = "urn:vedlegg:123".toUrn()
+            rapid.sendTestMessage(
+                arkiverbartDokumentBehovLøsning(
+                    behandlingId = behandlingId,
+                    pdfUrnString = pdfUrn.toString(),
+                ),
+            )
+
+            testObserver.arkiverbartBrevHendelser shouldHaveSize 1
+            testObserver.arkiverbartBrevHendelser.first().behandlingId shouldBe behandlingId
+
+            // Journalført
+            val journalpostId = "123"
+            rapid.sendTestMessage(
+                journalføringBehovLøsning(
+                    behandlingId = behandlingId,
+                    journalpostId = journalpostId,
+                ),
+            )
+
+            testObserver.journalførtHendelser shouldHaveSize 1
+            testObserver.journalførtHendelser.first().behandlingId shouldBe behandlingId
+
+            // Distribuert
+            rapid.sendTestMessage(
+                distribuertDokumentBehovLøsning(
+                    behandlingId = behandlingId,
+                    journalpostId = journalpostId,
+                    distribusjonId = "456",
+                ),
+            )
+
+            testObserver.distribuertHendelser shouldHaveSize 1
+            testObserver.distribuertHendelser.first().behandlingId shouldBe behandlingId
+        }
+    }
+
+    private class TestUtsendingObserver : UtsendingHendelseObserver {
+        val startUtsendingHendelser = mutableListOf<StartUtsendingHendelse>()
+        val arkiverbartBrevHendelser = mutableListOf<ArkiverbartBrevHendelse>()
+        val journalførtHendelser = mutableListOf<JournalførtHendelse>()
+        val distribuertHendelser = mutableListOf<DistribuertHendelse>()
+
+        override fun onStartUtsending(
+            hendelse: StartUtsendingHendelse,
+            utsending: Utsending,
+        ) {
+            startUtsendingHendelser.add(hendelse)
+        }
+
+        override fun onArkiverbartBrev(
+            hendelse: ArkiverbartBrevHendelse,
+            utsending: Utsending,
+        ) {
+            arkiverbartBrevHendelser.add(hendelse)
+        }
+
+        override fun onJournalført(
+            hendelse: JournalførtHendelse,
+            utsending: Utsending,
+        ) {
+            journalførtHendelser.add(hendelse)
+        }
+
+        override fun onDistribuert(
+            hendelse: DistribuertHendelse,
+            utsending: Utsending,
+        ) {
+            distribuertHendelser.add(hendelse)
+        }
+    }
+}


### PR DESCRIPTION
## Beskrivelse

Denne PR'en introduserer et observer pattern for utsending hendelser og refaktorerer klage mottaket til å bruke den nye event-baserte arkitekturen.

## Endringer

### Observer Pattern
- ✅ Opprettet **UtsendingHendelseObserver** interface for å reagere på utsending hendelser
- ✅ Implementert **UtsendingDistribuertObserver** som publiserer `utsending_distribuert` event når en utsending er distribuert
- ✅ Lagt til `addObserver()` metode i **UtsendingMediator** for å registrere observers

### Refaktorering av Klage Mottak
- ✅ Refaktorert **UtsendingDistribuertMottakForKlage** til å konsumere `utsending_distribuert` event
  - **Før**: Lyttet på `@event_name: "behov"` med `DistribueringBehov` løsning
  - **Etter**: Lytter på `@event_name: "utsending_distribuert"` event
  - Forenklet: Trenger ikke lenger å ekstrahere data fra nested `@løsning` struktur

### Konfigurasjon
- ✅ Wired opp observer og klage mottaks i **ApplicationBuilder**
- ✅ Lagt til **KlageBehandlingUtførtMottakForUtsending** og **KlageBehandlingUtførtMottakForOppgave**

### Tester
- ✅ **UtsendingHendelseObserverTest** - Tester observer pattern
- ✅ **UtsendingDistribuertObserverTest** - Verifiserer at observer publiserer korrekte meldinger
- ✅ **UtsendingDistribuertMottakForKlageTest** - Oppdatert til å teste ny event format

## Event Format

Den nye `utsending_distribuert` event ser slik ut:
```json
{
  "@event_name": "utsending_distribuert",
  "behandlingId": "<uuid>",
  "utsendingId": "<uuid>",
  "distribusjonId": "<string>",
  "journalpostId": "<string>",
  "ident": "<string>",
  "type": "VEDTAK_DAGPENGER" | "KLAGEMELDING"
}
```

## Testing
Alle eksisterende tester passerer ✅