### PR TITLE
Flytt aarsak fra query param til request body på legg-tilbake

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApi.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApi.kt
@@ -4,7 +4,6 @@ import PersonMediator
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.oshai.kotlinlogging.withLoggingContext
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.parseQueryString
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.authenticate
 import io.ktor.server.request.path
@@ -33,6 +32,7 @@ import no.nav.dagpenger.saksbehandling.api.models.HttpProblemDTO
 import no.nav.dagpenger.saksbehandling.api.models.KontrollertBrevDTO
 import no.nav.dagpenger.saksbehandling.api.models.KontrollertBrevRequestDTO
 import no.nav.dagpenger.saksbehandling.api.models.LagreNotatResponseDTO
+import no.nav.dagpenger.saksbehandling.api.models.LeggTilbakeOppgaveDTO
 import no.nav.dagpenger.saksbehandling.api.models.MeldingOmVedtakKildeDTO
 import no.nav.dagpenger.saksbehandling.api.models.MeldingOmVedtakKildeRequestDTO
 import no.nav.dagpenger.saksbehandling.api.models.NesteOppgaveDTO
@@ -296,8 +296,8 @@ internal fun Route.oppgaveApi(
                 route("legg-tilbake") {
                     put {
                         val saksbehandler = applicationCallParser.saksbehandler(call)
-                        val aarsak = parseQueryString(call.request.queryString()).get("aarsak") ?: "ukjent"
-                        val aarsak2 = call.request.queryParameters["aarsak"]
+                        val leggTilbakeOppgave = runCatching { call.receive<LeggTilbakeOppgaveDTO>() }.getOrNull()
+                        val aarsak = leggTilbakeOppgave?.aarsak?.name ?: "ukjent"
                         val oppgaveAnsvarHendelse = call.fjernOppgaveAnsvarHendelse(saksbehandler)
                         val oppgaveId = call.finnUUID("oppgaveId")
                         withLoggingContext("oppgaveId" to oppgaveId.toString()) {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApiTest.kt
@@ -246,7 +246,7 @@ class OppgaveApiTest {
                                     ],
                                     "leggTilbakeAarsaker": [
                                         "MANGLER_KOMPETANSE",
-                                        "HABILITET",
+                                        "INHABILITET",
                                         "FRAVÆR",
                                         "ANNET"
                                     ]
@@ -765,27 +765,39 @@ class OppgaveApiTest {
                 saksbehandlerIdent = TestHelper.saksbehandler.navIdent,
             )
 
+        val forventetFjernOppgaveAnsvarHendelse =
+            FjernOppgaveAnsvarHendelse(
+                oppgaveId = oppgave.oppgaveId,
+                utførtAv = TestHelper.saksbehandler,
+                årsak = "INHABILITET",
+            )
+
         coEvery {
             oppgaveMediatorMock.fristillOppgave(
-                FjernOppgaveAnsvarHendelse(
-                    oppgaveId = oppgave.oppgaveId,
-                    utførtAv = TestHelper.saksbehandler,
-                ),
+                forventetFjernOppgaveAnsvarHendelse,
             )
         } just runs
 
         withOppgaveApi(oppgaveMediator = oppgaveMediatorMock) {
-            client.put("oppgave/${oppgave.oppgaveId}/legg-tilbake") { autentisert() }.also { response ->
-                response.status shouldBe HttpStatusCode.NoContent
-            }
+            client
+                .put("oppgave/${oppgave.oppgaveId}/legg-tilbake") {
+                    autentisert()
+                    contentType(ContentType.Application.Json)
+                    setBody(
+                        """
+                         {
+                           "aarsak": "INHABILITET"
+                        }
+                        """.trimIndent(),
+                    )
+                }.also { response ->
+                    response.status shouldBe HttpStatusCode.NoContent
+                }
         }
 
         verify(exactly = 1) {
             oppgaveMediatorMock.fristillOppgave(
-                FjernOppgaveAnsvarHendelse(
-                    oppgaveId = oppgave.oppgaveId,
-                    utførtAv = TestHelper.saksbehandler,
-                ),
+                forventetFjernOppgaveAnsvarHendelse,
             )
         }
     }
@@ -1220,7 +1232,7 @@ class OppgaveApiTest {
                       "lovligeEndringer" : {
                           "paaVentAarsaker" : [ "AVVENT_SVAR", "AVVENT_DOKUMENTASJON", "AVVENT_MELDEKORT", "AVVENT_PERMITTERINGSÅRSAK", "AVVENT_RAPPORTERINGSFRIST", "AVVENT_SVAR_PÅ_FORESPØRSEL", "ANNET" ],
                           "avbrytAarsaker" : [ "BEHANDLES_I_ARENA", "FLERE_SØKNADER", "TRUKKET_SØKNAD", "ANNET" ],
-                          "leggTilbakeAarsaker": [ "MANGLER_KOMPETANSE", "HABILITET", "FRAVÆR", "ANNET" ]
+                          "leggTilbakeAarsaker": [ "MANGLER_KOMPETANSE", "INHABILITET", "FRAVÆR", "ANNET" ]
                       },
                       "historikk": [
                         {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveDTOMapperTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveDTOMapperTest.kt
@@ -138,7 +138,7 @@ class OppgaveDTOMapperTest {
                         "avbrytAarsaker": [],
                         "leggTilbakeAarsaker": [
                           "MANGLER_KOMPETANSE",
-                          "HABILITET",
+                          "INHABILITET",
                           "FRAVÆR",
                           "ANNET"
                         ]
@@ -303,7 +303,7 @@ class OppgaveDTOMapperTest {
                         ],
                         "leggTilbakeAarsaker": [
                           "MANGLER_KOMPETANSE",
-                          "HABILITET",
+                          "INHABILITET",
                           "FRAVÆR",
                           "ANNET"
                         ]
@@ -469,7 +469,7 @@ class OppgaveDTOMapperTest {
                         ],
                         "leggTilbakeAarsaker": [
                           "MANGLER_KOMPETANSE",
-                          "HABILITET",
+                          "INHABILITET",
                           "FRAVÆR",
                           "ANNET"
                         ]
@@ -635,7 +635,7 @@ class OppgaveDTOMapperTest {
                         ],
                         "leggTilbakeAarsaker": [
                           "MANGLER_KOMPETANSE",
-                          "HABILITET",
+                          "INHABILITET",
                           "FRAVÆR",
                           "ANNET"
                         ]

--- a/openapi/src/main/resources/saksbehandling-api.yaml
+++ b/openapi/src/main/resources/saksbehandling-api.yaml
@@ -646,7 +646,7 @@ paths:
             type: string
             format: uuid
       requestBody:
-        required: false
+        required: true
         content:
           application/json:
             schema:
@@ -1559,12 +1559,14 @@ components:
       properties:
         aarsak:
           $ref: '#/components/schemas/LeggTilbakeAarsak'
+      required:
+        - aarsak
 
     LeggTilbakeAarsak:
       type: string
       enum:
         - MANGLER_KOMPETANSE
-        - HABILITET
+        - INHABILITET
         - FRAVÆR
         - ANNET
 

--- a/openapi/src/main/resources/saksbehandling-api.yaml
+++ b/openapi/src/main/resources/saksbehandling-api.yaml
@@ -645,13 +645,12 @@ paths:
           schema:
             type: string
             format: uuid
-        - in: query
-          name: aarsak
-          required: false
-          style: form
-          explode: true
-          schema:
-            $ref: '#/components/schemas/LeggTilbakeAarsak'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LeggTilbakeOppgave'
       responses:
         '204':
           description: Fjernet saksbehandler/beslutter som ansvarlig for oppgaven, og oppgaven gjøres klar til behandling/kontroll
@@ -1554,6 +1553,12 @@ components:
         - FLERE_SØKNADER
         - TRUKKET_SØKNAD
         - ANNET
+
+    LeggTilbakeOppgave:
+      type: object
+      properties:
+        aarsak:
+          $ref: '#/components/schemas/LeggTilbakeAarsak'
 
     LeggTilbakeAarsak:
       type: string


### PR DESCRIPTION
## Endringer

- Fjernet `aarsak` som query parameter fra `/oppgave/{oppgaveId}/legg-tilbake`
- Lagt til `requestBody` med nytt `LeggTilbakeOppgave` schema (valgfri body med `aarsak`-felt)
- Oppdatert `OppgaveApi.kt` til å lese `aarsak` fra request body i stedet for query string
- Fjernet ubrukt `parseQueryString`-import