### PR TITLE
refactor: Generaliser BehandlingOpprettetMottak med UtløstAvType enum

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
@@ -48,6 +48,7 @@ import no.nav.dagpenger.saksbehandling.hendelser.BehandlingOpplåstHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.FjernOppgaveAnsvarHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.ForslagTilVedtakHendelse
+import no.nav.dagpenger.saksbehandling.hendelser.GenerellBehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.GodkjentBehandlingHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.Hendelse
 import no.nav.dagpenger.saksbehandling.hendelser.InnsendingFerdigstiltHendelse
@@ -415,8 +416,8 @@ class PostgresOppgaveRepository(
                         JOIN    person_v1       pers ON pers.id = beha.person_id
                         JOIN    hendelse_v1     hend ON beha.id = hend.behandling_id
                         WHERE   pers.ident = :ident
-                        AND     hend.hendelse_type = 'SøknadsbehandlingOpprettetHendelse'
-                        AND     hend.hendelse_data->>'søknadId' = :soknad_id
+                        AND     hend.hendelse_type IN ('SøknadsbehandlingOpprettetHendelse', 'GenerellBehandlingOpprettetHendelse')
+                        AND     (hend.hendelse_data->>'søknadId' = :soknad_id OR hend.hendelse_data->>'behandletHendelseId' = :soknad_id)
                     """.trimMargin(),
                     mapOf(
                         "ident" to ident,
@@ -487,8 +488,8 @@ class PostgresOppgaveRepository(
             val søknadIdClause =
                 søkeFilter.søknadId?.let {
                     """
-                    AND hend.hendelse_type = 'SøknadsbehandlingOpprettetHendelse' 
-                    AND hend.hendelse_data ->> 'søknadId' = :soknad_id 
+                    AND hend.hendelse_type IN ('SøknadsbehandlingOpprettetHendelse', 'GenerellBehandlingOpprettetHendelse')
+                    AND (hend.hendelse_data ->> 'søknadId' = :soknad_id OR hend.hendelse_data ->> 'behandletHendelseId' = :soknad_id)
                     """.trimIndent()
                 } ?: ""
 
@@ -627,6 +628,7 @@ private fun rehydrerTilstandsendringHendelse(
         "BehandlingLåstHendelse" -> hendelseJson.tilHendelse<BehandlingLåstHendelse>()
         "BehandlingOpplåstHendelse" -> hendelseJson.tilHendelse<BehandlingOpplåstHendelse>()
         "BehandlingOpprettetHendelse" -> hendelseJson.tilHendelse<BehandlingOpprettetHendelse>()
+        "GenerellBehandlingOpprettetHendelse" -> hendelseJson.tilHendelse<GenerellBehandlingOpprettetHendelse>()
         "FjernOppgaveAnsvarHendelse" -> hendelseJson.tilHendelse<FjernOppgaveAnsvarHendelse>()
         "ForslagTilVedtakHendelse" -> hendelseJson.tilHendelse<ForslagTilVedtakHendelse>()
         "GodkjentBehandlingHendelse" -> hendelseJson.tilHendelse<GodkjentBehandlingHendelse>()
@@ -962,6 +964,11 @@ private fun Row.rehydrerHendelse(): Hendelse {
                 .tilHendelse<SøknadsbehandlingOpprettetHendelse>()
 
         "BehandlingOpprettetHendelse" -> this.string("hendelse_data").tilHendelse<BehandlingOpprettetHendelse>()
+        "GenerellBehandlingOpprettetHendelse" ->
+            this
+                .string("hendelse_data")
+                .tilHendelse<GenerellBehandlingOpprettetHendelse>()
+
         "MeldekortbehandlingOpprettetHendelse" ->
             this
                 .string("hendelse_data")

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/sak/PostgresSakRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/sak/PostgresSakRepository.kt
@@ -13,6 +13,7 @@ import no.nav.dagpenger.saksbehandling.SakHistorikk
 import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingOpprettetHendelse
+import no.nav.dagpenger.saksbehandling.hendelser.GenerellBehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.Hendelse
 import no.nav.dagpenger.saksbehandling.hendelser.InnsendingMottattHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.ManuellBehandlingOpprettetHendelse
@@ -430,6 +431,11 @@ class PostgresSakRepository(
                     .tilHendelse<SøknadsbehandlingOpprettetHendelse>()
 
             "BehandlingOpprettetHendelse" -> this.string("hendelse_data").tilHendelse<BehandlingOpprettetHendelse>()
+            "GenerellBehandlingOpprettetHendelse" ->
+                this
+                    .string("hendelse_data")
+                    .tilHendelse<GenerellBehandlingOpprettetHendelse>()
+
             "MeldekortbehandlingOpprettetHendelse" ->
                 this
                     .string("hendelse_data")

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediator.kt
@@ -137,7 +137,7 @@ class InnsendingMediator(
                         BehandlingAvbruttHendelse(
                             behandlingId = innsending.innsendingId,
                             behandletHendelseId = hendelse.søknadId.toString(),
-                            behandletHendelseType = "Søknad",
+                            behandletHendelseType = UtløstAvType.SØKNAD,
                             ident = hendelse.ident,
                             utførtAv = hendelse.utførtAv,
                         ),

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/AbstractBehandlingsresultatMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/AbstractBehandlingsresultatMottak.kt
@@ -8,6 +8,7 @@ import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.oshai.kotlinlogging.withLoggingContext
 import io.micrometer.core.instrument.MeterRegistry
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.UtsendingSak
 import no.nav.dagpenger.saksbehandling.hendelser.VedtakFattetHendelse
 import java.util.UUID
@@ -90,7 +91,7 @@ internal abstract class AbstractBehandlingsresultatMottak(
 internal data class Behandlingsresultat(
     val behandlingId: UUID,
     val basertPåBehandlingId: UUID? = null,
-    val behandletHendelseType: String,
+    val behandletHendelseType: UtløstAvType,
     val behandletHendelseId: String,
     val rettighetsperioder: List<Rettighetsperiode>,
     val automatiskBehandlet: Boolean,
@@ -98,7 +99,7 @@ internal data class Behandlingsresultat(
     constructor(packet: JsonMessage) : this(
         behandlingId = packet["behandlingId"].asUUID(),
         basertPåBehandlingId = packet["basertPå"].uuidOrNull(),
-        behandletHendelseType = packet["behandletHendelse"]["type"].asText(),
+        behandletHendelseType = UtløstAvType.fraNavn(packet["behandletHendelse"]["type"].asText()),
         behandletHendelseId = packet["behandletHendelse"]["id"].asText(),
         automatiskBehandlet = packet["automatisk"].asBoolean(),
         rettighetsperioder =
@@ -110,7 +111,7 @@ internal data class Behandlingsresultat(
     )
 
     private fun dagpengerInnvilget(): Boolean =
-        behandletHendelseType == "Søknad" &&
+        behandletHendelseType == UtløstAvType.SØKNAD &&
             rettighetsperioder.any { it.harRett }
 
     fun nyDagpengerettInnvilget(): Boolean = basertPåBehandlingId == null && dagpengerInnvilget()

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/ArenaSinkVedtakOpprettetMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/ArenaSinkVedtakOpprettetMottak.kt
@@ -8,6 +8,7 @@ import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.oshai.kotlinlogging.withLoggingContext
 import io.micrometer.core.instrument.MeterRegistry
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.UtsendingSak
 import no.nav.dagpenger.saksbehandling.db.person.PersonRepository
 import no.nav.dagpenger.saksbehandling.hendelser.VedtakFattetHendelse
@@ -83,7 +84,7 @@ class ArenaSinkVedtakOpprettetMottak(
                     VedtakFattetHendelse(
                         behandlingId = behandlingId,
                         behandletHendelseId = behandletHendelseId,
-                        behandletHendelseType = "Søknad",
+                        behandletHendelseType = UtløstAvType.SØKNAD,
                         ident = ident,
                         sak =
                             UtsendingSak(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/BehandlingAvbruttMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/BehandlingAvbruttMottak.kt
@@ -9,6 +9,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.oshai.kotlinlogging.withLoggingContext
 import io.micrometer.core.instrument.MeterRegistry
 import no.nav.dagpenger.saksbehandling.OppgaveMediator
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingAvbruttHendelse
 
 internal class BehandlingAvbruttMottak(
@@ -20,7 +21,7 @@ internal class BehandlingAvbruttMottak(
         val rapidFilter: River.() -> Unit = {
             precondition {
                 it.requireValue("@event_name", "behandling_avbrutt")
-                it.requireAny(key = "behandletHendelse.type", values = listOf("Søknad", "Meldekort", "Manuell", "Omgjøring"))
+                it.requireAny(key = "behandletHendelse.type", values = UtløstAvType.entries.map { t -> t.rapidNavn })
             }
             validate { it.requireKey("ident", "behandlingId") }
             validate { it.interestedIn("behandletHendelse") }
@@ -46,7 +47,7 @@ internal class BehandlingAvbruttMottak(
                 BehandlingAvbruttHendelse(
                     behandlingId = behandlingId,
                     behandletHendelseId = behandletHendelseId,
-                    behandletHendelseType = packet["behandletHendelse"]["type"].asText(),
+                    behandletHendelseType = UtløstAvType.fraNavn(packet["behandletHendelse"]["type"].asText()),
                     ident = packet["ident"].asText(),
                 ),
             )

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/BehandlingOpprettetMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/BehandlingOpprettetMottak.kt
@@ -10,15 +10,12 @@ import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.oshai.kotlinlogging.withLoggingContext
 import io.micrometer.core.instrument.MeterRegistry
-import no.nav.dagpenger.saksbehandling.hendelser.ManuellBehandlingOpprettetHendelse
-import no.nav.dagpenger.saksbehandling.hendelser.MeldekortbehandlingOpprettetHendelse
-import no.nav.dagpenger.saksbehandling.hendelser.RevurderingBehandlingOpprettetHendelse
-import no.nav.dagpenger.saksbehandling.hendelser.SøknadsbehandlingOpprettetHendelse
+import no.nav.dagpenger.saksbehandling.UtløstAvType
+import no.nav.dagpenger.saksbehandling.hendelser.GenerellBehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.sak.SakMediator
 import java.util.UUID
 
 private val logger = KotlinLogging.logger {}
-private val sikkerlogger = KotlinLogging.logger("tjenestekall")
 
 internal class BehandlingOpprettetMottak(
     rapidsConnection: RapidsConnection,
@@ -26,12 +23,11 @@ internal class BehandlingOpprettetMottak(
 ) : River.PacketListener {
     companion object {
         val rapidFilter: River.() -> Unit = {
-
             precondition {
                 it.requireValue("@event_name", "behandling_opprettet")
                 it.requireAny(
                     key = "behandletHendelse.type",
-                    values = listOf("Søknad", "Meldekort", "Manuell", "Omgjøring"),
+                    values = UtløstAvType.entries.map { t -> t.rapidNavn },
                 )
             }
             validate {
@@ -51,9 +47,17 @@ internal class BehandlingOpprettetMottak(
         metadata: MessageMetadata,
         meterRegistry: MeterRegistry,
     ) {
-        val behandletHendelseType = packet["behandletHendelse"]["type"].asText()
-        val behandletHendelseSkjedde = packet["behandletHendelse"]["skjedde"].asLocalDate()
         val behandlingId = packet["behandlingId"].asUUID()
+
+        val skipSet = setOf<UUID>(UUID.fromString("019a5e65-869d-78f2-84b9-fdd152f4f9aa"))
+        if (behandlingId in skipSet) {
+            logger.info { "Skipper behandlingId: $behandlingId fra BehandlingOpprettetMottak" }
+            return
+        }
+
+        val type = UtløstAvType.fraNavn(packet["behandletHendelse"]["type"].asText())
+        val behandletHendelseId = packet["behandletHendelse"]["id"].asText()
+        val behandletHendelseSkjedde = packet["behandletHendelse"]["skjedde"].asLocalDate()
         val ident = packet["ident"].asText()
         val behandlingskjedeId = packet["behandlingskjedeId"].asUUID()
         val basertPåBehandling: UUID? =
@@ -63,104 +67,26 @@ internal class BehandlingOpprettetMottak(
                 packet["basertPåBehandling"].asUUID()
             }
 
-        val skipSet = setOf<UUID>(UUID.fromString("019a5e65-869d-78f2-84b9-fdd152f4f9aa"))
-        if (behandlingId in skipSet) {
-            logger.info { "Skipper behandlingId: $behandlingId fra BehandlingOpprettetMottak" }
-            return
-        }
-        when (behandletHendelseType) {
-            "Søknad" -> {
-                val søknadId = packet.søknadId()
-                withLoggingContext("søknadId" to "$søknadId", "behandlingId" to "$behandlingId") {
-                    logger.info { "Mottok behandling_opprettet hendelse for søknad" }
-                    val søknadsbehandlingOpprettetHendelse =
-                        SøknadsbehandlingOpprettetHendelse(
-                            søknadId = søknadId,
-                            behandlingId = behandlingId,
-                            ident = ident,
-                            opprettet = behandletHendelseSkjedde.atStartOfDay(),
-                            basertPåBehandling = basertPåBehandling,
-                            behandlingskjedeId = behandlingskjedeId,
-                        )
-                    if (basertPåBehandling != null) {
-                        sakMediator.knyttTilSak(søknadsbehandlingOpprettetHendelse)
-                    } else {
-                        sakMediator.opprettSak(søknadsbehandlingOpprettetHendelse)
-                    }
-                }
+        withLoggingContext("behandlingId" to "$behandlingId", "type" to type.rapidNavn) {
+            logger.info { "Mottok behandling_opprettet hendelse for ${type.rapidNavn}" }
+
+            if (type == UtløstAvType.REVURDERING && basertPåBehandling == null) {
+                logger.warn { "Mottok behandling_opprettet av type ${type.rapidNavn}, uten 'basertPåBehandling'. Opprettes ikke!" }
+                return
             }
 
-            "Omgjøring" -> {
-                withLoggingContext("behandlingId" to "$behandlingId") {
-                    logger.info { "Mottok behandling_opprettet hendelse for omgjøring" }
-                    if (basertPåBehandling != null) {
-                        sakMediator.knyttTilSak(
-                            RevurderingBehandlingOpprettetHendelse(
-                                behandlingId = behandlingId,
-                                ident = ident,
-                                opprettet = behandletHendelseSkjedde.atStartOfDay(),
-                                basertPåBehandling = basertPåBehandling,
-                                behandlingskjedeId = behandlingskjedeId,
-                            ),
-                        )
-                    } else {
-                        logger.warn { "Mottok behandling_opprettet av type omgjøring, uten 'basertPåBehandling'. Opprettes ikke!" }
-                    }
-                }
-            }
+            val hendelse =
+                GenerellBehandlingOpprettetHendelse(
+                    behandlingId = behandlingId,
+                    ident = ident,
+                    opprettet = behandletHendelseSkjedde.atStartOfDay(),
+                    type = type,
+                    behandletHendelseId = behandletHendelseId,
+                    basertPåBehandling = basertPåBehandling,
+                    behandlingskjedeId = behandlingskjedeId,
+                )
 
-            "Meldekort" -> {
-                val meldekortId = packet.meldekortId()
-                withLoggingContext("meldekortId" to meldekortId, "behandlingId" to "$behandlingId") {
-                    logger.info { "Mottok behandling_opprettet hendelse for meldekort" }
-                    if (basertPåBehandling != null) {
-                        sakMediator.knyttTilSak(
-                            MeldekortbehandlingOpprettetHendelse(
-                                meldekortId = meldekortId,
-                                behandlingId = behandlingId,
-                                ident = ident,
-                                opprettet = behandletHendelseSkjedde.atStartOfDay(),
-                                basertPåBehandling = basertPåBehandling,
-                                behandlingskjedeId = behandlingskjedeId,
-                            ),
-                        )
-                    } else {
-                        logger.warn { "Mottok behandling_opprettet av type meldekort, uten 'basertPåBehandling'. Opprettes ikke!" }
-                    }
-                }
-            }
-
-            "Manuell" -> {
-                val manuellId = packet.manuellId()
-                withLoggingContext("manuellId" to "$manuellId", "behandlingId" to "$behandlingId") {
-                    logger.info { "Mottok behandling_opprettet hendelse for manuell behandling" }
-                    if (basertPåBehandling != null) {
-                        sakMediator.knyttTilSak(
-                            ManuellBehandlingOpprettetHendelse(
-                                manuellId = manuellId,
-                                behandlingId = behandlingId,
-                                ident = ident,
-                                opprettet = behandletHendelseSkjedde.atStartOfDay(),
-                                basertPåBehandling = basertPåBehandling,
-                                behandlingskjedeId = behandlingskjedeId,
-                            ),
-                        )
-                    } else {
-                        logger.warn { "Mottok behandling_opprettet av type manuell, uten 'basertPåBehandling'. Opprettes ikke!" }
-                    }
-                }
-            }
-
-            else -> {
-                logger.error { "Mottok behandling opprettet for ukjent hendelsetype. Se sikker logg for detaljer." }
-                sikkerlogger.error { "Mottok behandling opprettet for ukjent hendelsetype. ${packet.toJson()}" }
-            }
+            sakMediator.opprettEllerKnyttTilSak(hendelse)
         }
     }
 }
-
-private fun JsonMessage.søknadId(): UUID = this["behandletHendelse"]["id"].asUUID()
-
-private fun JsonMessage.manuellId(): UUID = this["behandletHendelse"]["id"].asUUID()
-
-private fun JsonMessage.meldekortId(): String = this["behandletHendelse"]["id"].asText()

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/ForslagTilBehandlingsresultatMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/ForslagTilBehandlingsresultatMottak.kt
@@ -9,6 +9,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.oshai.kotlinlogging.withLoggingContext
 import io.micrometer.core.instrument.MeterRegistry
 import no.nav.dagpenger.saksbehandling.OppgaveMediator
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.hendelser.ForslagTilVedtakHendelse
 
 internal class ForslagTilBehandlingsresultatMottak(
@@ -22,7 +23,7 @@ internal class ForslagTilBehandlingsresultatMottak(
         val rapidFilter: River.() -> Unit = {
             precondition {
                 it.requireValue("@event_name", "forslag_til_behandlingsresultat")
-                it.requireAny(key = "behandletHendelse.type", values = listOf("Søknad", "Meldekort", "Manuell", "Omgjøring"))
+                it.requireAny(key = "behandletHendelse.type", values = UtløstAvType.entries.map { t -> t.rapidNavn })
                 it.requireKey("ident", "behandlingId")
                 it.requireKey("opplysninger")
                 it.requireKey("behandletHendelse")
@@ -56,7 +57,7 @@ internal class ForslagTilBehandlingsresultatMottak(
                     ForslagTilVedtakHendelse(
                         ident = ident,
                         behandletHendelseId = behandletHendelseId,
-                        behandletHendelseType = packet["behandletHendelse"]["type"].asText(),
+                        behandletHendelseType = UtløstAvType.fraNavn(packet["behandletHendelse"]["type"].asText()),
                         behandlingId = behandlingId,
                         emneknagger = emneknagger,
                     )

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/sak/SakMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/sak/SakMediator.kt
@@ -15,6 +15,7 @@ import no.nav.dagpenger.saksbehandling.SakHistorikk
 import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.db.sak.SakRepository
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingOpprettetHendelse
+import no.nav.dagpenger.saksbehandling.hendelser.GenerellBehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.InnsendingMottattHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.ManuellBehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.MeldekortbehandlingOpprettetHendelse
@@ -154,6 +155,65 @@ class SakMediator(
         }
     }
 
+    fun opprettEllerKnyttTilSak(hendelse: GenerellBehandlingOpprettetHendelse) {
+        if (hendelse.type == UtløstAvType.SØKNAD && hendelse.basertPåBehandling == null) {
+            opprettSakForSøknad(hendelse)
+        } else {
+            sakRepository.hentSakHistorikk(hendelse.ident).also {
+                it.knyttTilSak(hendelse).also { resultat ->
+                    sjekkResultat(hendelse.behandlingId, hendelse.javaClass.simpleName, resultat)
+                }
+                sakRepository.lagre(it)
+            }
+        }
+    }
+
+    private fun opprettSakForSøknad(hendelse: GenerellBehandlingOpprettetHendelse) {
+        val sakId =
+            requireNotNull(hendelse.behandlingskjedeId) {
+                logger.error {
+                    "Mottok GenerellBehandlingOpprettetHendelse av type SØKNAD uten behandlingskjedeId for " +
+                        "behandlingId ${hendelse.behandlingId}"
+                }
+            }
+        val sak =
+            Sak(
+                sakId = sakId,
+                søknadId = UUID.fromString(hendelse.behandletHendelseId),
+                opprettet = hendelse.opprettet,
+            ).also {
+                it.leggTilBehandling(
+                    Behandling(
+                        behandlingId = hendelse.behandlingId,
+                        utløstAv = UtløstAvType.SØKNAD,
+                        opprettet = hendelse.opprettet,
+                        hendelse = hendelse,
+                    ),
+                )
+            }
+
+        runCatching {
+            personMediator.finnEllerOpprettPerson(hendelse.ident)
+        }.onFailure { e ->
+            when (e is AdresseBeeskyttetPersonException || e is SkjermetPersonException) {
+                true -> {
+                    sendAvbrytBehandling(
+                        behandlingId = hendelse.behandlingId,
+                        ident = hendelse.ident,
+                        årsak = "Skjermet eller adressebeskyttet person",
+                    )
+                }
+
+                else -> throw e
+            }
+        }.onSuccess { person ->
+            val sakHistorikk =
+                sakRepository.finnSakHistorikk(hendelse.ident) ?: SakHistorikk(person = person)
+            sakHistorikk.leggTilSak(sak)
+            sakRepository.lagre(sakHistorikk)
+        }
+    }
+
     fun oppdaterSakMedArenaSakId(vedtakFattetHendelse: VedtakFattetHendelse) {
         val sak = vedtakFattetHendelse.sak
         require(sak != null) { "VedtakFattetHendelse må ha en sak" }
@@ -192,16 +252,28 @@ class SakMediator(
         søknadsbehandlingOpprettetHendelse: SøknadsbehandlingOpprettetHendelse,
         årsak: String,
     ) {
+        sendAvbrytBehandling(
+            behandlingId = søknadsbehandlingOpprettetHendelse.behandlingId,
+            ident = søknadsbehandlingOpprettetHendelse.ident,
+            årsak = årsak,
+        )
+    }
+
+    private fun sendAvbrytBehandling(
+        behandlingId: UUID,
+        ident: String,
+        årsak: String,
+    ) {
         rapidsConnection.publish(
-            key = søknadsbehandlingOpprettetHendelse.ident,
+            key = ident,
             message =
                 JsonMessage
                     .newMessage(
                         eventName = "avbryt_behandling",
                         map =
                             mapOf(
-                                "behandlingId" to søknadsbehandlingOpprettetHendelse.behandlingId,
-                                "ident" to søknadsbehandlingOpprettetHendelse.ident,
+                                "behandlingId" to behandlingId,
+                                "ident" to ident,
                                 "årsak" to årsak,
                             ),
                     ).toJson(),

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorAlertTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorAlertTest.kt
@@ -8,6 +8,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.db.oppgave.OppgaveRepository
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.ForslagTilVedtakHendelse
@@ -26,7 +27,7 @@ class OppgaveMediatorAlertTest {
             ForslagTilVedtakHendelse(
                 ident = "12345678910",
                 behandletHendelseId = UUIDv7.ny().toString(),
-                behandletHendelseType = "Søknad",
+                behandletHendelseType = UtløstAvType.SØKNAD,
                 behandlingId = behandlingId,
                 emneknagger = emptySet(),
             )
@@ -73,7 +74,7 @@ class OppgaveMediatorAlertTest {
             ForslagTilVedtakHendelse(
                 ident = "12345678910",
                 behandletHendelseId = UUIDv7.ny().toString(),
-                behandletHendelseType = "Søknad",
+                behandletHendelseType = UtløstAvType.SØKNAD,
                 behandlingId = behandlingId,
                 emneknagger = emptySet(),
             )

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
@@ -44,6 +44,7 @@ import no.nav.dagpenger.saksbehandling.TilgangType.FORTROLIG_ADRESSE
 import no.nav.dagpenger.saksbehandling.TilgangType.SAKSBEHANDLER
 import no.nav.dagpenger.saksbehandling.TilgangType.STRENGT_FORTROLIG_ADRESSE
 import no.nav.dagpenger.saksbehandling.TilgangType.STRENGT_FORTROLIG_ADRESSE_UTLAND
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.api.Oppslag
 import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTO
 import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTOEnhetDTO
@@ -253,7 +254,7 @@ OppgaveMediatorTest {
                 ident = personUtenBehandling,
                 behandlingId = UUIDv7.ny(),
                 behandletHendelseId = UUIDv7.ny().toString(),
-                behandletHendelseType = "Søknad",
+                behandletHendelseType = UtløstAvType.SØKNAD,
             ),
         ) shouldBe null
 
@@ -262,7 +263,7 @@ OppgaveMediatorTest {
                 ident = personUtenSakHistorikk,
                 behandlingId = UUIDv7.ny(),
                 behandletHendelseId = UUIDv7.ny().toString(),
-                behandletHendelseType = "Søknad",
+                behandletHendelseType = UtløstAvType.SØKNAD,
             ),
         ) shouldBe null
 
@@ -425,7 +426,7 @@ OppgaveMediatorTest {
                 ForslagTilVedtakHendelse(
                     ident = "ad",
                     behandletHendelseId = UUIDv7.ny().toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     behandlingId = UUIDv7.ny(),
                 )
             oppgaveMediator.opprettEllerOppdaterOppgave(forslagTilVedtakHendelse)
@@ -456,7 +457,7 @@ OppgaveMediatorTest {
                 ForslagTilVedtakHendelse(
                     ident = testIdent,
                     behandletHendelseId = UUIDv7.ny().toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     behandlingId = behandling.behandlingId,
                     emneknagger = forventedeEmneknagger,
                 )
@@ -489,7 +490,7 @@ OppgaveMediatorTest {
             VedtakFattetHendelse(
                 behandlingId = behandlingId,
                 behandletHendelseId = søknadId.toString(),
-                behandletHendelseType = "Søknad",
+                behandletHendelseType = UtløstAvType.SØKNAD,
                 ident = testIdent,
                 sak = null,
                 automatiskBehandlet = automatiskBehandlet,
@@ -561,7 +562,7 @@ OppgaveMediatorTest {
                 ForslagTilVedtakHendelse(
                     ident = testIdent,
                     behandletHendelseId = UUIDv7.ny().toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     behandlingId = oppgave.behandling.behandlingId,
                     emneknagger = testEmneknagger1,
                 ),
@@ -571,7 +572,7 @@ OppgaveMediatorTest {
                 ForslagTilVedtakHendelse(
                     ident = testIdent,
                     behandletHendelseId = UUIDv7.ny().toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     behandlingId = oppgave.behandling.behandlingId,
                     emneknagger = testEmneknagger2,
                 ),
@@ -827,7 +828,7 @@ OppgaveMediatorTest {
                 ForslagTilVedtakHendelse(
                     ident = testIdent,
                     behandletHendelseId = UUIDv7.ny().toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     behandlingId = behandlingId,
                     emneknagger = emneknagger,
                 ),
@@ -948,7 +949,7 @@ OppgaveMediatorTest {
                 BehandlingAvbruttHendelse(
                     behandlingId = oppgave.behandling.behandlingId,
                     behandletHendelseId = oppgave.søknadId()!!.toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     ident = testIdent,
                 ),
             )
@@ -976,7 +977,7 @@ OppgaveMediatorTest {
                 ForslagTilVedtakHendelse(
                     ident = testIdent,
                     behandletHendelseId = søknadId.toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     behandlingId = behandlingId,
                     emneknagger = emneknagger,
                 ),
@@ -1409,7 +1410,7 @@ OppgaveMediatorTest {
                     VedtakFattetHendelse(
                         behandlingId = sak.behandlinger().first().behandlingId,
                         behandletHendelseId = sak.søknadId.toString(),
-                        behandletHendelseType = "Søknad",
+                        behandletHendelseType = UtløstAvType.SØKNAD,
                         ident = testPerson.ident,
                         sak =
                             UtsendingSak(
@@ -1511,7 +1512,7 @@ OppgaveMediatorTest {
                 ForslagTilVedtakHendelse(
                     ident = testIdent,
                     behandletHendelseId = UUIDv7.ny().toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     behandlingId = behandlingId,
                     emneknagger = emneknagger,
                 ),

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/TestHelper.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/TestHelper.kt
@@ -11,6 +11,7 @@ import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.Type.UNDER_BEHANDLING
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.Type.UNDER_KONTROLL
 import no.nav.dagpenger.saksbehandling.TilgangType.BESLUTTER
 import no.nav.dagpenger.saksbehandling.TilgangType.SAKSBEHANDLER
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.hendelser.ForslagTilVedtakHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.Hendelse
 import no.nav.dagpenger.saksbehandling.hendelser.Kategori
@@ -147,7 +148,7 @@ internal object TestHelper {
                     ForslagTilVedtakHendelse(
                         ident = personIdent,
                         behandletHendelseId = søknadId.toString(),
-                        behandletHendelseType = "Søknad",
+                        behandletHendelseType = UtløstAvType.SØKNAD,
                         behandlingId = UUID.randomUUID(),
                     ),
                 tidspunkt = opprettetNå.minusDays(3),

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApiTest.kt
@@ -45,6 +45,7 @@ import no.nav.dagpenger.saksbehandling.ReturnerTilSaksbehandlingÅrsak
 import no.nav.dagpenger.saksbehandling.TestHelper
 import no.nav.dagpenger.saksbehandling.Tilstandsendring
 import no.nav.dagpenger.saksbehandling.UUIDv7
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.autentisert
 import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.gyldigSaksbehandlerToken
 import no.nav.dagpenger.saksbehandling.api.OppgaveApiTestHelper.withOppgaveApi
@@ -604,7 +605,7 @@ class OppgaveApiTest {
                                 ForslagTilVedtakHendelse(
                                     ident = TestHelper.personIdent,
                                     behandletHendelseId = TestHelper.søknadId.toString(),
-                                    behandletHendelseType = "Søknad",
+                                    behandletHendelseType = UtløstAvType.SØKNAD,
                                     behandlingId = UUID.randomUUID(),
                                 ),
                             tidspunkt = TestHelper.opprettetNå,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveHistorikkDTOMapperTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveHistorikkDTOMapperTest.kt
@@ -22,6 +22,7 @@ import no.nav.dagpenger.saksbehandling.TilgangType.BESLUTTER
 import no.nav.dagpenger.saksbehandling.TilgangType.SAKSBEHANDLER
 import no.nav.dagpenger.saksbehandling.Tilstandsendring
 import no.nav.dagpenger.saksbehandling.UUIDv7
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTO
 import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTOEnhetDTO
 import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTORolleDTO
@@ -300,7 +301,7 @@ class OppgaveHistorikkDTOMapperTest {
                                         ForslagTilVedtakHendelse(
                                             ident = "12345612345",
                                             behandletHendelseId = UUIDv7.ny().toString(),
-                                            behandletHendelseType = "Søknad",
+                                            behandletHendelseType = UtløstAvType.SØKNAD,
                                             behandlingId = UUIDv7.ny(),
                                             emneknagger = setOf("Knaggen"),
                                         ),
@@ -356,7 +357,7 @@ class OppgaveHistorikkDTOMapperTest {
                                     ForslagTilVedtakHendelse(
                                         ident = TestHelper.personIdent,
                                         behandletHendelseId = søknadId.toString(),
-                                        behandletHendelseType = "Søknad",
+                                        behandletHendelseType = UtløstAvType.SØKNAD,
                                         behandlingId = UUID.randomUUID(),
                                     ),
                             ),
@@ -380,7 +381,7 @@ class OppgaveHistorikkDTOMapperTest {
                 ForslagTilVedtakHendelse(
                     ident = oppgave.personIdent(),
                     behandletHendelseId = søknadId.toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     behandlingId = oppgave.behandling.behandlingId,
                 ),
             )

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/RelevanteJournalpostIdOppslagTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/RelevanteJournalpostIdOppslagTest.kt
@@ -33,7 +33,7 @@ class RelevanteJournalpostIdOppslagTest {
                             hendelse =
                                 ForslagTilVedtakHendelse(
                                     behandletHendelseId = UUIDv7.ny().toString(),
-                                    behandletHendelseType = "Søknad",
+                                    behandletHendelseType = UtløstAvType.SØKNAD,
                                     behandlingId = UUIDv7.ny(),
                                     ident = ident,
                                 ),

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediatorTest.kt
@@ -180,7 +180,7 @@ class InnsendingMediatorTest {
                     VedtakFattetHendelse(
                         behandlingId = sak.behandlinger().first().behandlingId,
                         behandletHendelseId = sak.søknadId.toString(),
-                        behandletHendelseType = "Søknad",
+                        behandletHendelseType = UtløstAvType.SØKNAD,
                         ident = testPerson.ident,
                         sak =
                             UtsendingSak(

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/ArenaSinkVedtakOpprettetMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/ArenaSinkVedtakOpprettetMottakTest.kt
@@ -10,6 +10,7 @@ import io.mockk.verify
 import no.nav.dagpenger.saksbehandling.Oppgave
 import no.nav.dagpenger.saksbehandling.TestHelper
 import no.nav.dagpenger.saksbehandling.UUIDv7
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.UtsendingSak
 import no.nav.dagpenger.saksbehandling.db.person.PersonRepository
 import no.nav.dagpenger.saksbehandling.hendelser.VedtakFattetHendelse
@@ -33,7 +34,7 @@ class ArenaSinkVedtakOpprettetMottakTest {
             VedtakFattetHendelse(
                 behandlingId = testOppgave.behandling.behandlingId,
                 behandletHendelseId = søknadId.toString(),
-                behandletHendelseType = "Søknad",
+                behandletHendelseType = UtløstAvType.SØKNAD,
                 ident = testOppgave.person.ident,
                 sak =
                     UtsendingSak(

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/BehandlingAvbruttMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/BehandlingAvbruttMottakTest.kt
@@ -4,6 +4,7 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.dagpenger.saksbehandling.OppgaveMediator
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingAvbruttHendelse
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -34,12 +35,13 @@ class BehandlingAvbruttMottakTest {
         testRapid.sendTestMessage(behandlingAvbruttHendelse(hendelseType = hendelseType))
         when (skalBehandles) {
             true -> {
+                val utløstAvType = UtløstAvType.fraNavn(hendelseType)
                 verify(exactly = 1) {
                     oppgaveMediatorMock.avbrytOppgave(
                         BehandlingAvbruttHendelse(
                             behandlingId = behandlingId,
                             behandletHendelseId = behandletHendelseId.toString(),
-                            behandletHendelseType = hendelseType,
+                            behandletHendelseType = utløstAvType,
                             ident = ident,
                         ),
                     )
@@ -48,14 +50,7 @@ class BehandlingAvbruttMottakTest {
 
             false -> {
                 verify(exactly = 0) {
-                    oppgaveMediatorMock.avbrytOppgave(
-                        BehandlingAvbruttHendelse(
-                            behandlingId = behandlingId,
-                            behandletHendelseId = behandletHendelseId.toString(),
-                            behandletHendelseType = hendelseType,
-                            ident = ident,
-                        ),
-                    )
+                    oppgaveMediatorMock.avbrytOppgave(any())
                 }
             }
         }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/BehandlingOpprettetMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/BehandlingOpprettetMottakTest.kt
@@ -4,9 +4,8 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.dagpenger.saksbehandling.UUIDv7
-import no.nav.dagpenger.saksbehandling.hendelser.ManuellBehandlingOpprettetHendelse
-import no.nav.dagpenger.saksbehandling.hendelser.MeldekortbehandlingOpprettetHendelse
-import no.nav.dagpenger.saksbehandling.hendelser.SøknadsbehandlingOpprettetHendelse
+import no.nav.dagpenger.saksbehandling.UtløstAvType
+import no.nav.dagpenger.saksbehandling.hendelser.GenerellBehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.sak.SakMediator
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
@@ -22,23 +21,6 @@ class BehandlingOpprettetMottakTest {
     val behandlingIdGjenopptak = UUID.randomUUID()
     val behandletHendelseSkjedde = LocalDate.parse("2024-02-27")
     val behandlingskjedeId = UUIDv7.ny()
-    private val søknadsbehandlingOpprettetHendelseNyRett =
-        SøknadsbehandlingOpprettetHendelse(
-            søknadId = søknadId,
-            behandlingId = behandlingIdNyRett,
-            ident = testIdent,
-            opprettet = behandletHendelseSkjedde.atStartOfDay(),
-            behandlingskjedeId = behandlingskjedeId,
-        )
-    private val søknadsbehandlingOpprettetHendelseGjenopptak =
-        SøknadsbehandlingOpprettetHendelse(
-            søknadId = søknadId,
-            behandlingId = behandlingIdGjenopptak,
-            ident = testIdent,
-            opprettet = behandletHendelseSkjedde.atStartOfDay(),
-            basertPåBehandling = behandlingIdNyRett,
-            behandlingskjedeId = behandlingskjedeId,
-        )
 
     private val testRapid = TestRapid()
     private val sakMediatorMock = mockk<SakMediator>(relaxed = true)
@@ -51,8 +33,16 @@ class BehandlingOpprettetMottakTest {
     fun `Skal behandle behandling_opprettet hendelse for søknadsbehandling av ny dagpengerett`() {
         testRapid.sendTestMessage(søknadsbehandlingOpprettetMeldingNyRett())
         verify(exactly = 1) {
-            sakMediatorMock.opprettSak(
-                søknadsbehandlingOpprettetHendelse = søknadsbehandlingOpprettetHendelseNyRett,
+            sakMediatorMock.opprettEllerKnyttTilSak(
+                GenerellBehandlingOpprettetHendelse(
+                    behandlingId = behandlingIdNyRett,
+                    ident = testIdent,
+                    opprettet = behandletHendelseSkjedde.atStartOfDay(),
+                    type = UtløstAvType.SØKNAD,
+                    behandletHendelseId = søknadId.toString(),
+                    basertPåBehandling = null,
+                    behandlingskjedeId = behandlingskjedeId,
+                ),
             )
         }
     }
@@ -61,8 +51,16 @@ class BehandlingOpprettetMottakTest {
     fun `Skal behandle behandling_opprettet hendelse for søknadsbehandling som er basert på en annen behandling`() {
         testRapid.sendTestMessage(søknadsbehandlingOpprettetMeldingBasertPåBehandling())
         verify(exactly = 1) {
-            sakMediatorMock.knyttTilSak(
-                søknadsbehandlingOpprettetHendelse = søknadsbehandlingOpprettetHendelseGjenopptak,
+            sakMediatorMock.opprettEllerKnyttTilSak(
+                GenerellBehandlingOpprettetHendelse(
+                    behandlingId = behandlingIdGjenopptak,
+                    ident = testIdent,
+                    opprettet = behandletHendelseSkjedde.atStartOfDay(),
+                    type = UtløstAvType.SØKNAD,
+                    behandletHendelseId = søknadId.toString(),
+                    basertPåBehandling = behandlingIdNyRett,
+                    behandlingskjedeId = behandlingskjedeId,
+                ),
             )
         }
     }
@@ -77,16 +75,16 @@ class BehandlingOpprettetMottakTest {
             ),
         )
         verify(exactly = 1) {
-            sakMediatorMock.knyttTilSak(
-                meldekortbehandlingOpprettetHendelse =
-                    MeldekortbehandlingOpprettetHendelse(
-                        meldekortId = meldekortId,
-                        behandlingId = behandlingIdNyRett,
-                        ident = testIdent,
-                        opprettet = behandletHendelseSkjedde.atStartOfDay(),
-                        basertPåBehandling = basertPåBehandling,
-                        behandlingskjedeId = behandlingskjedeId,
-                    ),
+            sakMediatorMock.opprettEllerKnyttTilSak(
+                GenerellBehandlingOpprettetHendelse(
+                    behandlingId = behandlingIdNyRett,
+                    ident = testIdent,
+                    opprettet = behandletHendelseSkjedde.atStartOfDay(),
+                    type = UtløstAvType.MELDEKORT,
+                    behandletHendelseId = meldekortId,
+                    basertPåBehandling = basertPåBehandling,
+                    behandlingskjedeId = behandlingskjedeId,
+                ),
             )
         }
     }
@@ -101,16 +99,16 @@ class BehandlingOpprettetMottakTest {
             ),
         )
         verify(exactly = 1) {
-            sakMediatorMock.knyttTilSak(
-                manuellBehandlingOpprettetHendelse =
-                    ManuellBehandlingOpprettetHendelse(
-                        manuellId = manuellId,
-                        behandlingId = behandlingIdNyRett,
-                        ident = testIdent,
-                        opprettet = behandletHendelseSkjedde.atStartOfDay(),
-                        basertPåBehandling = basertPåBehandling,
-                        behandlingskjedeId = behandlingskjedeId,
-                    ),
+            sakMediatorMock.opprettEllerKnyttTilSak(
+                GenerellBehandlingOpprettetHendelse(
+                    behandlingId = behandlingIdNyRett,
+                    ident = testIdent,
+                    opprettet = behandletHendelseSkjedde.atStartOfDay(),
+                    type = UtløstAvType.MANUELL,
+                    behandletHendelseId = manuellId.toString(),
+                    basertPåBehandling = basertPåBehandling,
+                    behandlingskjedeId = behandlingskjedeId,
+                ),
             )
         }
     }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/BehandlingsresultatMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/BehandlingsresultatMottakTest.kt
@@ -9,6 +9,7 @@ import io.mockk.verify
 import no.nav.dagpenger.saksbehandling.OppgaveMediator
 import no.nav.dagpenger.saksbehandling.TestHelper
 import no.nav.dagpenger.saksbehandling.TestHelper.lagBehandling
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.hendelser.VedtakFattetHendelse
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
@@ -37,14 +38,14 @@ class BehandlingsresultatMottakTest {
 
     @Test
     fun `skal håndtere behandlingsresultat event og ferdigstille oppgave for søknad og automatisk behandlet`() {
-        testRapid.sendTestMessage(behandlingsresultatEvent(behandletHendelseType = "Søknad"))
+        testRapid.sendTestMessage(behandlingsresultatEvent(behandletHendelseType = UtløstAvType.SØKNAD.rapidNavn))
         verify(exactly = 1) {
             oppgaveMediatorMock.håndter(
                 vedtakFattetHendelse =
                     VedtakFattetHendelse(
                         behandlingId = behandlingId,
                         behandletHendelseId = søknadId.toString(),
-                        behandletHendelseType = "Søknad",
+                        behandletHendelseType = UtløstAvType.SØKNAD,
                         ident = TestHelper.testPerson.ident,
                         automatiskBehandlet = true,
                         sak = null,
@@ -56,14 +57,14 @@ class BehandlingsresultatMottakTest {
 
     @Test
     fun `skal håndtere behandlingsresultat event og ferdigstille oppgave for søknad og ikke automatisk `() {
-        testRapid.sendTestMessage(behandlingsresultatEvent(behandletHendelseType = "Søknad", automatisk = false))
+        testRapid.sendTestMessage(behandlingsresultatEvent(behandletHendelseType = UtløstAvType.SØKNAD.rapidNavn, automatisk = false))
         verify(exactly = 1) {
             oppgaveMediatorMock.håndter(
                 vedtakFattetHendelse =
                     VedtakFattetHendelse(
                         behandlingId = behandlingId,
                         behandletHendelseId = søknadId.toString(),
-                        behandletHendelseType = "Søknad",
+                        behandletHendelseType = UtløstAvType.SØKNAD,
                         ident = TestHelper.testPerson.ident,
                         automatiskBehandlet = false,
                         sak = null,
@@ -75,14 +76,14 @@ class BehandlingsresultatMottakTest {
 
     @Test
     fun `skal håndtere behandlingsresultat event og ferdigstille oppgave for meldekort`() {
-        testRapid.sendTestMessage(behandlingsresultatEvent(behandletHendelseType = "Meldekort"))
+        testRapid.sendTestMessage(behandlingsresultatEvent(behandletHendelseType = UtløstAvType.MELDEKORT.rapidNavn))
         verify(exactly = 1) {
             oppgaveMediatorMock.håndter(
                 vedtakFattetHendelse =
                     VedtakFattetHendelse(
                         behandlingId = behandlingId,
                         behandletHendelseId = søknadId.toString(),
-                        behandletHendelseType = "Meldekort",
+                        behandletHendelseType = UtløstAvType.MELDEKORT,
                         ident = TestHelper.testPerson.ident,
                         automatiskBehandlet = true,
                         sak = null,
@@ -94,14 +95,14 @@ class BehandlingsresultatMottakTest {
 
     @Test
     fun `skal håndtere behandlingsresultat event og ferdigstille oppgave for manuell`() {
-        testRapid.sendTestMessage(behandlingsresultatEvent(behandletHendelseType = "Manuell"))
+        testRapid.sendTestMessage(behandlingsresultatEvent(behandletHendelseType = UtløstAvType.MANUELL.rapidNavn))
         verify(exactly = 1) {
             oppgaveMediatorMock.håndter(
                 vedtakFattetHendelse =
                     VedtakFattetHendelse(
                         behandlingId = behandlingId,
                         behandletHendelseId = søknadId.toString(),
-                        behandletHendelseType = "Manuell",
+                        behandletHendelseType = UtløstAvType.MANUELL,
                         ident = TestHelper.testPerson.ident,
                         automatiskBehandlet = true,
                         sak = null,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/ForslagTilBehandlingsresultatMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/ForslagTilBehandlingsresultatMottakTest.kt
@@ -7,6 +7,7 @@ import io.mockk.mockk
 import no.nav.dagpenger.saksbehandling.Emneknagg.Regelknagg.AVSLAG
 import no.nav.dagpenger.saksbehandling.OppgaveMediator
 import no.nav.dagpenger.saksbehandling.UUIDv7
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.hendelser.ForslagTilVedtakHendelse
 import org.junit.jupiter.api.Test
 import kotlin.also
@@ -26,19 +27,25 @@ class ForslagTilBehandlingsresultatMottakTest {
             }
         ForslagTilBehandlingsresultatMottak(testRapid, oppgaveMediator)
 
-        listOf("Søknad", "Meldekort", "Manuell").forEachIndexed { index, behandletHendelseType ->
-            testRapid.sendTestMessage(testMessage(behandletHendelseType = behandletHendelseType))
+        val typeMapping =
+            listOf(
+                "Søknad" to UtløstAvType.SØKNAD,
+                "Meldekort" to UtløstAvType.MELDEKORT,
+                "Manuell" to UtløstAvType.MANUELL,
+            )
+        typeMapping.forEachIndexed { index, (rapidNavn, enumType) ->
+            testRapid.sendTestMessage(testMessage(behandletHendelseType = rapidNavn))
             slots[index].let { hendelse ->
                 hendelse.ident shouldBe ident
                 hendelse.behandletHendelseId shouldBe søknadId.toString()
                 hendelse.behandlingId shouldBe behandlingId
-                hendelse.behandletHendelseType shouldBe behandletHendelseType
+                hendelse.behandletHendelseType shouldBe enumType
             }
         }
 
-        slots.single { it.behandletHendelseType == "Søknad" }.emneknagger shouldBe setOf(AVSLAG.visningsnavn)
-        slots.single { it.behandletHendelseType == "Meldekort" }.emneknagger shouldBe emptySet()
-        slots.single { it.behandletHendelseType == "Manuell" }.emneknagger shouldBe emptySet()
+        slots.single { it.behandletHendelseType == UtløstAvType.SØKNAD }.emneknagger shouldBe setOf(AVSLAG.visningsnavn)
+        slots.single { it.behandletHendelseType == UtløstAvType.MELDEKORT }.emneknagger shouldBe emptySet()
+        slots.single { it.behandletHendelseType == UtløstAvType.MANUELL }.emneknagger shouldBe emptySet()
     }
 
     private fun testMessage(behandletHendelseType: String): String {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/sak/BehandlingsresultatMottakForSakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/sak/BehandlingsresultatMottakForSakTest.kt
@@ -9,6 +9,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import no.nav.dagpenger.saksbehandling.UUIDv7
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.db.sak.SakRepository
 import no.nav.dagpenger.saksbehandling.helper.behandlingsresultatEvent
 import no.nav.dagpenger.saksbehandling.hendelser.VedtakFattetHendelse
@@ -48,7 +49,7 @@ class BehandlingsresultatMottakForSakTest {
         hendelse.captured.ident shouldBe ident
         hendelse.captured.behandlingId shouldBe behandlingId
         hendelse.captured.behandletHendelseId shouldBe søknadId.toString()
-        hendelse.captured.behandletHendelseType shouldBe "Søknad"
+        hendelse.captured.behandletHendelseType shouldBe UtløstAvType.SØKNAD
         hendelse.captured.sak.let {
             require(it != null)
             it.id shouldBe sakId.toString()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/sak/SakMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/sak/SakMediatorTest.kt
@@ -266,7 +266,7 @@ class SakMediatorTest {
                 VedtakFattetHendelse(
                     behandlingId = behandlingIdSøknadNyRett,
                     behandletHendelseId = "id",
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     ident = testIdent,
                     sak =
                         UtsendingSak(
@@ -282,7 +282,7 @@ class SakMediatorTest {
                 VedtakFattetHendelse(
                     behandlingId = behandlingIdSøknadNyRett,
                     behandletHendelseId = "id",
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     ident = testIdent,
                     sak =
                         UtsendingSak(
@@ -329,7 +329,7 @@ class SakMediatorTest {
                 VedtakFattetHendelse(
                     behandlingId = behandlingIdSøknadNyRett,
                     behandletHendelseId = "id",
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     ident = testIdent,
                     sak =
                         UtsendingSak(
@@ -464,7 +464,7 @@ class SakMediatorTest {
                 VedtakFattetHendelse(
                     behandlingId = behandlingIdSøknadNyRett,
                     behandletHendelseId = søknadIdNyRett.toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     ident = testIdent,
                     sak = null,
                 ),
@@ -483,7 +483,7 @@ class SakMediatorTest {
                 VedtakFattetHendelse(
                     behandlingId = behandlingIdEndaEnSøknad,
                     behandletHendelseId = endaEnSøknadId.toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     ident = testIdent,
                     sak = null,
                 ),

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/serder/HendelseJsonSerDerTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/serder/HendelseJsonSerDerTest.kt
@@ -68,7 +68,7 @@ class HendelseJsonSerDerTest {
                 "ident": "1234",
                 "sakId": "${hendelse.sakId}",
                 "opprettet": "-999999999-01-01T00:00:00",
-                "type": "SØKNAD",
+                "type": "Søknad",
                 "utførtAv": { "navn": "dp-mottak" }
              }
             """
@@ -91,7 +91,7 @@ class HendelseJsonSerDerTest {
                 "behandlingId": "$aUUID",
                 "ident": "1234",
                 "opprettet": "-999999999-01-01T00:00:00",
-                "type": "SØKNAD",
+                "type": "Søknad",
                 "sakId": "$aUUID",
                 "utførtAv": {
                   "navIdent": "navIdent",
@@ -130,7 +130,7 @@ class HendelseJsonSerDerTest {
             VedtakFattetHendelse(
                 behandlingId = UUIDv7.ny(),
                 behandletHendelseId = UUIDv7.ny().toString(),
-                behandletHendelseType = "Søknad",
+                behandletHendelseType = UtløstAvType.SØKNAD,
                 ident = "12345678901",
                 sak =
                     UtsendingSak(
@@ -143,7 +143,7 @@ class HendelseJsonSerDerTest {
             {
                 "behandlingId": "${vedtakFattetHendelse.behandlingId}",
                 "behandletHendelseId": "${vedtakFattetHendelse.behandletHendelseId}",
-                "behandletHendelseType": "${vedtakFattetHendelse.behandletHendelseType}",
+                "behandletHendelseType": "${vedtakFattetHendelse.behandletHendelseType.rapidNavn}",
                 "ident": "${vedtakFattetHendelse.ident}",
                 "sak": {
                     "id": "${vedtakFattetHendelse.sak!!.id}",

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/utsending/UtsendingMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/utsending/UtsendingMediatorTest.kt
@@ -109,7 +109,7 @@ class UtsendingMediatorTest {
                     ident = person.ident,
                     behandlingId = behandling.behandlingId.toString(),
                     behandletHendelseId = søknadId.toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD.rapidNavn,
                     harRett = true,
                 )
 
@@ -696,7 +696,7 @@ class UtsendingMediatorTest {
             VedtakFattetHendelse(
                 behandlingId = utsending.behandlingId,
                 behandletHendelseId = UUIDv7.ny().toString(),
-                behandletHendelseType = "Søknad",
+                behandletHendelseType = UtløstAvType.SØKNAD,
                 ident = utsending.ident,
                 sak =
                     UtsendingSak(

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/utsending/mottak/BehandlingsresultatMottakForAutomatiskVedtakUtsendingTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/utsending/mottak/BehandlingsresultatMottakForAutomatiskVedtakUtsendingTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.dagpenger.saksbehandling.UUIDv7
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.UtsendingSak
 import no.nav.dagpenger.saksbehandling.db.sak.SakRepository
 import no.nav.dagpenger.saksbehandling.hendelser.VedtakFattetHendelse
@@ -58,7 +59,7 @@ class BehandlingsresultatMottakForAutomatiskVedtakUtsendingTest {
                 VedtakFattetHendelse(
                     behandlingId = behandlingId,
                     behandletHendelseId = søknadId.toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     ident = ident,
                     sak =
                         UtsendingSak(

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/utsending/mottak/BehandlingsresultatMottakForUtsendingTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/utsending/mottak/BehandlingsresultatMottakForUtsendingTest.kt
@@ -9,6 +9,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import no.nav.dagpenger.saksbehandling.UUIDv7
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.UtsendingSak
 import no.nav.dagpenger.saksbehandling.db.sak.SakRepository
 import no.nav.dagpenger.saksbehandling.helper.behandlingsresultatEvent
@@ -55,7 +56,7 @@ class BehandlingsresultatMottakForUtsendingTest {
         hendelse.captured.ident shouldBe ident
         hendelse.captured.behandlingId shouldBe behandlingId
         hendelse.captured.behandletHendelseId shouldBe søknadId.toString()
-        hendelse.captured.behandletHendelseType shouldBe "Søknad"
+        hendelse.captured.behandletHendelseType shouldBe UtløstAvType.SØKNAD
         hendelse.captured.sak.let {
             require(it != null)
             it.id shouldBe sakId.toString()
@@ -98,7 +99,7 @@ class BehandlingsresultatMottakForUtsendingTest {
             sakRepository = sakRepositoryMock,
         )
 
-        testRapid.sendTestMessage(behandlingsresultat(behandletHendelseType = "Meldekort"))
+        testRapid.sendTestMessage(behandlingsresultat(behandletHendelseType = UtløstAvType.MELDEKORT.rapidNavn))
 
         verify(exactly = 1) {
             utsendingMediatorMock.startUtsendingForVedtakFattet(any())
@@ -122,7 +123,7 @@ class BehandlingsresultatMottakForUtsendingTest {
             sakRepository = sakRepositoryMock,
         )
 
-        testRapid.sendTestMessage(behandlingsresultat(behandletHendelseType = "Manuell"))
+        testRapid.sendTestMessage(behandlingsresultat(behandletHendelseType = UtløstAvType.MANUELL.rapidNavn))
 
         verify(exactly = 1) {
             utsendingMediatorMock.startUtsendingForVedtakFattet(any())
@@ -174,7 +175,7 @@ class BehandlingsresultatMottakForUtsendingTest {
                 VedtakFattetHendelse(
                     behandlingId = behandlingId,
                     behandletHendelseId = søknadId.toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     ident = ident,
                     sak =
                         UtsendingSak(

--- a/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/Behandling.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/Behandling.kt
@@ -1,5 +1,7 @@
 package no.nav.dagpenger.saksbehandling
 
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
 import no.nav.dagpenger.saksbehandling.hendelser.Hendelse
 import java.time.LocalDateTime
 import java.util.UUID
@@ -28,11 +30,21 @@ data class Behandling(
 
 enum class UtløstAvType(
     val applikasjon: Applikasjon,
+    @get:JsonValue val rapidNavn: String,
 ) {
-    SØKNAD(applikasjon = Applikasjon.DpBehandling),
-    MELDEKORT(applikasjon = Applikasjon.DpBehandling),
-    MANUELL(applikasjon = Applikasjon.DpBehandling),
-    REVURDERING(applikasjon = Applikasjon.DpBehandling),
-    INNSENDING(applikasjon = Applikasjon.DpSaksbehandling),
-    KLAGE(applikasjon = Applikasjon.DpSaksbehandling),
+    SØKNAD(applikasjon = Applikasjon.DpBehandling, rapidNavn = "Søknad"),
+    MELDEKORT(applikasjon = Applikasjon.DpBehandling, rapidNavn = "Meldekort"),
+    MANUELL(applikasjon = Applikasjon.DpBehandling, rapidNavn = "Manuell"),
+    REVURDERING(applikasjon = Applikasjon.DpBehandling, rapidNavn = "Omgjøring"),
+    INNSENDING(applikasjon = Applikasjon.DpSaksbehandling, rapidNavn = "Innsending"),
+    KLAGE(applikasjon = Applikasjon.DpSaksbehandling, rapidNavn = "Klage"),
+    ;
+
+    companion object {
+        @JsonCreator
+        @JvmStatic
+        fun fraNavn(navn: String): UtløstAvType =
+            entries.firstOrNull { it.rapidNavn == navn }
+                ?: throw IllegalArgumentException("Ukjent UtløstAvType: '$navn'. Gyldige verdier: ${entries.map { it.rapidNavn }}")
+    }
 }

--- a/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/Oppgave.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/Oppgave.kt
@@ -326,10 +326,10 @@ data class Oppgave private constructor(
             _tilstandslogg.firstOrNull { it.hendelse is ForslagTilVedtakHendelse }?.let {
                 val hendelse = it.hendelse as ForslagTilVedtakHendelse
                 when (hendelse.behandletHendelseType) {
-                    "Søknad" -> UUID.fromString(hendelse.behandletHendelseId)
-                    "Manuell", "Meldekort", "Omgjøring" -> {
+                    UtløstAvType.SØKNAD -> UUID.fromString(hendelse.behandletHendelseId)
+                    UtløstAvType.MANUELL, UtløstAvType.MELDEKORT, UtløstAvType.REVURDERING -> {
                         logger.info {
-                            "behandletHendelseType is ${hendelse.behandletHendelseType} " +
+                            "behandletHendelseType er ${hendelse.behandletHendelseType.rapidNavn} " +
                                 "for oppgave: ${this.oppgaveId} " +
                                 "søknadId eksisterer derfor ikke"
                         }

--- a/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/Sak.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/Sak.kt
@@ -1,6 +1,7 @@
 package no.nav.dagpenger.saksbehandling
 
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingOpprettetHendelse
+import no.nav.dagpenger.saksbehandling.hendelser.GenerellBehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.ManuellBehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.MeldekortbehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.RevurderingBehandlingOpprettetHendelse
@@ -125,6 +126,23 @@ data class Sak(
                     utløstAv = behandlingOpprettetHendelse.type,
                     opprettet = behandlingOpprettetHendelse.opprettet,
                     hendelse = behandlingOpprettetHendelse,
+                ),
+            )
+            KnyttTilSakResultat.KnyttetTilSak(this)
+        } else {
+            KnyttTilSakResultat.IkkeKnyttetTilSak(this.sakId)
+        }
+
+    fun knyttTilSak(hendelse: GenerellBehandlingOpprettetHendelse): KnyttTilSakResultat =
+        if (this.sakId == hendelse.behandlingskjedeId ||
+            this.basertPåBehandlingErKnyttetTilSak(hendelse.basertPåBehandling)
+        ) {
+            behandlinger.add(
+                Behandling(
+                    behandlingId = hendelse.behandlingId,
+                    utløstAv = hendelse.type,
+                    opprettet = hendelse.opprettet,
+                    hendelse = hendelse,
                 ),
             )
             KnyttTilSakResultat.KnyttetTilSak(this)

--- a/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/SakHistorikk.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/SakHistorikk.kt
@@ -1,6 +1,7 @@
 package no.nav.dagpenger.saksbehandling
 
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingOpprettetHendelse
+import no.nav.dagpenger.saksbehandling.hendelser.GenerellBehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.ManuellBehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.MeldekortbehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.RevurderingBehandlingOpprettetHendelse
@@ -48,6 +49,12 @@ data class SakHistorikk(
         saker
             .map {
                 it.knyttTilSak(behandlingOpprettetHendelse)
+            }.knyttTilSakResultat()
+
+    fun knyttTilSak(hendelse: GenerellBehandlingOpprettetHendelse): KnyttTilSakResultat =
+        saker
+            .map {
+                it.knyttTilSak(hendelse)
             }.knyttTilSakResultat()
 
     fun knyttTilSak(søknadsbehandlingOpprettetHendelse: SøknadsbehandlingOpprettetHendelse): KnyttTilSakResultat =

--- a/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/hendelser/BehandlingAvbruttHendelse.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/hendelser/BehandlingAvbruttHendelse.kt
@@ -1,12 +1,13 @@
 package no.nav.dagpenger.saksbehandling.hendelser
 
 import no.nav.dagpenger.saksbehandling.Applikasjon
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import java.util.UUID
 
 data class BehandlingAvbruttHendelse(
     val behandlingId: UUID,
     val behandletHendelseId: String,
-    val behandletHendelseType: String,
+    val behandletHendelseType: UtløstAvType,
     val ident: String,
     override val utførtAv: Applikasjon = Applikasjon.DpBehandling,
 ) : Hendelse(utførtAv)

--- a/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/hendelser/ForslagTilVedtakHendelse.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/hendelser/ForslagTilVedtakHendelse.kt
@@ -1,12 +1,13 @@
 package no.nav.dagpenger.saksbehandling.hendelser
 
 import no.nav.dagpenger.saksbehandling.Applikasjon
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import java.util.UUID
 
 data class ForslagTilVedtakHendelse(
     val ident: String,
     val behandletHendelseId: String,
-    val behandletHendelseType: String,
+    val behandletHendelseType: UtløstAvType,
     val behandlingId: UUID,
     val emneknagger: Set<String> = emptySet(),
     override val utførtAv: Applikasjon = Applikasjon.DpBehandling,

--- a/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/hendelser/GenerellBehandlingOpprettetHendelse.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/hendelser/GenerellBehandlingOpprettetHendelse.kt
@@ -1,16 +1,17 @@
 package no.nav.dagpenger.saksbehandling.hendelser
 
 import no.nav.dagpenger.saksbehandling.Applikasjon
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import java.time.LocalDateTime
 import java.util.UUID
 
-@Deprecated("Bruk GenerellBehandlingOpprettetHendelse i stedet. Beholdes for deserialisering av eksisterende DB-poster.")
-data class MeldekortbehandlingOpprettetHendelse(
-    val meldekortId: String,
+data class GenerellBehandlingOpprettetHendelse(
     val behandlingId: UUID,
     val ident: String,
     val opprettet: LocalDateTime,
-    val basertPåBehandling: UUID,
+    val type: UtløstAvType,
+    val behandletHendelseId: String,
+    val basertPåBehandling: UUID? = null,
     val behandlingskjedeId: UUID? = null,
     override val utførtAv: Applikasjon = Applikasjon.DpBehandling,
 ) : Hendelse(utførtAv)

--- a/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/hendelser/ManuellBehandlingOpprettetHendelse.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/hendelser/ManuellBehandlingOpprettetHendelse.kt
@@ -4,6 +4,7 @@ import no.nav.dagpenger.saksbehandling.Applikasjon
 import java.time.LocalDateTime
 import java.util.UUID
 
+@Deprecated("Bruk GenerellBehandlingOpprettetHendelse i stedet. Beholdes for deserialisering av eksisterende DB-poster.")
 data class ManuellBehandlingOpprettetHendelse(
     val manuellId: UUID,
     val behandlingId: UUID,

--- a/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/hendelser/RevurderingBehandlingOpprettetHendelse.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/hendelser/RevurderingBehandlingOpprettetHendelse.kt
@@ -4,6 +4,7 @@ import no.nav.dagpenger.saksbehandling.Applikasjon
 import java.time.LocalDateTime
 import java.util.UUID
 
+@Deprecated("Bruk GenerellBehandlingOpprettetHendelse i stedet. Beholdes for deserialisering av eksisterende DB-poster.")
 data class RevurderingBehandlingOpprettetHendelse(
     val behandlingId: UUID,
     val ident: String,

--- a/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/hendelser/SøknadsbehandlingOpprettetHendelse.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/hendelser/SøknadsbehandlingOpprettetHendelse.kt
@@ -9,6 +9,7 @@ import no.nav.dagpenger.saksbehandling.Applikasjon
 import java.time.LocalDateTime
 import java.util.UUID
 
+@Deprecated("Bruk GenerellBehandlingOpprettetHendelse i stedet. Beholdes for deserialisering av eksisterende DB-poster.")
 data class SøknadsbehandlingOpprettetHendelse(
     val søknadId: UUID,
     val behandlingId: UUID,

--- a/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/hendelser/VedtakFattetHendelse.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/hendelser/VedtakFattetHendelse.kt
@@ -1,13 +1,14 @@
 package no.nav.dagpenger.saksbehandling.hendelser
 
 import no.nav.dagpenger.saksbehandling.Applikasjon
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.UtsendingSak
 import java.util.UUID
 
 data class VedtakFattetHendelse(
     val behandlingId: UUID,
     val behandletHendelseId: String,
-    val behandletHendelseType: String,
+    val behandletHendelseType: UtløstAvType,
     val ident: String,
     val sak: UtsendingSak?,
     val automatiskBehandlet: Boolean? = null,

--- a/modell/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveTilstandTest.kt
+++ b/modell/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveTilstandTest.kt
@@ -25,6 +25,7 @@ import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.Type.UNDER_KONTROLL
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.UlovligTilstandsendringException
 import no.nav.dagpenger.saksbehandling.TilgangType.BESLUTTER
 import no.nav.dagpenger.saksbehandling.TilgangType.SAKSBEHANDLER
+import no.nav.dagpenger.saksbehandling.UtløstAvType
 import no.nav.dagpenger.saksbehandling.hendelser.AvbruttHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.AvbrytOppgaveHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingAvbruttHendelse
@@ -104,7 +105,7 @@ class OppgaveTilstandTest {
             ForslagTilVedtakHendelse(
                 ident = testIdent,
                 behandletHendelseId = UUIDv7.ny().toString(),
-                behandletHendelseType = "Søknad",
+                behandletHendelseType = UtløstAvType.SØKNAD,
                 behandlingId = UUIDv7.ny(),
                 utførtAv = Applikasjon.DpBehandling,
             )
@@ -134,7 +135,7 @@ class OppgaveTilstandTest {
                     VedtakFattetHendelse(
                         behandlingId = oppgave.behandling.behandlingId,
                         behandletHendelseId = UUIDv7.ny().toString(),
-                        behandletHendelseType = "Søknad",
+                        behandletHendelseType = UtløstAvType.SØKNAD,
                         ident = testIdent,
                         automatiskBehandlet = false,
                         sak = utsendingSak,
@@ -168,7 +169,7 @@ class OppgaveTilstandTest {
                     VedtakFattetHendelse(
                         behandlingId = oppgave.behandling.behandlingId,
                         behandletHendelseId = UUIDv7.ny().toString(),
-                        behandletHendelseType = "Søknad",
+                        behandletHendelseType = UtløstAvType.SØKNAD,
                         ident = testIdent,
                         automatiskBehandlet = false,
                         sak = utsendingSak,
@@ -189,7 +190,7 @@ class OppgaveTilstandTest {
                     VedtakFattetHendelse(
                         behandlingId = oppgave.behandling.behandlingId,
                         behandletHendelseId = UUIDv7.ny().toString(),
-                        behandletHendelseType = "Søknad",
+                        behandletHendelseType = UtløstAvType.SØKNAD,
                         ident = testIdent,
                         sak = utsendingSak,
                         automatiskBehandlet = true,
@@ -211,7 +212,7 @@ class OppgaveTilstandTest {
                     VedtakFattetHendelse(
                         behandlingId = oppgave.behandling.behandlingId,
                         behandletHendelseId = UUIDv7.ny().toString(),
-                        behandletHendelseType = "Søknad",
+                        behandletHendelseType = UtløstAvType.SØKNAD,
                         ident = testIdent,
                         automatiskBehandlet = true,
                         sak = utsendingSak,
@@ -275,7 +276,7 @@ class OppgaveTilstandTest {
                     BehandlingAvbruttHendelse(
                         behandlingId = oppgave.behandling.behandlingId,
                         behandletHendelseId = UUIDv7.ny().toString(),
-                        behandletHendelseType = "Søknad",
+                        behandletHendelseType = UtløstAvType.SØKNAD,
                         ident = testIdent,
                     ),
                 )
@@ -294,7 +295,7 @@ class OppgaveTilstandTest {
                     BehandlingAvbruttHendelse(
                         behandlingId = oppgave.behandling.behandlingId,
                         behandletHendelseId = UUIDv7.ny().toString(),
-                        behandletHendelseType = "Søknad",
+                        behandletHendelseType = UtløstAvType.SØKNAD,
                         ident = testIdent,
                     ),
                 )
@@ -355,7 +356,7 @@ class OppgaveTilstandTest {
                     ForslagTilVedtakHendelse(
                         behandlingId = oppgave.behandling.behandlingId,
                         behandletHendelseId = UUIDv7.ny().toString(),
-                        behandletHendelseType = "Søknad",
+                        behandletHendelseType = UtløstAvType.SØKNAD,
                         ident = testIdent,
                     ),
                 )
@@ -382,7 +383,7 @@ class OppgaveTilstandTest {
                     ForslagTilVedtakHendelse(
                         behandlingId = oppgave.behandling.behandlingId,
                         behandletHendelseId = UUIDv7.ny().toString(),
-                        behandletHendelseType = "Søknad",
+                        behandletHendelseType = UtløstAvType.SØKNAD,
                         ident = testIdent,
                     ),
                 )
@@ -416,7 +417,7 @@ class OppgaveTilstandTest {
                 BehandlingAvbruttHendelse(
                     behandlingId = oppgave.behandling.behandlingId,
                     behandletHendelseId = UUIDv7.ny().toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     ident = testIdent,
                 ),
             )
@@ -516,7 +517,7 @@ class OppgaveTilstandTest {
                 ForslagTilVedtakHendelse(
                     ident = testIdent,
                     behandletHendelseId = UUIDv7.ny().toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     behandlingId = oppgave.behandling.behandlingId,
                     utførtAv = Applikasjon.DpBehandling,
                     emneknagger = nyeEmneknagger,
@@ -536,7 +537,7 @@ class OppgaveTilstandTest {
                 ForslagTilVedtakHendelse(
                     ident = testIdent,
                     behandletHendelseId = UUIDv7.ny().toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     behandlingId = oppgave.behandling.behandlingId,
                     utførtAv = Applikasjon.DpBehandling,
                     emneknagger = nyeEmneknagger,
@@ -556,7 +557,7 @@ class OppgaveTilstandTest {
                 ForslagTilVedtakHendelse(
                     ident = testIdent,
                     behandletHendelseId = UUIDv7.ny().toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     behandlingId = oppgave.behandling.behandlingId,
                     utførtAv = Applikasjon.DpBehandling,
                     emneknagger = nyeEmneknagger,
@@ -778,7 +779,7 @@ class OppgaveTilstandTest {
                 BehandlingAvbruttHendelse(
                     behandlingId = oppgave.behandling.behandlingId,
                     behandletHendelseId = UUIDv7.ny().toString(),
-                    behandletHendelseType = "Søknad",
+                    behandletHendelseType = UtløstAvType.SØKNAD,
                     ident = testIdent,
                 ),
             )
@@ -859,7 +860,7 @@ class OppgaveTilstandTest {
                                     ident = "11111155555",
                                     behandlingId = UUIDv7.ny(),
                                     behandletHendelseId = UUIDv7.ny().toString(),
-                                    behandletHendelseType = "Søknad",
+                                    behandletHendelseType = UtløstAvType.SØKNAD,
                                     emneknagger = emptySet(),
                                 ),
                         )
@@ -884,7 +885,7 @@ class OppgaveTilstandTest {
             ForslagTilVedtakHendelse(
                 ident = testIdent,
                 behandletHendelseId = UUIDv7.ny().toString(),
-                behandletHendelseType = "Søknad",
+                behandletHendelseType = UtløstAvType.SØKNAD,
                 behandlingId = UUIDv7.ny(),
                 utførtAv = Applikasjon.DpBehandling,
             ),


### PR DESCRIPTION
Erstatter fire spesifikke *BehandlingOpprettetHendelse-klasser med en generell GenerellBehandlingOpprettetHendelse som bruker UtløstAvType-enum for å skille mellom hendelsestyper.

Endringer:
- Legger til rapidNavn: String på UtløstAvType med @JsonValue/@JsonCreator for bakoverkompatibel Jackson-serialisering
- Ny GenerellBehandlingOpprettetHendelse data class erstatter de fire spesifikke klassene (som beholdes som @Deprecated for DB-bakoverkompatibilitet)
- behandletHendelseType: String endres til UtløstAvType i ForslagTilVedtakHendelse, BehandlingAvbruttHendelse og VedtakFattetHendelse
- BehandlingOpprettetMottak forenklet: fjerner when-blokk, bruker UtløstAvType.fraNavn() og sakMediator.opprettEllerKnyttTilSak()
- requireAny-filtre drives dynamisk av UtløstAvType.entries.map { it.rapidNavn }
- SakMediator får ny opprettEllerKnyttTilSak(GenerellBehandlingOpprettetHendelse)
- Å legge til en ny behandlingstype krever nå kun ett nytt enum-entry