### PR TITLE
Oppdater Entra ID Object IDs for adressebeskyttelse

### DIFF
--- a/.nais/vars-dev.yaml
+++ b/.nais/vars-dev.yaml
@@ -4,8 +4,8 @@ azure:
     saksbehandler: "3e28466f-c53d-46da-8b44-a4abc2ad4593" # 0000-GA-Dagpenger-Saksbehandler
     beslutter: "11b8475a-fb12-41aa-b1f6-8497c1b5385b" # 0000-GA-Dagpenger-Beslutter
     egne_ansatte: "dbe4ad45-320b-4e9a-aaa1-73cca4ee124d" # 0000-GA-Egne_ansatte
-    adressebeskyttelse_fortrolig: "ea930b6b-9397-44d9-b9e6-f4cf527a632a"  # 0000-GA-Fortrolig_Adresse
-    adressebeskyttelse_strengt_fortrolig: "5ef775f2-61f8-4283-bf3d-8d03f428aa14"  # 0000-GA-Strengt_Fortrolig_Adresse,
+    adressebeskyttelse_fortrolig: "2e1dc582-f762-4510-a660-88bf68fb7128"  # 0000-GA-Fortrolig_Adresse
+    adressebeskyttelse_strengt_fortrolig: "a1b518e2-3947-478d-8929-e5d685c47cac"  # 0000-GA-Strengt_Fortrolig_Adresse,
     adressebeskyttelse_strengt_fortrolig_utland: "fc792042-93d8-4d5e-a501-55c45c03c576" #0000-GA-Person-EndreStrengtFortroligUtland
 
 db:

--- a/.nais/vars-prod.yaml
+++ b/.nais/vars-prod.yaml
@@ -4,8 +4,8 @@ azure:
     saksbehandler: "2e9c63d8-322e-4c1f-b500-a0abb812761c" # 0000-GA-Dagpenger-Saksbehandler
     beslutter: "70d54cad-53a3-4788-bbe3-565096f01da7" # 0000-GA-Dagpenger-Beslutter
     egne_ansatte: "e750ceb5-b70b-4d94-b4fa-9d22467b786b" # 0000-GA-Egne_ansatte
-    adressebeskyttelse_fortrolig: "9ec6487d-f37a-4aad-a027-cd221c1ac32b"  # 0000-GA-Fortrolig_Adresse
-    adressebeskyttelse_strengt_fortrolig: "ad7b87a6-9180-467c-affc-20a566b0fec0"  # 0000-GA-Strengt_Fortrolig_Adresse,
+    adressebeskyttelse_fortrolig: "e98efc34-12d1-401f-b059-f17e62834065"  # 0000-GA-Fortrolig_Adresse
+    adressebeskyttelse_strengt_fortrolig: "2931da41-8b8e-42cd-99c0-04a169ddae40"  # 0000-GA-Strengt_Fortrolig_Adresse,
     adressebeskyttelse_strengt_fortrolig_utland: "d9555b40-e0ab-4c6d-ba0b-0f1b9ecc252b" #0000-GA-Person-EndreStrengtFortroligUtland
 db:
   highAvailability: true


### PR DESCRIPTION
AD-gruppene `0000-GA-Fortrolig_Adresse` og `0000-GA-Strengt_Fortrolig_Adresse` ble slettet ved en feil 02.03 og gjenopprettet med nye Object IDs i Entra ID.

**Prod:**
- Fortrolig: `9ec6487d` → `e98efc34`
- Strengt Fortrolig: `ad7b87a6` → `2931da41`

**Dev:**
- Fortrolig: `ea930b6b` → `2e1dc582`
- Strengt Fortrolig: `5ef775f2` → `a1b518e2`

⚠️ Må merges og deployes ASAP for å gjenopprette tilgang til fortrolige adresser.