### PR TITLE
Legg til sortering query-parameter på GET /oppgave

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
@@ -512,7 +512,8 @@ class PostgresOppgaveRepository(
 
                     else -> ""
                 }
-            val orderByOpprettetClause = """ ORDER BY oppg.opprettet, oppg.id """
+            val sorteringsretning = søkeFilter.sortering.name
+            val orderByOpprettetClause = """ ORDER BY oppg.opprettet $sorteringsretning, oppg.id $sorteringsretning """
 
             val limitAndOffsetClause =
                 søkeFilter.paginering?.let {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/Søkefilter.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/Søkefilter.kt
@@ -27,7 +27,13 @@ data class Søkefilter(
     val utløstAvTyper: Set<UtløstAvType> = emptySet(),
     val søknadId: UUID? = null,
     val paginering: Paginering? = Paginering.DEFAULT,
+    val sortering: Sortering = Sortering.ASC,
 ) {
+    enum class Sortering {
+        ASC,
+        DESC,
+    }
+
     data class Paginering(
         val antallOppgaver: Int,
         val side: Int,
@@ -53,6 +59,7 @@ data class Søkefilter(
             val mineOppgaver = builder.mineOppgaver() ?: false
             val utløstAvTyper = builder.utløstAvTyper() ?: emptySet()
             val paginering = builder.paginering()
+            val sortering = builder.sortering()
 
             return Søkefilter(
                 periode = Periode.fra(queryParameters),
@@ -65,6 +72,7 @@ data class Søkefilter(
                 emneknaggGruppertPerKategori = builder.emneknaggGruppertPerKategori(),
                 utløstAvTyper = utløstAvTyper,
                 paginering = paginering,
+                sortering = sortering,
             )
         }
     }
@@ -192,6 +200,8 @@ class FilterBuilder {
     fun tilstander(): Set<Tilstand.Type>? = stringValues.getAll("tilstand")?.map { Tilstand.Type.valueOf(it) }?.toSet()
 
     fun utløstAvTyper(): Set<UtløstAvType>? = stringValues.getAll("utlostAv")?.map { UtløstAvType.valueOf(it) }?.toSet()
+
+    fun sortering(): Søkefilter.Sortering = stringValues["sortering"]?.let { Søkefilter.Sortering.valueOf(it) } ?: Søkefilter.Sortering.ASC
 }
 
 private fun Set<String>.grupperEmneknaggPerKategori(): Map<String, Set<String>> =

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/SøkefilterTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/SøkefilterTest.kt
@@ -69,6 +69,7 @@ class SøkefilterTest {
         søkefilter.behandlingId shouldBe null
         søkefilter.paginering shouldBe Søkefilter.Paginering(20, 0)
         søkefilter.emneknaggGruppertPerKategori shouldBe emptyMap()
+        søkefilter.sortering shouldBe Søkefilter.Sortering.ASC
     }
 
     @Test
@@ -109,6 +110,34 @@ class SøkefilterTest {
                         EmneknaggKategori.RETTIGHET to setOf("Ordinær", "Verneplikt"),
                         EmneknaggKategori.SØKNADSRESULTAT to setOf("Avslag"),
                     )
+            }
+    }
+
+    @Test
+    fun `Sortering default skal være ASC`() {
+        val søkefilter = Søkefilter.fra(Parameters.Companion.Empty, "testIdent")
+        søkefilter.sortering shouldBe Søkefilter.Sortering.ASC
+    }
+
+    @Test
+    fun `Skal kunne sette sortering til DESC`() {
+        Parameters.Companion
+            .build {
+                this["sortering"] = "DESC"
+            }.let {
+                val søkefilter = Søkefilter.fra(it, "testIdent")
+                søkefilter.sortering shouldBe Søkefilter.Sortering.DESC
+            }
+    }
+
+    @Test
+    fun `Skal kunne sette sortering til ASC eksplisitt`() {
+        Parameters.Companion
+            .build {
+                this["sortering"] = "ASC"
+            }.let {
+                val søkefilter = Søkefilter.fra(it, "testIdent")
+                søkefilter.sortering shouldBe Søkefilter.Sortering.ASC
             }
     }
 }

--- a/openapi/src/main/resources/saksbehandling-api.yaml
+++ b/openapi/src/main/resources/saksbehandling-api.yaml
@@ -195,6 +195,16 @@ paths:
           required: false
           schema:
             type: integer
+        - in: query
+          name: sortering
+          description: Sorteringsrekkefølge for oppgaver basert på opprettet-tidspunkt
+          required: false
+          schema:
+            type: string
+            enum:
+              - ASC
+              - DESC
+            default: ASC
       responses:
         '200':
           description: Vellykket respons med en liste over oppgaver


### PR DESCRIPTION
## Endringer

Legger til mulighet for å styre sorteringsrekkefølge (ASC/DESC) på oppgavelisten via ny query-parameter `sortering` på `GET /oppgave`.

**Default er `ASC` (eldste først)** som bevarer eksisterende oppførsel.

### Hva er endret?
- **OpenAPI-spec**: Ny query-parameter `sortering` med enum `ASC`/`DESC`
- **Søkefilter**: Ny `Sortering`-enum og felt med default `ASC`, parsing i `FilterBuilder`
- **PostgresOppgaveRepository**: Dynamisk `ORDER BY` basert på sorteringsverdien
- **Tester**: 3 nye tester + verifisering av default i eksisterende test

### Eksempel
```
GET /oppgave?sortering=DESC   # Nyeste først
GET /oppgave?sortering=ASC    # Eldste først (default)
GET /oppgave                  # Eldste først (default)
```