### PR TITLE
Legg til proxy-endepunkter for melding-om-vedtak

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/ApplicationBuilder.kt
@@ -169,6 +169,14 @@ internal class ApplicationBuilder(
             sakMediator = sakMediator,
         )
 
+    private val meldingOmVedtakMediator =
+        MeldingOmVedtakMediator(
+            oppgaveMediator = oppgaveMediator,
+            meldingOmVedtakKlient = meldingOmVedtakKlient,
+            oppslag = oppslag,
+            sakMediator = sakMediator,
+        )
+
     private val innsendingMediator =
         InnsendingMediator(
             sakMediator = sakMediator,
@@ -211,6 +219,7 @@ internal class ApplicationBuilder(
                             personMediator = personMediator,
                             sakMediator = sakMediator,
                             innsendingMediator = innsendingMediator,
+                            meldingOmVedtakMediator = meldingOmVedtakMediator,
                         )
                         this.install(KafkaStreamsPlugin) {
                             kafkaStreams =

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/MeldingOmVedtakMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/MeldingOmVedtakMediator.kt
@@ -1,0 +1,94 @@
+package no.nav.dagpenger.saksbehandling
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import no.nav.dagpenger.saksbehandling.api.Oppslag
+import no.nav.dagpenger.saksbehandling.db.oppgave.OppgaveRepository
+import no.nav.dagpenger.saksbehandling.sak.SakMediator
+import no.nav.dagpenger.saksbehandling.vedtaksmelding.MeldingOmVedtakKlient
+import java.util.UUID
+
+private val logger = KotlinLogging.logger {}
+private val sikkerlogg = KotlinLogging.logger("tjenestekall")
+
+class MeldingOmVedtakMediator(
+    private val oppgaveRepository: OppgaveRepository,
+    private val meldingOmVedtakKlient: MeldingOmVedtakKlient,
+    private val oppslag: Oppslag,
+    private val sakMediator: SakMediator,
+) {
+    suspend fun hentMeldingOmVedtakHtml(
+        oppgaveId: UUID,
+        saksbehandler: Saksbehandler,
+        saksbehandlerToken: String,
+    ): String {
+        val oppgave = hentOppgaveMedTilgangskontroll(oppgaveId, saksbehandler)
+
+        return coroutineScope {
+            val personDeferred = async(Dispatchers.IO) { oppslag.hentPerson(oppgave.personIdent()) }
+            val saksbehandlerDeferred = async(Dispatchers.IO) { oppslag.hentBehandler(saksbehandler.navIdent) }
+            val beslutterDeferred =
+                async(Dispatchers.IO) {
+                    oppgave.sisteBeslutter()?.let { oppslag.hentBehandler(it) }
+                }
+            val sakIdDeferred =
+                async(Dispatchers.IO) {
+                    sakMediator.hentSakIdForBehandlingId(oppgave.behandling.behandlingId)
+                }
+
+            meldingOmVedtakKlient
+                .hentMeldingOmVedtakHtml(
+                    person = personDeferred.await(),
+                    saksbehandler = saksbehandlerDeferred.await(),
+                    beslutter = beslutterDeferred.await(),
+                    behandlingId = oppgave.behandling.behandlingId,
+                    saksbehandlerToken = saksbehandlerToken,
+                    utløstAvType = oppgave.behandling.utløstAv,
+                    sakId = sakIdDeferred.await()?.toString(),
+                ).getOrThrow()
+        }
+    }
+
+    suspend fun lagreUtvidetBeskrivelse(
+        oppgaveId: UUID,
+        brevblokkId: String,
+        tekst: String,
+        saksbehandler: Saksbehandler,
+        saksbehandlerToken: String,
+    ): String {
+        val oppgave = hentOppgaveMedTilgangskontroll(oppgaveId, saksbehandler)
+
+        return meldingOmVedtakKlient.lagreUtvidetBeskrivelse(
+            behandlingId = oppgave.behandling.behandlingId,
+            brevblokkId = brevblokkId,
+            tekst = tekst,
+            saksbehandlerToken = saksbehandlerToken,
+        )
+    }
+
+    suspend fun lagreBrevVariant(
+        oppgaveId: UUID,
+        brevVariant: String,
+        saksbehandler: Saksbehandler,
+        saksbehandlerToken: String,
+    ) {
+        val oppgave = hentOppgaveMedTilgangskontroll(oppgaveId, saksbehandler)
+
+        meldingOmVedtakKlient.lagreBrevVariant(
+            behandlingId = oppgave.behandling.behandlingId,
+            brevVariant = brevVariant,
+            saksbehandlerToken = saksbehandlerToken,
+        )
+    }
+
+    private fun hentOppgaveMedTilgangskontroll(
+        oppgaveId: UUID,
+        saksbehandler: Saksbehandler,
+    ): Oppgave =
+        oppgaveRepository.hentOppgave(oppgaveId).also { oppgave ->
+            oppgave.egneAnsatteTilgangskontroll(saksbehandler)
+            oppgave.adressebeskyttelseTilgangskontroll(saksbehandler)
+        }
+}

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/MeldingOmVedtakMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/MeldingOmVedtakMediator.kt
@@ -41,7 +41,7 @@ class MeldingOmVedtakMediator(
                     behandlingId = oppgave.behandling.behandlingId,
                     saksbehandlerToken = saksbehandlerToken,
                     utløstAvType = oppgave.behandling.utløstAv,
-                    sakId = sakIdDeferred.await()?.toString(),
+                    sakId = sakIdDeferred.await().toString(),
                 ).getOrThrow()
         }
     }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/MeldingOmVedtakMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/MeldingOmVedtakMediator.kt
@@ -1,20 +1,15 @@
 package no.nav.dagpenger.saksbehandling
 
-import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import no.nav.dagpenger.saksbehandling.api.Oppslag
-import no.nav.dagpenger.saksbehandling.db.oppgave.OppgaveRepository
 import no.nav.dagpenger.saksbehandling.sak.SakMediator
 import no.nav.dagpenger.saksbehandling.vedtaksmelding.MeldingOmVedtakKlient
 import java.util.UUID
 
-private val logger = KotlinLogging.logger {}
-private val sikkerlogg = KotlinLogging.logger("tjenestekall")
-
 class MeldingOmVedtakMediator(
-    private val oppgaveRepository: OppgaveRepository,
+    private val oppgaveMediator: OppgaveMediator,
     private val meldingOmVedtakKlient: MeldingOmVedtakKlient,
     private val oppslag: Oppslag,
     private val sakMediator: SakMediator,
@@ -24,7 +19,7 @@ class MeldingOmVedtakMediator(
         saksbehandler: Saksbehandler,
         saksbehandlerToken: String,
     ): String {
-        val oppgave = hentOppgaveMedTilgangskontroll(oppgaveId, saksbehandler)
+        val oppgave = oppgaveMediator.hentOppgave(oppgaveId, saksbehandler)
 
         return coroutineScope {
             val personDeferred = async(Dispatchers.IO) { oppslag.hentPerson(oppgave.personIdent()) }
@@ -58,7 +53,7 @@ class MeldingOmVedtakMediator(
         saksbehandler: Saksbehandler,
         saksbehandlerToken: String,
     ): String {
-        val oppgave = hentOppgaveMedTilgangskontroll(oppgaveId, saksbehandler)
+        val oppgave = oppgaveMediator.hentOppgave(oppgaveId, saksbehandler)
 
         return meldingOmVedtakKlient.lagreUtvidetBeskrivelse(
             behandlingId = oppgave.behandling.behandlingId,
@@ -74,7 +69,7 @@ class MeldingOmVedtakMediator(
         saksbehandler: Saksbehandler,
         saksbehandlerToken: String,
     ) {
-        val oppgave = hentOppgaveMedTilgangskontroll(oppgaveId, saksbehandler)
+        val oppgave = oppgaveMediator.hentOppgave(oppgaveId, saksbehandler)
 
         meldingOmVedtakKlient.lagreBrevVariant(
             behandlingId = oppgave.behandling.behandlingId,
@@ -82,13 +77,4 @@ class MeldingOmVedtakMediator(
             saksbehandlerToken = saksbehandlerToken,
         )
     }
-
-    private fun hentOppgaveMedTilgangskontroll(
-        oppgaveId: UUID,
-        saksbehandler: Saksbehandler,
-    ): Oppgave =
-        oppgaveRepository.hentOppgave(oppgaveId).also { oppgave ->
-            oppgave.egneAnsatteTilgangskontroll(saksbehandler)
-            oppgave.adressebeskyttelseTilgangskontroll(saksbehandler)
-        }
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/ApiConfig.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/ApiConfig.kt
@@ -82,5 +82,8 @@ internal fun Application.installerApis(
             klageDtoMapper = klageDTOMapper,
             applicationCallParser = applicationCallParser,
         )
+        meldingOmVedtakApi(
+            applicationCallParser = applicationCallParser,
+        )
     }
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/ApiConfig.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/ApiConfig.kt
@@ -16,6 +16,7 @@ import io.ktor.server.request.path
 import io.ktor.server.routing.routing
 import no.nav.dagpenger.saksbehandling.Configuration.applicationCallParser
 import no.nav.dagpenger.saksbehandling.KlageMediator
+import no.nav.dagpenger.saksbehandling.MeldingOmVedtakMediator
 import no.nav.dagpenger.saksbehandling.OppgaveMediator
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.api.auth.authConfig
@@ -34,6 +35,7 @@ internal fun Application.installerApis(
     personMediator: PersonMediator,
     sakMediator: SakMediator,
     innsendingMediator: InnsendingMediator,
+    meldingOmVedtakMediator: MeldingOmVedtakMediator,
 ) {
     this.authConfig()
     install(CallId) {
@@ -83,6 +85,7 @@ internal fun Application.installerApis(
             applicationCallParser = applicationCallParser,
         )
         meldingOmVedtakApi(
+            meldingOmVedtakMediator = meldingOmVedtakMediator,
             applicationCallParser = applicationCallParser,
         )
     }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/MeldingOmVedtakApi.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/MeldingOmVedtakApi.kt
@@ -8,18 +8,29 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.put
 import io.ktor.server.routing.route
+import no.nav.dagpenger.saksbehandling.MeldingOmVedtakMediator
 import no.nav.dagpenger.saksbehandling.api.models.MeldingOmVedtakBrevVariantRequestDTO
 import no.nav.dagpenger.saksbehandling.api.models.MeldingOmVedtakUtvidetBeskrivelseRequestDTO
 import no.nav.dagpenger.saksbehandling.jwt.ApplicationCallParser
+import no.nav.dagpenger.saksbehandling.jwt.jwt
 
-internal fun Route.meldingOmVedtakApi(applicationCallParser: ApplicationCallParser) {
+internal fun Route.meldingOmVedtakApi(
+    meldingOmVedtakMediator: MeldingOmVedtakMediator,
+    applicationCallParser: ApplicationCallParser,
+) {
     authenticate("azureAd") {
         route("oppgave/{oppgaveId}/melding-om-vedtak") {
             get("html") {
                 val oppgaveId = call.finnUUID("oppgaveId")
                 val saksbehandler = applicationCallParser.saksbehandler(call)
-                // TODO: Hent oppgave, berik med person/saksbehandler-data, kall dp-melding-om-vedtak
-                call.respond(HttpStatusCode.OK)
+                val saksbehandlerToken = call.request.jwt()
+                val html =
+                    meldingOmVedtakMediator.hentMeldingOmVedtakHtml(
+                        oppgaveId = oppgaveId,
+                        saksbehandler = saksbehandler,
+                        saksbehandlerToken = saksbehandlerToken,
+                    )
+                call.respond(HttpStatusCode.OK, html)
             }
 
             route("utvidet-beskrivelse/{brevblokkId}") {
@@ -30,8 +41,16 @@ internal fun Route.meldingOmVedtakApi(applicationCallParser: ApplicationCallPars
                             ?: throw IllegalArgumentException("Kunne ikke finne brevblokkId i path")
                     val request = call.receive<MeldingOmVedtakUtvidetBeskrivelseRequestDTO>()
                     val saksbehandler = applicationCallParser.saksbehandler(call)
-                    // TODO: Slå opp behandlingId fra oppgave, kall dp-melding-om-vedtak
-                    call.respond(HttpStatusCode.OK)
+                    val saksbehandlerToken = call.request.jwt()
+                    val response =
+                        meldingOmVedtakMediator.lagreUtvidetBeskrivelse(
+                            oppgaveId = oppgaveId,
+                            brevblokkId = brevblokkId,
+                            tekst = request.tekst,
+                            saksbehandler = saksbehandler,
+                            saksbehandlerToken = saksbehandlerToken,
+                        )
+                    call.respond(HttpStatusCode.OK, response)
                 }
             }
 
@@ -40,7 +59,13 @@ internal fun Route.meldingOmVedtakApi(applicationCallParser: ApplicationCallPars
                     val oppgaveId = call.finnUUID("oppgaveId")
                     val request = call.receive<MeldingOmVedtakBrevVariantRequestDTO>()
                     val saksbehandler = applicationCallParser.saksbehandler(call)
-                    // TODO: Slå opp behandlingId fra oppgave, kall dp-melding-om-vedtak
+                    val saksbehandlerToken = call.request.jwt()
+                    meldingOmVedtakMediator.lagreBrevVariant(
+                        oppgaveId = oppgaveId,
+                        brevVariant = request.brevVariant.value,
+                        saksbehandler = saksbehandler,
+                        saksbehandlerToken = saksbehandlerToken,
+                    )
                     call.respond(HttpStatusCode.NoContent)
                 }
             }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/MeldingOmVedtakApi.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/MeldingOmVedtakApi.kt
@@ -1,0 +1,49 @@
+package no.nav.dagpenger.saksbehandling.api
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.auth.authenticate
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.put
+import io.ktor.server.routing.route
+import no.nav.dagpenger.saksbehandling.api.models.MeldingOmVedtakBrevVariantRequestDTO
+import no.nav.dagpenger.saksbehandling.api.models.MeldingOmVedtakUtvidetBeskrivelseRequestDTO
+import no.nav.dagpenger.saksbehandling.jwt.ApplicationCallParser
+
+internal fun Route.meldingOmVedtakApi(applicationCallParser: ApplicationCallParser) {
+    authenticate("azureAd") {
+        route("oppgave/{oppgaveId}/melding-om-vedtak") {
+            get("html") {
+                val oppgaveId = call.finnUUID("oppgaveId")
+                val saksbehandler = applicationCallParser.saksbehandler(call)
+                // TODO: Hent oppgave, berik med person/saksbehandler-data, kall dp-melding-om-vedtak
+                call.respond(HttpStatusCode.OK)
+            }
+
+            route("utvidet-beskrivelse/{brevblokkId}") {
+                put {
+                    val oppgaveId = call.finnUUID("oppgaveId")
+                    val brevblokkId =
+                        call.parameters["brevblokkId"]
+                            ?: throw IllegalArgumentException("Kunne ikke finne brevblokkId i path")
+                    val request = call.receive<MeldingOmVedtakUtvidetBeskrivelseRequestDTO>()
+                    val saksbehandler = applicationCallParser.saksbehandler(call)
+                    // TODO: Slå opp behandlingId fra oppgave, kall dp-melding-om-vedtak
+                    call.respond(HttpStatusCode.OK)
+                }
+            }
+
+            route("brev-variant") {
+                put {
+                    val oppgaveId = call.finnUUID("oppgaveId")
+                    val request = call.receive<MeldingOmVedtakBrevVariantRequestDTO>()
+                    val saksbehandler = applicationCallParser.saksbehandler(call)
+                    // TODO: Slå opp behandlingId fra oppgave, kall dp-melding-om-vedtak
+                    call.respond(HttpStatusCode.NoContent)
+                }
+            }
+        }
+    }
+}

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/vedtaksmelding/MeldingOmVedtakKlient.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/vedtaksmelding/MeldingOmVedtakKlient.kt
@@ -50,16 +50,6 @@ class MeldingOmVedtakKlient(
         utløstAvType: UtløstAvType = UtløstAvType.SØKNAD,
         sakId: String? = null,
     ): Result<String> {
-        val utløstAvTypeString =
-            when (utløstAvType) {
-                UtløstAvType.KLAGE -> "KLAGE"
-                UtløstAvType.SØKNAD -> "RETT_TIL_DAGPENGER"
-                UtløstAvType.MELDEKORT -> "MELDEKORT"
-                UtløstAvType.MANUELL -> "MANUELL"
-                UtløstAvType.INNSENDING -> "INNSENDING"
-                UtløstAvType.OMGJØRING -> "OMGJØRING"
-            }
-
         val meldingOmVedtakDataDTO =
             MeldingOmVedtakDataDTO(
                 fornavn = person.fornavn,
@@ -67,7 +57,7 @@ class MeldingOmVedtakKlient(
                 fodselsnummer = person.ident,
                 saksbehandler = saksbehandler,
                 beslutter = beslutter,
-                behandlingstype = utløstAvTypeString,
+                behandlingstype = utløstAvType.tilMeldingOmVedtakBehandlingstype(),
                 sakId = sakId,
             )
         return kotlin
@@ -100,7 +90,7 @@ class MeldingOmVedtakKlient(
                 fodselsnummer = person.ident,
                 saksbehandler = saksbehandler,
                 beslutter = beslutter,
-                behandlingstype = utløstAv.name,
+                behandlingstype = utløstAv.tilMeldingOmVedtakBehandlingstype(),
                 sakId = sakId,
             )
         return kotlin
@@ -153,16 +143,6 @@ class MeldingOmVedtakKlient(
         utløstAvType: UtløstAvType = UtløstAvType.SØKNAD,
         sakId: String? = null,
     ): Result<String> {
-        val utløstAvTypeString =
-            when (utløstAvType) {
-                UtløstAvType.KLAGE -> "KLAGE"
-                UtløstAvType.SØKNAD -> "RETT_TIL_DAGPENGER"
-                UtløstAvType.MELDEKORT -> "MELDEKORT"
-                UtløstAvType.MANUELL -> "MANUELL"
-                UtløstAvType.INNSENDING -> "INNSENDING"
-                UtløstAvType.OMGJØRING -> "OMGJØRING"
-            }
-
         val meldingOmVedtakDataDTO =
             MeldingOmVedtakDataDTO(
                 fornavn = person.fornavn,
@@ -170,7 +150,7 @@ class MeldingOmVedtakKlient(
                 fodselsnummer = person.ident,
                 saksbehandler = saksbehandler,
                 beslutter = beslutter,
-                behandlingstype = utløstAvTypeString,
+                behandlingstype = utløstAvType.tilMeldingOmVedtakBehandlingstype(),
                 sakId = sakId,
             )
         return kotlin
@@ -230,6 +210,16 @@ class MeldingOmVedtakKlient(
         message: String,
     ) : RuntimeException(message)
 }
+
+private fun UtløstAvType.tilMeldingOmVedtakBehandlingstype(): String =
+    when (this) {
+        UtløstAvType.KLAGE -> "KLAGE"
+        UtløstAvType.SØKNAD -> "RETT_TIL_DAGPENGER"
+        UtløstAvType.MELDEKORT -> "MELDEKORT"
+        UtløstAvType.MANUELL -> "MANUELL"
+        UtløstAvType.INNSENDING -> "INNSENDING"
+        UtløstAvType.OMGJØRING -> "OMGJØRING"
+    }
 
 private data class MeldingOmVedtakDataDTO(
     val fornavn: String,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/vedtaksmelding/MeldingOmVedtakKlient.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/vedtaksmelding/MeldingOmVedtakKlient.kt
@@ -6,6 +6,7 @@ import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.request.header
 import io.ktor.client.request.post
+import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
@@ -140,6 +141,88 @@ class MeldingOmVedtakKlient(
             }.onFailure {
                 logger.error(it) { "Feil ved henting av automatisk avslag brev for behandlingId: $behandlingId" }
                 throw KanIkkeLageMeldingOmVedtak("Kan ikke lage automatisk avslag brev for behandlingId: $behandlingId")
+            }
+    }
+
+    suspend fun hentMeldingOmVedtakHtml(
+        person: PDLPersonIntern,
+        saksbehandler: BehandlerDTO,
+        beslutter: BehandlerDTO?,
+        behandlingId: UUID,
+        saksbehandlerToken: String,
+        utløstAvType: UtløstAvType = UtløstAvType.SØKNAD,
+        sakId: String? = null,
+    ): Result<String> {
+        val utløstAvTypeString =
+            when (utløstAvType) {
+                UtløstAvType.KLAGE -> "KLAGE"
+                UtløstAvType.SØKNAD -> "RETT_TIL_DAGPENGER"
+                UtløstAvType.MELDEKORT -> "MELDEKORT"
+                UtløstAvType.MANUELL -> "MANUELL"
+                UtløstAvType.INNSENDING -> "INNSENDING"
+                UtløstAvType.OMGJØRING -> "OMGJØRING"
+            }
+
+        val meldingOmVedtakDataDTO =
+            MeldingOmVedtakDataDTO(
+                fornavn = person.fornavn,
+                etternavn = person.etternavn,
+                fodselsnummer = person.ident,
+                saksbehandler = saksbehandler,
+                beslutter = beslutter,
+                behandlingstype = utløstAvTypeString,
+                sakId = sakId,
+            )
+        return kotlin
+            .runCatching {
+                httpClient
+                    .post("$dpMeldingOmVedtakUrl/melding-om-vedtak/$behandlingId/html") {
+                        header("Authorization", "Bearer ${tokenProvider.invoke(saksbehandlerToken)}")
+                        header(HttpHeaders.ContentType, ContentType.Application.Json)
+                        setBody(objectMapper.writeValueAsString(meldingOmVedtakDataDTO))
+                    }.bodyAsText()
+            }.onFailure {
+                logger.error(it) { "Feil ved henting av melding om vedtak HTML for behandlingId: $behandlingId" }
+            }
+    }
+
+    suspend fun lagreUtvidetBeskrivelse(
+        behandlingId: UUID,
+        brevblokkId: String,
+        tekst: String,
+        saksbehandlerToken: String,
+    ): String =
+        kotlin
+            .runCatching {
+                httpClient
+                    .put("$dpMeldingOmVedtakUrl/melding-om-vedtak/$behandlingId/$brevblokkId/utvidet-beskrivelse-json") {
+                        header("Authorization", "Bearer ${tokenProvider.invoke(saksbehandlerToken)}")
+                        header(HttpHeaders.ContentType, ContentType.Application.Json)
+                        setBody(objectMapper.writeValueAsString(mapOf("tekst" to tekst)))
+                    }.bodyAsText()
+            }.getOrElse {
+                logger.error(it) { "Feil ved lagring av utvidet beskrivelse for behandlingId: $behandlingId, brevblokkId: $brevblokkId" }
+                throw KanIkkeLageMeldingOmVedtak(
+                    "Kan ikke lagre utvidet beskrivelse for behandlingId: $behandlingId, brevblokkId: $brevblokkId",
+                )
+            }
+
+    suspend fun lagreBrevVariant(
+        behandlingId: UUID,
+        brevVariant: String,
+        saksbehandlerToken: String,
+    ) {
+        kotlin
+            .runCatching {
+                httpClient
+                    .put("$dpMeldingOmVedtakUrl/melding-om-vedtak/$behandlingId/brev-variant") {
+                        header("Authorization", "Bearer ${tokenProvider.invoke(saksbehandlerToken)}")
+                        header(HttpHeaders.ContentType, ContentType.Application.Json)
+                        setBody(objectMapper.writeValueAsString(mapOf("brevVariant" to brevVariant)))
+                    }
+            }.onFailure {
+                logger.error(it) { "Feil ved lagring av brevvariant for behandlingId: $behandlingId" }
+                throw KanIkkeLageMeldingOmVedtak("Kan ikke lagre brevvariant for behandlingId: $behandlingId")
             }
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/MeldingOmVedtakMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/MeldingOmVedtakMediatorTest.kt
@@ -1,0 +1,291 @@
+package no.nav.dagpenger.saksbehandling
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.dagpenger.saksbehandling.api.Oppslag
+import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTO
+import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTOEnhetDTO
+import no.nav.dagpenger.saksbehandling.sak.SakMediator
+import no.nav.dagpenger.saksbehandling.vedtaksmelding.MeldingOmVedtakKlient
+import no.nav.dagpenger.saksbehandling.vedtaksmelding.MeldingOmVedtakKlient.KanIkkeLageMeldingOmVedtak
+import kotlin.test.Test
+
+class MeldingOmVedtakMediatorTest {
+    private val oppgaveMediator = mockk<OppgaveMediator>()
+    private val meldingOmVedtakKlient = mockk<MeldingOmVedtakKlient>()
+    private val oppslag = mockk<Oppslag>()
+    private val sakMediator = mockk<SakMediator>()
+
+    private val mediator =
+        MeldingOmVedtakMediator(
+            oppgaveMediator = oppgaveMediator,
+            meldingOmVedtakKlient = meldingOmVedtakKlient,
+            oppslag = oppslag,
+            sakMediator = sakMediator,
+        )
+
+    private val saksbehandler = TestHelper.saksbehandler
+    private val saksbehandlerToken = "test-saksbehandler-token"
+    private val oppgaveId = UUIDv7.ny()
+    private val behandlingId = UUIDv7.ny()
+    private val sakId = UUIDv7.ny()
+    private val oppgave = TestHelper.lagOppgave(oppgaveId = oppgaveId, behandling = TestHelper.lagBehandling(behandlingId = behandlingId))
+
+    private val behandlerDTO =
+        BehandlerDTO(
+            ident = saksbehandler.navIdent,
+            fornavn = "Saks",
+            etternavn = "Behandler",
+            enhet =
+                BehandlerDTOEnhetDTO(
+                    navn = "Nav Enhet",
+                    enhetNr = "1234",
+                    postadresse = "Postadresse",
+                ),
+        )
+
+    @Test
+    fun `hentMeldingOmVedtakHtml - henter oppgave, person, saksbehandler, beslutter og sakId`() {
+        every { oppgaveMediator.hentOppgave(oppgaveId, saksbehandler) } returns oppgave
+        coEvery { oppslag.hentPerson(oppgave.personIdent()) } returns TestHelper.pdlPerson
+        coEvery { oppslag.hentBehandler(saksbehandler.navIdent) } returns behandlerDTO
+        every { sakMediator.hentSakIdForBehandlingId(behandlingId) } returns sakId
+        coEvery {
+            meldingOmVedtakKlient.hentMeldingOmVedtakHtml(
+                person = TestHelper.pdlPerson,
+                saksbehandler = behandlerDTO,
+                beslutter = null,
+                behandlingId = behandlingId,
+                saksbehandlerToken = saksbehandlerToken,
+                utløstAvType = UtløstAvType.SØKNAD,
+                sakId = sakId.toString(),
+            )
+        } returns Result.success("<html>Vedtak</html>")
+
+        runBlocking {
+            val result =
+                mediator.hentMeldingOmVedtakHtml(
+                    oppgaveId = oppgaveId,
+                    saksbehandler = saksbehandler,
+                    saksbehandlerToken = saksbehandlerToken,
+                )
+            result shouldBe "<html>Vedtak</html>"
+        }
+
+        coVerify(exactly = 1) {
+            oppslag.hentPerson(oppgave.personIdent())
+            oppslag.hentBehandler(saksbehandler.navIdent)
+            meldingOmVedtakKlient.hentMeldingOmVedtakHtml(
+                person = TestHelper.pdlPerson,
+                saksbehandler = behandlerDTO,
+                beslutter = null,
+                behandlingId = behandlingId,
+                saksbehandlerToken = saksbehandlerToken,
+                utløstAvType = UtløstAvType.SØKNAD,
+                sakId = sakId.toString(),
+            )
+        }
+    }
+
+    @Test
+    fun `hentMeldingOmVedtakHtml - sender med beslutter når oppgave har beslutter`() {
+        val beslutterIdent = TestHelper.beslutter.navIdent
+        val beslutterDTO =
+            BehandlerDTO(
+                ident = beslutterIdent,
+                fornavn = "Be",
+                etternavn = "Slutter",
+                enhet =
+                    BehandlerDTOEnhetDTO(
+                        navn = "Nav Beslutter",
+                        enhetNr = "5678",
+                        postadresse = "Beslutter Postadresse",
+                    ),
+            )
+        val oppgaveMedBeslutter =
+            TestHelper.lagOppgave(
+                oppgaveId = oppgaveId,
+                behandling = TestHelper.lagBehandling(behandlingId = behandlingId),
+                tilstandslogg = TestHelper.lagOppgaveTilstandslogg(),
+            )
+
+        every { oppgaveMediator.hentOppgave(oppgaveId, saksbehandler) } returns oppgaveMedBeslutter
+        coEvery { oppslag.hentPerson(oppgaveMedBeslutter.personIdent()) } returns TestHelper.pdlPerson
+        coEvery { oppslag.hentBehandler(saksbehandler.navIdent) } returns behandlerDTO
+        coEvery { oppslag.hentBehandler(beslutterIdent) } returns beslutterDTO
+        every { sakMediator.hentSakIdForBehandlingId(behandlingId) } returns sakId
+        coEvery {
+            meldingOmVedtakKlient.hentMeldingOmVedtakHtml(
+                person = TestHelper.pdlPerson,
+                saksbehandler = behandlerDTO,
+                beslutter = beslutterDTO,
+                behandlingId = behandlingId,
+                saksbehandlerToken = saksbehandlerToken,
+                utløstAvType = UtløstAvType.SØKNAD,
+                sakId = sakId.toString(),
+            )
+        } returns Result.success("<html>Vedtak med beslutter</html>")
+
+        runBlocking {
+            val result =
+                mediator.hentMeldingOmVedtakHtml(
+                    oppgaveId = oppgaveId,
+                    saksbehandler = saksbehandler,
+                    saksbehandlerToken = saksbehandlerToken,
+                )
+            result shouldBe "<html>Vedtak med beslutter</html>"
+        }
+
+        coVerify(exactly = 1) {
+            oppslag.hentBehandler(beslutterIdent)
+        }
+    }
+
+    @Test
+    fun `hentMeldingOmVedtakHtml - kaster feil når klient feiler`() {
+        every { oppgaveMediator.hentOppgave(oppgaveId, saksbehandler) } returns oppgave
+        coEvery { oppslag.hentPerson(oppgave.personIdent()) } returns TestHelper.pdlPerson
+        coEvery { oppslag.hentBehandler(saksbehandler.navIdent) } returns behandlerDTO
+        every { sakMediator.hentSakIdForBehandlingId(behandlingId) } returns sakId
+        coEvery {
+            meldingOmVedtakKlient.hentMeldingOmVedtakHtml(
+                person = any(),
+                saksbehandler = any(),
+                beslutter = any(),
+                behandlingId = any(),
+                saksbehandlerToken = any(),
+                utløstAvType = any(),
+                sakId = any(),
+            )
+        } returns Result.failure(KanIkkeLageMeldingOmVedtak("Feil"))
+
+        runBlocking {
+            shouldThrow<KanIkkeLageMeldingOmVedtak> {
+                mediator.hentMeldingOmVedtakHtml(
+                    oppgaveId = oppgaveId,
+                    saksbehandler = saksbehandler,
+                    saksbehandlerToken = saksbehandlerToken,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `lagreUtvidetBeskrivelse - henter oppgave og delegerer til klient`() {
+        val brevblokkId = "brevblokk-abc"
+        val tekst = "En utvidet beskrivelse"
+        every { oppgaveMediator.hentOppgave(oppgaveId, saksbehandler) } returns oppgave
+        coEvery {
+            meldingOmVedtakKlient.lagreUtvidetBeskrivelse(
+                behandlingId = behandlingId,
+                brevblokkId = brevblokkId,
+                tekst = tekst,
+                saksbehandlerToken = saksbehandlerToken,
+            )
+        } returns """{"sistEndretTidspunkt": "2025-01-01T12:00:00"}"""
+
+        runBlocking {
+            val result =
+                mediator.lagreUtvidetBeskrivelse(
+                    oppgaveId = oppgaveId,
+                    brevblokkId = brevblokkId,
+                    tekst = tekst,
+                    saksbehandler = saksbehandler,
+                    saksbehandlerToken = saksbehandlerToken,
+                )
+            result shouldBe """{"sistEndretTidspunkt": "2025-01-01T12:00:00"}"""
+        }
+
+        coVerify(exactly = 1) {
+            meldingOmVedtakKlient.lagreUtvidetBeskrivelse(
+                behandlingId = behandlingId,
+                brevblokkId = brevblokkId,
+                tekst = tekst,
+                saksbehandlerToken = saksbehandlerToken,
+            )
+        }
+    }
+
+    @Test
+    fun `lagreUtvidetBeskrivelse - kaster feil når klient feiler`() {
+        val brevblokkId = "brevblokk-abc"
+        every { oppgaveMediator.hentOppgave(oppgaveId, saksbehandler) } returns oppgave
+        coEvery {
+            meldingOmVedtakKlient.lagreUtvidetBeskrivelse(
+                behandlingId = behandlingId,
+                brevblokkId = brevblokkId,
+                tekst = any(),
+                saksbehandlerToken = any(),
+            )
+        } throws KanIkkeLageMeldingOmVedtak("Feil ved lagring")
+
+        runBlocking {
+            shouldThrow<KanIkkeLageMeldingOmVedtak> {
+                mediator.lagreUtvidetBeskrivelse(
+                    oppgaveId = oppgaveId,
+                    brevblokkId = brevblokkId,
+                    tekst = "tekst",
+                    saksbehandler = saksbehandler,
+                    saksbehandlerToken = saksbehandlerToken,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `lagreBrevVariant - henter oppgave og delegerer til klient`() {
+        every { oppgaveMediator.hentOppgave(oppgaveId, saksbehandler) } returns oppgave
+        coEvery {
+            meldingOmVedtakKlient.lagreBrevVariant(
+                behandlingId = behandlingId,
+                brevVariant = "GENERERT",
+                saksbehandlerToken = saksbehandlerToken,
+            )
+        } returns Unit
+
+        runBlocking {
+            mediator.lagreBrevVariant(
+                oppgaveId = oppgaveId,
+                brevVariant = "GENERERT",
+                saksbehandler = saksbehandler,
+                saksbehandlerToken = saksbehandlerToken,
+            )
+        }
+
+        coVerify(exactly = 1) {
+            meldingOmVedtakKlient.lagreBrevVariant(
+                behandlingId = behandlingId,
+                brevVariant = "GENERERT",
+                saksbehandlerToken = saksbehandlerToken,
+            )
+        }
+    }
+
+    @Test
+    fun `lagreBrevVariant - kaster feil når klient feiler`() {
+        every { oppgaveMediator.hentOppgave(oppgaveId, saksbehandler) } returns oppgave
+        coEvery {
+            meldingOmVedtakKlient.lagreBrevVariant(
+                behandlingId = behandlingId,
+                brevVariant = any(),
+                saksbehandlerToken = any(),
+            )
+        } throws KanIkkeLageMeldingOmVedtak("Feil ved lagring av brevvariant")
+
+        runBlocking {
+            shouldThrow<KanIkkeLageMeldingOmVedtak> {
+                mediator.lagreBrevVariant(
+                    oppgaveId = oppgaveId,
+                    brevVariant = "EGENDEFINERT",
+                    saksbehandler = saksbehandler,
+                    saksbehandlerToken = saksbehandlerToken,
+                )
+            }
+        }
+    }
+}

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/InnsendingApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/InnsendingApiTest.kt
@@ -251,6 +251,7 @@ class InnsendingApiTest {
                     personMediator = mockk(),
                     sakMediator = mockk(),
                     innsendingMediator = innsendingMediator,
+                    meldingOmVedtakMediator = mockk(relaxed = true),
                 )
             }
             test()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/KlageApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/KlageApiTest.kt
@@ -480,6 +480,7 @@ class KlageApiTest {
                     personMediator = mockk(),
                     sakMediator = mockk(),
                     innsendingMediator = mockk(),
+                    meldingOmVedtakMediator = mockk(relaxed = true),
                 )
             }
             test()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/MeldingOmVedtakApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/MeldingOmVedtakApiTest.kt
@@ -1,0 +1,253 @@
+package no.nav.dagpenger.saksbehandling.api
+
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.get
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import no.nav.dagpenger.saksbehandling.MeldingOmVedtakMediator
+import no.nav.dagpenger.saksbehandling.TestHelper
+import no.nav.dagpenger.saksbehandling.UUIDv7
+import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.autentisert
+import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.gyldigSaksbehandlerToken
+import no.nav.dagpenger.saksbehandling.vedtaksmelding.MeldingOmVedtakKlient.KanIkkeLageMeldingOmVedtak
+import org.junit.jupiter.api.Test
+
+class MeldingOmVedtakApiTest {
+    init {
+        mockAzure()
+    }
+
+    private val oppgaveId = UUIDv7.ny()
+
+    @Test
+    fun `Skal kaste feil når det mangler autentisering`() {
+        val mediator = mockk<MeldingOmVedtakMediator>()
+        withMeldingOmVedtakApi(mediator) {
+            client.get("oppgave/$oppgaveId/melding-om-vedtak/html").status shouldBe HttpStatusCode.Unauthorized
+            client
+                .put("oppgave/$oppgaveId/melding-om-vedtak/utvidet-beskrivelse/brevblokk-123") {
+                    headers[HttpHeaders.ContentType] = "application/json"
+                    //language=json
+                    setBody("""{ "tekst": "en tekst" }""")
+                }.status shouldBe HttpStatusCode.Unauthorized
+            client
+                .put("oppgave/$oppgaveId/melding-om-vedtak/brev-variant") {
+                    headers[HttpHeaders.ContentType] = "application/json"
+                    //language=json
+                    setBody("""{ "brevVariant": "GENERERT" }""")
+                }.status shouldBe HttpStatusCode.Unauthorized
+        }
+    }
+
+    @Test
+    fun `Skal hente melding om vedtak HTML`() {
+        val saksbehandlerToken = gyldigSaksbehandlerToken()
+        val mediator =
+            mockk<MeldingOmVedtakMediator>().also {
+                coEvery {
+                    it.hentMeldingOmVedtakHtml(
+                        oppgaveId = oppgaveId,
+                        saksbehandler = TestHelper.saksbehandler,
+                        saksbehandlerToken = saksbehandlerToken,
+                    )
+                } returns "<html><h1>Vedtak</h1></html>"
+            }
+
+        withMeldingOmVedtakApi(mediator) {
+            client
+                .get("oppgave/$oppgaveId/melding-om-vedtak/html") {
+                    autentisert(token = saksbehandlerToken)
+                }.let { response ->
+                    response.status shouldBe HttpStatusCode.OK
+                    response.bodyAsText() shouldBe "<html><h1>Vedtak</h1></html>"
+                }
+        }
+
+        coVerify(exactly = 1) {
+            mediator.hentMeldingOmVedtakHtml(
+                oppgaveId = oppgaveId,
+                saksbehandler = TestHelper.saksbehandler,
+                saksbehandlerToken = saksbehandlerToken,
+            )
+        }
+    }
+
+    @Test
+    fun `Skal returnere 500 når henting av HTML feiler`() {
+        val mediator =
+            mockk<MeldingOmVedtakMediator>().also {
+                coEvery {
+                    it.hentMeldingOmVedtakHtml(
+                        oppgaveId = oppgaveId,
+                        saksbehandler = any(),
+                        saksbehandlerToken = any(),
+                    )
+                } throws KanIkkeLageMeldingOmVedtak("Feil ved henting av HTML")
+            }
+
+        withMeldingOmVedtakApi(mediator) {
+            client
+                .get("oppgave/$oppgaveId/melding-om-vedtak/html") { autentisert() }
+                .status shouldBe HttpStatusCode.InternalServerError
+        }
+    }
+
+    @Test
+    fun `Skal lagre utvidet beskrivelse`() {
+        val brevblokkId = "brevblokk-123"
+        val saksbehandlerToken = gyldigSaksbehandlerToken()
+        val mediator =
+            mockk<MeldingOmVedtakMediator>().also {
+                coEvery {
+                    it.lagreUtvidetBeskrivelse(
+                        oppgaveId = oppgaveId,
+                        brevblokkId = brevblokkId,
+                        tekst = "En utvidet beskrivelse",
+                        saksbehandler = TestHelper.saksbehandler,
+                        saksbehandlerToken = saksbehandlerToken,
+                    )
+                } returns """{"sistEndretTidspunkt": "2025-01-01T12:00:00"}"""
+            }
+
+        withMeldingOmVedtakApi(mediator) {
+            client
+                .put("oppgave/$oppgaveId/melding-om-vedtak/utvidet-beskrivelse/$brevblokkId") {
+                    autentisert(token = saksbehandlerToken)
+                    headers[HttpHeaders.ContentType] = "application/json"
+                    //language=json
+                    setBody("""{ "tekst": "En utvidet beskrivelse" }""")
+                }.let { response ->
+                    response.status shouldBe HttpStatusCode.OK
+                    response.bodyAsText() shouldBe """{"sistEndretTidspunkt": "2025-01-01T12:00:00"}"""
+                }
+        }
+
+        coVerify(exactly = 1) {
+            mediator.lagreUtvidetBeskrivelse(
+                oppgaveId = oppgaveId,
+                brevblokkId = brevblokkId,
+                tekst = "En utvidet beskrivelse",
+                saksbehandler = TestHelper.saksbehandler,
+                saksbehandlerToken = saksbehandlerToken,
+            )
+        }
+    }
+
+    @Test
+    fun `Skal returnere 500 når lagring av utvidet beskrivelse feiler`() {
+        val mediator =
+            mockk<MeldingOmVedtakMediator>().also {
+                coEvery {
+                    it.lagreUtvidetBeskrivelse(
+                        oppgaveId = oppgaveId,
+                        brevblokkId = any(),
+                        tekst = any(),
+                        saksbehandler = any(),
+                        saksbehandlerToken = any(),
+                    )
+                } throws KanIkkeLageMeldingOmVedtak("Feil ved lagring")
+            }
+
+        withMeldingOmVedtakApi(mediator) {
+            client
+                .put("oppgave/$oppgaveId/melding-om-vedtak/utvidet-beskrivelse/brevblokk-123") {
+                    autentisert()
+                    headers[HttpHeaders.ContentType] = "application/json"
+                    //language=json
+                    setBody("""{ "tekst": "En tekst" }""")
+                }.status shouldBe HttpStatusCode.InternalServerError
+        }
+    }
+
+    @Test
+    fun `Skal lagre brevvariant`() {
+        val saksbehandlerToken = gyldigSaksbehandlerToken()
+        val mediator =
+            mockk<MeldingOmVedtakMediator>().also {
+                coEvery {
+                    it.lagreBrevVariant(
+                        oppgaveId = oppgaveId,
+                        brevVariant = "GENERERT",
+                        saksbehandler = TestHelper.saksbehandler,
+                        saksbehandlerToken = saksbehandlerToken,
+                    )
+                } returns Unit
+            }
+
+        withMeldingOmVedtakApi(mediator) {
+            client
+                .put("oppgave/$oppgaveId/melding-om-vedtak/brev-variant") {
+                    autentisert(token = saksbehandlerToken)
+                    headers[HttpHeaders.ContentType] = "application/json"
+                    //language=json
+                    setBody("""{ "brevVariant": "GENERERT" }""")
+                }.let { response ->
+                    response.status shouldBe HttpStatusCode.NoContent
+                }
+        }
+
+        coVerify(exactly = 1) {
+            mediator.lagreBrevVariant(
+                oppgaveId = oppgaveId,
+                brevVariant = "GENERERT",
+                saksbehandler = TestHelper.saksbehandler,
+                saksbehandlerToken = saksbehandlerToken,
+            )
+        }
+    }
+
+    @Test
+    fun `Skal returnere 500 når lagring av brevvariant feiler`() {
+        val mediator =
+            mockk<MeldingOmVedtakMediator>().also {
+                coEvery {
+                    it.lagreBrevVariant(
+                        oppgaveId = oppgaveId,
+                        brevVariant = any(),
+                        saksbehandler = any(),
+                        saksbehandlerToken = any(),
+                    )
+                } throws KanIkkeLageMeldingOmVedtak("Feil ved lagring av brevvariant")
+            }
+
+        withMeldingOmVedtakApi(mediator) {
+            client
+                .put("oppgave/$oppgaveId/melding-om-vedtak/brev-variant") {
+                    autentisert()
+                    headers[HttpHeaders.ContentType] = "application/json"
+                    //language=json
+                    setBody("""{ "brevVariant": "EGENDEFINERT" }""")
+                }.status shouldBe HttpStatusCode.InternalServerError
+        }
+    }
+
+    private fun withMeldingOmVedtakApi(
+        meldingOmVedtakMediator: MeldingOmVedtakMediator,
+        test: suspend ApplicationTestBuilder.() -> Unit,
+    ) {
+        testApplication {
+            this.application {
+                installerApis(
+                    oppgaveMediator = mockk(),
+                    oppgaveDTOMapper = mockk(),
+                    produksjonsstatistikkRepository = mockk(),
+                    klageMediator = mockk(),
+                    klageDTOMapper = mockk(),
+                    personMediator = mockk(),
+                    sakMediator = mockk(),
+                    innsendingMediator = mockk(),
+                    meldingOmVedtakMediator = meldingOmVedtakMediator,
+                )
+            }
+            test()
+        }
+    }
+}

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApiTestHelper.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApiTestHelper.kt
@@ -28,6 +28,7 @@ internal object OppgaveApiTestHelper {
                     personMediator = personMediator,
                     sakMediator = mockk(relaxed = true),
                     innsendingMediator = mockk(relaxed = true),
+                    meldingOmVedtakMediator = mockk(relaxed = true),
                 )
             }
             test()
@@ -64,6 +65,7 @@ internal object OppgaveApiTestHelper {
                     personMediator = personMediator,
                     sakMediator = mockk(relaxed = true),
                     innsendingMediator = mockk(relaxed = true),
+                    meldingOmVedtakMediator = mockk(relaxed = true),
                 )
             }
             test()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/SakApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/SakApiTest.kt
@@ -90,6 +90,7 @@ class SakApiTest {
                     personMediator = mockk(),
                     sakMediator = sakMediator,
                     innsendingMediator = mockk(),
+                    meldingOmVedtakMediator = mockk(relaxed = true),
                 )
             }
             test()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/StatuspageTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/StatuspageTest.kt
@@ -369,6 +369,7 @@ class StatuspageTest {
             personMediator = mockk(),
             sakMediator = mockk(),
             innsendingMediator = mockk(),
+            meldingOmVedtakMediator = mockk(relaxed = true),
         )
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/statistikk/api/StatistikkApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/statistikk/api/StatistikkApiTest.kt
@@ -42,6 +42,7 @@ class StatistikkApiTest {
                     personMediator = mockk(),
                     sakMediator = mockk(),
                     innsendingMediator = mockk(),
+                    meldingOmVedtakMediator = mockk(relaxed = true),
                 )
             }
 
@@ -79,6 +80,7 @@ class StatistikkApiTest {
                     personMediator = mockk(),
                     sakMediator = mockk(),
                     innsendingMediator = mockk(),
+                    meldingOmVedtakMediator = mockk(relaxed = true),
                 )
             }
 
@@ -144,6 +146,7 @@ class StatistikkApiTest {
                     personMediator = mockk(),
                     sakMediator = mockk(),
                     innsendingMediator = mockk(),
+                    meldingOmVedtakMediator = mockk(relaxed = true),
                 )
             }
 
@@ -257,6 +260,7 @@ class StatistikkApiTest {
                     personMediator = mockk(),
                     sakMediator = mockk(),
                     innsendingMediator = mockk(),
+                    meldingOmVedtakMediator = mockk(relaxed = true),
                 )
             }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/vedtaksmelding/MeldingOmVedtakKlientTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/vedtaksmelding/MeldingOmVedtakKlientTest.kt
@@ -181,7 +181,7 @@ class MeldingOmVedtakKlientTest {
                         "fornavn": "Test",
                         "etternavn": "Person",
                         "fodselsnummer": "testIdent",
-                        "behandlingstype": "SØKNAD",
+                        "behandlingstype": "RETT_TIL_DAGPENGER",
                         "sakId": "$sakId",
                         "saksbehandler": {
                             "ident": "saksbehandlerIdent",

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/vedtaksmelding/MeldingOmVedtakKlientTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/vedtaksmelding/MeldingOmVedtakKlientTest.kt
@@ -271,4 +271,186 @@ class MeldingOmVedtakKlientTest {
             }
         }
     }
+
+    @Test
+    fun `hentMeldingOmVedtakHtml - happy path`() {
+        val sakId = UUIDv7.ny().toString()
+        runBlocking {
+            val result =
+                meldingOmVedtakKlient.hentMeldingOmVedtakHtml(
+                    person = person,
+                    saksbehandler = saksbehandler,
+                    beslutter = null,
+                    behandlingId = behandlingIdSuksess,
+                    saksbehandlerToken = saksbehandlerToken,
+                    utløstAvType = UtløstAvType.SØKNAD,
+                    sakId = sakId,
+                )
+            result.getOrThrow() shouldBe expectedHtmlResponse
+            requireNotNull(requestData).let {
+                it.url.encodedPath shouldBe "/melding-om-vedtak/$behandlingIdSuksess/html"
+                it.headers["Authorization"] shouldBe "Bearer $saksbehandlerToken"
+                it.body.contentType.toString() shouldBe "application/json"
+                it.body.toByteArray().decodeToString() shouldEqualJson
+                    """
+                    {
+                        "fornavn": "Test",
+                        "etternavn": "Person",
+                        "fodselsnummer": "testIdent",
+                        "behandlingstype": "RETT_TIL_DAGPENGER",
+                        "sakId": "$sakId",
+                        "saksbehandler": {
+                            "ident": "saksbehandlerIdent",
+                            "fornavn": "Saks",
+                            "etternavn": "Behandler",
+                            "enhet": {
+                                "navn": "Enhet",
+                                "enhetNr": "1234",
+                                "postadresse": "Postadresse"
+                            }
+                        }
+                    }
+                    """.trimIndent()
+            }
+        }
+    }
+
+    @Test
+    fun `hentMeldingOmVedtakHtml - med beslutter`() {
+        runBlocking {
+            val result =
+                meldingOmVedtakKlient.hentMeldingOmVedtakHtml(
+                    person = person,
+                    saksbehandler = saksbehandler,
+                    beslutter = saksbehandler,
+                    behandlingId = behandlingIdSuksess,
+                    saksbehandlerToken = saksbehandlerToken,
+                )
+            result.getOrThrow() shouldBe expectedHtmlResponse
+            requireNotNull(requestData).let {
+                it.body.toByteArray().decodeToString() shouldEqualJson
+                    """
+                    {
+                        "fornavn": "Test",
+                        "etternavn": "Person",
+                        "fodselsnummer": "testIdent",
+                        "behandlingstype": "RETT_TIL_DAGPENGER",
+                        "saksbehandler": {
+                            "ident": "saksbehandlerIdent",
+                            "fornavn": "Saks",
+                            "etternavn": "Behandler",
+                            "enhet": {
+                                "navn": "Enhet",
+                                "enhetNr": "1234",
+                                "postadresse": "Postadresse"
+                            }
+                        },
+                        "beslutter": {
+                            "ident": "saksbehandlerIdent",
+                            "fornavn": "Saks",
+                            "etternavn": "Behandler",
+                            "enhet": {
+                                "navn": "Enhet",
+                                "enhetNr": "1234",
+                                "postadresse": "Postadresse"
+                            }
+                        }
+                    }
+                    """.trimIndent()
+            }
+        }
+    }
+
+    @Test
+    fun `hentMeldingOmVedtakHtml - ved feil`() {
+        runBlocking {
+            val behandlingIdSomFeiler = UUIDv7.ny()
+            val result =
+                meldingOmVedtakKlient.hentMeldingOmVedtakHtml(
+                    person = person,
+                    saksbehandler = saksbehandler,
+                    beslutter = null,
+                    behandlingId = behandlingIdSomFeiler,
+                    saksbehandlerToken = saksbehandlerToken,
+                )
+            result.isFailure shouldBe true
+        }
+    }
+
+    @Test
+    fun `lagreUtvidetBeskrivelse - happy path`() {
+        val brevblokkId = "brevblokk-123"
+        runBlocking {
+            val result =
+                meldingOmVedtakKlient.lagreUtvidetBeskrivelse(
+                    behandlingId = behandlingIdSuksess,
+                    brevblokkId = brevblokkId,
+                    tekst = "En utvidet beskrivelse",
+                    saksbehandlerToken = saksbehandlerToken,
+                )
+            result shouldBe expectedHtmlResponse
+            requireNotNull(requestData).let {
+                it.url.encodedPath shouldBe "/melding-om-vedtak/$behandlingIdSuksess/$brevblokkId/utvidet-beskrivelse-json"
+                it.headers["Authorization"] shouldBe "Bearer $saksbehandlerToken"
+                it.body.contentType.toString() shouldBe "application/json"
+                it.body.toByteArray().decodeToString() shouldEqualJson
+                    """
+                    {
+                        "tekst": "En utvidet beskrivelse"
+                    }
+                    """.trimIndent()
+            }
+        }
+    }
+
+    @Test
+    fun `lagreUtvidetBeskrivelse - ved feil`() {
+        runBlocking {
+            val behandlingIdSomFeiler = UUIDv7.ny()
+            shouldThrow<KanIkkeLageMeldingOmVedtak> {
+                meldingOmVedtakKlient.lagreUtvidetBeskrivelse(
+                    behandlingId = behandlingIdSomFeiler,
+                    brevblokkId = "brevblokk-123",
+                    tekst = "En utvidet beskrivelse",
+                    saksbehandlerToken = saksbehandlerToken,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `lagreBrevVariant - happy path`() {
+        runBlocking {
+            meldingOmVedtakKlient.lagreBrevVariant(
+                behandlingId = behandlingIdSuksess,
+                brevVariant = "INNVILGELSE",
+                saksbehandlerToken = saksbehandlerToken,
+            )
+            requireNotNull(requestData).let {
+                it.url.encodedPath shouldBe "/melding-om-vedtak/$behandlingIdSuksess/brev-variant"
+                it.headers["Authorization"] shouldBe "Bearer $saksbehandlerToken"
+                it.body.contentType.toString() shouldBe "application/json"
+                it.body.toByteArray().decodeToString() shouldEqualJson
+                    """
+                    {
+                        "brevVariant": "INNVILGELSE"
+                    }
+                    """.trimIndent()
+            }
+        }
+    }
+
+    @Test
+    fun `lagreBrevVariant - ved feil`() {
+        runBlocking {
+            val behandlingIdSomFeiler = UUIDv7.ny()
+            shouldThrow<KanIkkeLageMeldingOmVedtak> {
+                meldingOmVedtakKlient.lagreBrevVariant(
+                    behandlingId = behandlingIdSomFeiler,
+                    brevVariant = "INNVILGELSE",
+                    saksbehandlerToken = saksbehandlerToken,
+                )
+            }
+        }
+    }
 }

--- a/openapi/src/main/resources/saksbehandling-api.yaml
+++ b/openapi/src/main/resources/saksbehandling-api.yaml
@@ -399,6 +399,121 @@ paths:
               schema:
                 $ref: '#/components/schemas/HttpProblem'
 
+  /oppgave/{oppgaveId}/melding-om-vedtak/html:
+    get:
+      tags:
+        - Melding om vedtak
+      summary: Hent forhåndsvisning av melding om vedtak som HTML
+      description: |
+        Henter HTML-forhåndsvisning av melding om vedtak for oppgaven.
+        dp-saksbehandling beriker requesten med person-, saksbehandler- og behandlingsdata,
+        og videresender til dp-melding-om-vedtak.
+      parameters:
+        - in: path
+          name: oppgaveId
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: HTML-forhåndsvisning av melding om vedtak
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeldingOmVedtakResponse'
+        '404':
+          description: Oppgaven eller behandlingen ble ikke funnet
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/HttpProblem'
+        default:
+          description: Feil
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/HttpProblem'
+
+  /oppgave/{oppgaveId}/melding-om-vedtak/utvidet-beskrivelse/{brevblokkId}:
+    put:
+      tags:
+        - Melding om vedtak
+      summary: Lagre utvidet beskrivelse for en brevblokk
+      description: Lagrer utvidet beskrivelse (rik tekst) for en gitt brevblokk i meldingen om vedtak.
+      parameters:
+        - in: path
+          name: oppgaveId
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - in: path
+          name: brevblokkId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MeldingOmVedtakUtvidetBeskrivelseRequest'
+      responses:
+        '200':
+          description: Utvidet beskrivelse er lagret
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeldingOmVedtakUtvidetBeskrivelseResponse'
+        '404':
+          description: Oppgaven eller behandlingen ble ikke funnet
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/HttpProblem'
+        default:
+          description: Feil
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/HttpProblem'
+
+  /oppgave/{oppgaveId}/melding-om-vedtak/brev-variant:
+    put:
+      tags:
+        - Melding om vedtak
+      summary: Lagre brevvariant for melding om vedtak
+      description: Lagrer brevvariant (generert eller egendefinert) for melding om vedtak.
+      parameters:
+        - in: path
+          name: oppgaveId
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MeldingOmVedtakBrevVariantRequest'
+      responses:
+        '204':
+          description: Brevvariant er lagret
+        '404':
+          description: Oppgaven eller behandlingen ble ikke funnet
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/HttpProblem'
+        default:
+          description: Feil
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/HttpProblem'
+
   /oppgave/{oppgaveId}/melding-om-vedtak-kilde:
     put:
       summary: Endre kilde for melding om vedtak
@@ -1342,6 +1457,72 @@ components:
         - JA
         - NEI
         - IKKE_RELEVANT
+
+    MeldingOmVedtakResponse:
+      type: object
+      properties:
+        html:
+          type: string
+          description: HTML for melding om vedtak
+        utvidedeBeskrivelser:
+          type: array
+          items:
+            $ref: '#/components/schemas/MeldingOmVedtakUtvidetBeskrivelse'
+        brevVariant:
+          $ref: '#/components/schemas/MeldingOmVedtakBrevVariant'
+      required:
+        - html
+        - utvidedeBeskrivelser
+        - brevVariant
+
+    MeldingOmVedtakUtvidetBeskrivelse:
+      type: object
+      properties:
+        brevblokkId:
+          type: string
+        tekst:
+          type: string
+        sistEndretTidspunkt:
+          type: string
+          format: date-time
+        tittel:
+          type: string
+      required:
+        - brevblokkId
+        - tekst
+        - tittel
+
+    MeldingOmVedtakUtvidetBeskrivelseRequest:
+      type: object
+      properties:
+        tekst:
+          type: string
+          description: Utvidet beskrivelse som skal inngå i vedtaksmeldingen
+      required:
+        - tekst
+
+    MeldingOmVedtakUtvidetBeskrivelseResponse:
+      type: object
+      properties:
+        sistEndretTidspunkt:
+          type: string
+          format: date-time
+          description: Tidspunkt utvidet beskrivelse sist ble endret
+
+    MeldingOmVedtakBrevVariant:
+      type: string
+      default: "GENERERT"
+      enum:
+        - "GENERERT"
+        - "EGENDEFINERT"
+
+    MeldingOmVedtakBrevVariantRequest:
+      type: object
+      properties:
+        brevVariant:
+          $ref: '#/components/schemas/MeldingOmVedtakBrevVariant'
+      required:
+        - brevVariant
 
     MeldingOmVedtakKildeRequest:
       type: object


### PR DESCRIPTION
## Hva gjør denne PR-en?

Legger til nye endepunkter i dp-saksbehandling som proxyer kall til dp-melding-om-vedtak. Dette forenkler frontenden ved at den kun trenger å forholde seg til dp-saksbehandling sitt API.

### Nye endepunkter

| Metode | Sti | Beskrivelse |
|--------|-----|-------------|
| GET | `/oppgave/{oppgaveId}/melding-om-vedtak/html` | Henter HTML-forhåndsvisning av vedtaksmelding |
| PUT | `/oppgave/{oppgaveId}/melding-om-vedtak/utvidet-beskrivelse/{brevblokkId}` | Lagrer utvidet beskrivelse |
| PUT | `/oppgave/{oppgaveId}/melding-om-vedtak/brev-variant` | Lagrer brevvariant |

### Endringer

- **OpenAPI-spec**: 3 nye endepunkter + 7 nye skjemaer under `/oppgave/{oppgaveId}/melding-om-vedtak/`
- **MeldingOmVedtakApi.kt**: Ny Ktor routing-fil
- **MeldingOmVedtakMediator.kt**: Ny mediator som orkestrerer mellom API-lag og klient. Bruker OppgaveMediator for tilgangskontroll.
- **MeldingOmVedtakKlient.kt**: 3 nye metoder (`hentMeldingOmVedtakHtml`, `lagreUtvidetBeskrivelse`, `lagreBrevVariant`)

### Designvalg

- Bruker `oppgaveId` (ikke `behandlingId`) i URL — konsistent med resten av dp-saksbehandling API
- HTML-endepunktet er GET — dp-saksbehandling beriker requesten med person/saksbehandler-data server-side
- Tilgangskontroll delegeres til OppgaveMediator (`egneAnsatteTilgangskontroll` + `adressebeskyttelseTilgangskontroll`)

### Tester

- **MeldingOmVedtakKlientTest**: 7 nye tester (happy path + feil for alle 3 metoder)
- **MeldingOmVedtakApiTest**: 7 nye tester (autentisering, happy path, feil)
- **MeldingOmVedtakMediatorTest**: 7 nye tester (orkestrering, beslutter-logikk, feilhåndtering)

### Neste steg (utenfor denne PR-en)

- Frontend-endringer i dp-saksbehandling-frontend for å bruke nye endepunkter
- Fjerne frontend sin direkte kobling mot dp-melding-om-vedtak