### PR TITLE
feat: send søknadsavklaring behov ved opprettelse av ny søknadsoppgave

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -45,7 +45,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     needs: [ build ]
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feat/generisk-behandlingstype'
+#    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: dev-gcp
     permissions:

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/ApplicationBuilder.kt
@@ -50,6 +50,7 @@ import no.nav.dagpenger.saksbehandling.mottak.ForslagTilBehandlingsresultatMotta
 import no.nav.dagpenger.saksbehandling.mottak.InnsendingBehovløser
 import no.nav.dagpenger.saksbehandling.mottak.MeldingOmVedtakProdusentBehovløser
 import no.nav.dagpenger.saksbehandling.mottak.SøknadBehandlingOpprettetMottak
+import no.nav.dagpenger.saksbehandling.mottak.SøknadsavklaringLøsningMottak
 import no.nav.dagpenger.saksbehandling.oppfolging.OppfølgingAlarmJob
 import no.nav.dagpenger.saksbehandling.oppfolging.OppfølgingAlarmRepository
 import no.nav.dagpenger.saksbehandling.oppfolging.OppfølgingBehandler
@@ -273,6 +274,7 @@ internal class ApplicationBuilder(
                 BehandlingAvbruttMottak(rapidsConnection, oppgaveMediator)
                 BehandlingsresultatMottak(rapidsConnection, oppgaveMediator)
                 ForslagTilBehandlingsresultatMottak(rapidsConnection, oppgaveMediator)
+                SøknadsavklaringLøsningMottak(rapidsConnection, oppgaveMediator)
                 UtsendingBehovLøsningMottak(rapidsConnection, utsendingMediator)
                 InnsendingBehovløser(
                     rapidsConnection = rapidsConnection,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
@@ -792,6 +792,7 @@ class OppgaveMediator(
                     mapOf(
                         "ident" to forslagTilVedtakHendelse.ident,
                         "søknadId" to forslagTilVedtakHendelse.behandletHendelseId,
+                        "behandlingId" to oppgave.behandling.behandlingId,
                         "oppgaveId" to oppgave.oppgaveId,
                     ),
                 ).toJson(),

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
@@ -788,7 +788,14 @@ class OppgaveMediator(
         rapidsConnection.publish(
             JsonMessage
                 .newNeed(
-                    setOf("EØSArbeid", "BostedslandErNorge", "PermittertGrensearbeider", "Sanksjon", "BarnOver16"),
+                    setOf(
+                        "EØSArbeid",
+                        "BostedslandErNorge",
+                        "PermittertGrensearbeider",
+                        "Sanksjon",
+                        "BarnOver16",
+                        "PlanleggerUtdanning",
+                    ),
                     mapOf(
                         "ident" to forslagTilVedtakHendelse.ident,
                         "søknadId" to forslagTilVedtakHendelse.behandletHendelseId,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
@@ -233,6 +233,10 @@ class OppgaveMediator(
                     oppgaveRepository.lagre(oppgave)
                     if (forslagTilVedtakHendelse.behandletHendelseType == "Søknad") {
                         sendSøknadsavklaringBehov(oppgave, forslagTilVedtakHendelse)
+                        if (forslagTilVedtakHendelse.ident.first().digitToInt() in 4..7) {
+                            oppgave.leggTilEmneknagger(setOf("D-nummer"))
+                            oppgaveRepository.lagre(oppgave)
+                        }
                     }
                 }
 

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
@@ -782,6 +782,9 @@ class OppgaveMediator(
         oppgave: Oppgave,
         forslagTilVedtakHendelse: ForslagTilVedtakHendelse,
     ) {
+        logger.info {
+            "Publiserer behov for søknadsinformasjon, behandling ${oppgave.behandling.behandlingId}, oppgave ${oppgave.oppgaveId}"
+        }
         rapidsConnection.publish(
             JsonMessage
                 .newNeed(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
@@ -231,6 +231,7 @@ class OppgaveMediator(
                             it.settKlarTilBehandling(forslagTilVedtakHendelse)
                         }
                     oppgaveRepository.lagre(oppgave)
+                    sendSøknadsavklaringBehov(oppgave, forslagTilVedtakHendelse)
                 }
 
                 false -> {
@@ -238,6 +239,7 @@ class OppgaveMediator(
                         when (handling) {
                             Handling.LAGRE_OPPGAVE -> {
                                 oppgaveRepository.lagre(oppgave)
+                                sendSøknadsavklaringBehov(oppgave, forslagTilVedtakHendelse)
                                 logger.info {
                                     "Behandlet forslag til vedtak. Oppgavens tilstand er" +
                                         " ${oppgave.tilstand().type} etter behandling."
@@ -759,6 +761,34 @@ class OppgaveMediator(
                     "${vedtakFattetHendelse.behandlingId} ved mottak av VedtakFattetHendelse"
             }
         }
+    }
+
+    fun leggTilEmneknagger(
+        oppgaveId: UUID,
+        emneknagger: Set<String>,
+    ) {
+        oppgaveRepository.hentOppgave(oppgaveId).also { oppgave ->
+            oppgave.leggTilEmneknagger(emneknagger)
+            oppgaveRepository.lagre(oppgave)
+        }
+    }
+
+    private fun sendSøknadsavklaringBehov(
+        oppgave: Oppgave,
+        forslagTilVedtakHendelse: ForslagTilVedtakHendelse,
+    ) {
+        if (forslagTilVedtakHendelse.behandletHendelseType != "Søknad") return
+        rapidsConnection.publish(
+            JsonMessage
+                .newNeed(
+                    setOf("EØSTilknytning", "Sanksjon", "BarnOver16"),
+                    mapOf(
+                        "ident" to forslagTilVedtakHendelse.ident,
+                        "søknadId" to forslagTilVedtakHendelse.behandletHendelseId,
+                        "oppgaveId" to oppgave.oppgaveId,
+                    ),
+                ).toJson(),
+        )
     }
 
     private fun sendAlertTilRapid(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
@@ -239,7 +239,6 @@ class OppgaveMediator(
                         when (handling) {
                             Handling.LAGRE_OPPGAVE -> {
                                 oppgaveRepository.lagre(oppgave)
-                                sendSøknadsavklaringBehov(oppgave, forslagTilVedtakHendelse)
                                 logger.info {
                                     "Behandlet forslag til vedtak. Oppgavens tilstand er" +
                                         " ${oppgave.tilstand().type} etter behandling."

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
@@ -231,7 +231,9 @@ class OppgaveMediator(
                             it.settKlarTilBehandling(forslagTilVedtakHendelse)
                         }
                     oppgaveRepository.lagre(oppgave)
-                    sendSøknadsavklaringBehov(oppgave, forslagTilVedtakHendelse)
+                    if (forslagTilVedtakHendelse.behandletHendelseType == "Søknad") {
+                        sendSøknadsavklaringBehov(oppgave, forslagTilVedtakHendelse)
+                    }
                 }
 
                 false -> {
@@ -776,7 +778,6 @@ class OppgaveMediator(
         oppgave: Oppgave,
         forslagTilVedtakHendelse: ForslagTilVedtakHendelse,
     ) {
-        if (forslagTilVedtakHendelse.behandletHendelseType != "Søknad") return
         rapidsConnection.publish(
             JsonMessage
                 .newNeed(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
@@ -781,7 +781,7 @@ class OppgaveMediator(
         rapidsConnection.publish(
             JsonMessage
                 .newNeed(
-                    setOf("EØSTilknytning", "Sanksjon", "BarnOver16"),
+                    setOf("EØSArbeid", "BostedslandErNorge", "Grensearbeider", "Sanksjon", "BarnOver16"),
                     mapOf(
                         "ident" to forslagTilVedtakHendelse.ident,
                         "søknadId" to forslagTilVedtakHendelse.behandletHendelseId,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
@@ -795,6 +795,7 @@ class OppgaveMediator(
                         "Sanksjon",
                         "BarnOver16",
                         "PlanleggerUtdanning",
+                        "EØSPengestøtte",
                     ),
                     mapOf(
                         "ident" to forslagTilVedtakHendelse.ident,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
@@ -781,7 +781,7 @@ class OppgaveMediator(
         rapidsConnection.publish(
             JsonMessage
                 .newNeed(
-                    setOf("EØSArbeid", "BostedslandErNorge", "Grensearbeider", "Sanksjon", "BarnOver16"),
+                    setOf("EØSArbeid", "BostedslandErNorge", "PermittertGrensearbeider", "Sanksjon", "BarnOver16"),
                     mapOf(
                         "ident" to forslagTilVedtakHendelse.ident,
                         "søknadId" to forslagTilVedtakHendelse.behandletHendelseId,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottak.kt
@@ -17,7 +17,7 @@ internal class SøknadsavklaringLøsningMottak(
 ) : River.PacketListener {
     companion object {
         private val logger = KotlinLogging.logger {}
-        private val behov = listOf("EØSArbeid", "BostedslandErNorge", "Grensearbeider", "Sanksjon", "BarnOver16")
+        private val behov = listOf("EØSArbeid", "BostedslandErNorge", "PermittertGrensearbeider", "Sanksjon", "BarnOver16")
         val rapidFilter: River.() -> Unit = {
             precondition {
                 it.requireValue("@event_name", "behov")
@@ -51,7 +51,7 @@ internal class SøknadsavklaringLøsningMottak(
             if (løsning["BostedslandErNorge"]?.get("verdi")?.asBoolean() == false) {
                 emneknagger.add("Bosatt utland")
             }
-            if (løsning["Grensearbeider"]?.get("verdi")?.asBoolean() == true) {
+            if (løsning["PermittertGrensearbeider"]?.get("verdi")?.asBoolean() == true) {
                 emneknagger.add("Grensearbeider")
             }
             if (løsning["Sanksjon"]?.get("verdi")?.asBoolean() == true) {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottak.kt
@@ -25,6 +25,7 @@ internal class SøknadsavklaringLøsningMottak(
                 "Sanksjon",
                 "BarnOver16",
                 "PlanleggerUtdanning",
+                "EØSPengestøtte",
             )
         val rapidFilter: River.() -> Unit = {
             precondition {
@@ -70,6 +71,9 @@ internal class SøknadsavklaringLøsningMottak(
             }
             if (løsning["PlanleggerUtdanning"]?.get("verdi")?.asBoolean() == true) {
                 emneknagger.add("Utdanning")
+            }
+            if (løsning["EØSPengestøtte"]?.get("verdi")?.asBoolean() == true) {
+                emneknagger.add("EØS-pengestøtte")
             }
 
             if (emneknagger.isNotEmpty()) {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottak.kt
@@ -1,0 +1,66 @@
+package no.nav.dagpenger.saksbehandling.mottak
+
+import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
+import com.github.navikt.tbd_libs.rapids_and_rivers.River
+import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageContext
+import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageMetadata
+import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.github.oshai.kotlinlogging.withLoggingContext
+import io.micrometer.core.instrument.MeterRegistry
+import no.nav.dagpenger.saksbehandling.OppgaveMediator
+import java.util.UUID
+
+internal class SøknadsavklaringLøsningMottak(
+    rapidsConnection: RapidsConnection,
+    private val oppgaveMediator: OppgaveMediator,
+) : River.PacketListener {
+    companion object {
+        private val logger = KotlinLogging.logger {}
+        private val behov = listOf("EØSTilknytning", "Sanksjon", "BarnOver16")
+        val rapidFilter: River.() -> Unit = {
+            precondition {
+                it.requireValue("@event_name", "behov")
+                it.requireAllOrAny(key = "@behov", values = behov)
+                it.requireValue("@final", true)
+            }
+            validate { it.requireKey("@løsning") }
+            validate { it.requireKey("oppgaveId") }
+        }
+    }
+
+    init {
+        River(rapidsConnection).apply(rapidFilter).register(this)
+    }
+
+    override fun onPacket(
+        packet: JsonMessage,
+        context: MessageContext,
+        metadata: MessageMetadata,
+        meterRegistry: MeterRegistry,
+    ) {
+        val oppgaveId = UUID.fromString(packet["oppgaveId"].asString())
+
+        withLoggingContext("oppgaveId" to oppgaveId.toString()) {
+            val løsning = packet["@løsning"]
+            val emneknagger = mutableSetOf<String>()
+
+            if (løsning["EØSTilknytning"]?.get("verdi")?.asBoolean() == true) {
+                emneknagger.add("EØS")
+            }
+            if (løsning["Sanksjon"]?.get("verdi")?.asBoolean() == true) {
+                emneknagger.add("Mulig sanksjon")
+            }
+            if (løsning["BarnOver16"]?.get("verdi")?.asBoolean() == true) {
+                emneknagger.add("Barn over 16")
+            }
+
+            if (emneknagger.isNotEmpty()) {
+                logger.info { "Legger til søknadsavklaring-emneknagger: $emneknagger" }
+                oppgaveMediator.leggTilEmneknagger(oppgaveId, emneknagger)
+            } else {
+                logger.info { "Ingen søknadsavklaring-emneknagger å legge til" }
+            }
+        }
+    }
+}

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottak.kt
@@ -17,7 +17,7 @@ internal class SøknadsavklaringLøsningMottak(
 ) : River.PacketListener {
     companion object {
         private val logger = KotlinLogging.logger {}
-        private val behov = listOf("EØSTilknytning", "Sanksjon", "BarnOver16")
+        private val behov = listOf("EØSArbeid", "BostedslandErNorge", "Grensearbeider", "Sanksjon", "BarnOver16")
         val rapidFilter: River.() -> Unit = {
             precondition {
                 it.requireValue("@event_name", "behov")
@@ -45,8 +45,14 @@ internal class SøknadsavklaringLøsningMottak(
             val løsning = packet["@løsning"]
             val emneknagger = mutableSetOf<String>()
 
-            if (løsning["EØSTilknytning"]?.get("verdi")?.asBoolean() == true) {
-                emneknagger.add("EØS")
+            if (løsning["EØSArbeid"]?.get("verdi")?.asBoolean() == true) {
+                emneknagger.add("EØS-inntekt")
+            }
+            if (løsning["BostedslandErNorge"]?.get("verdi")?.asBoolean() == false) {
+                emneknagger.add("Bosatt utland")
+            }
+            if (løsning["Grensearbeider"]?.get("verdi")?.asBoolean() == true) {
+                emneknagger.add("Grensearbeider")
             }
             if (løsning["Sanksjon"]?.get("verdi")?.asBoolean() == true) {
                 emneknagger.add("Mulig sanksjon")

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottak.kt
@@ -17,7 +17,15 @@ internal class SøknadsavklaringLøsningMottak(
 ) : River.PacketListener {
     companion object {
         private val logger = KotlinLogging.logger {}
-        private val behov = listOf("EØSArbeid", "BostedslandErNorge", "PermittertGrensearbeider", "Sanksjon", "BarnOver16")
+        private val behov =
+            listOf(
+                "EØSArbeid",
+                "BostedslandErNorge",
+                "PermittertGrensearbeider",
+                "Sanksjon",
+                "BarnOver16",
+                "PlanleggerUtdanning",
+            )
         val rapidFilter: River.() -> Unit = {
             precondition {
                 it.requireValue("@event_name", "behov")
@@ -59,6 +67,9 @@ internal class SøknadsavklaringLøsningMottak(
             }
             if (løsning["BarnOver16"]?.get("verdi")?.asBoolean() == true) {
                 emneknagger.add("Barn over 16")
+            }
+            if (løsning["PlanleggerUtdanning"]?.get("verdi")?.asBoolean() == true) {
+                emneknagger.add("Utdanning")
             }
 
             if (emneknagger.isNotEmpty()) {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorAlertTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorAlertTest.kt
@@ -125,7 +125,8 @@ class OppgaveMediatorAlertTest {
                 },
         ).also { it.setRapidsConnection(rapid) }.let { oppgaveMediator ->
             oppgaveMediator.opprettEllerOppdaterOppgave(forslagTilVedtakHendelse = forslagTilVedtakHendelse)
-            rapid.inspektør.size shouldBe 0
+            rapid.inspektør.size shouldBe 1
+            rapid.inspektør.message(0)["@event_name"].asText() shouldBe "behov"
         }
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
@@ -620,6 +620,7 @@ OppgaveMediatorTest {
             testRapid.inspektør.message(0).let { melding ->
                 melding["ident"].asString() shouldBe testIdent
                 melding["søknadId"].asString() shouldBe søknadId.toString()
+                melding["behandlingId"].asString() shouldBe behandlingId.toString()
                 val behov = melding["@behov"].values().map { it.asString() }.toSet()
                 behov shouldBe setOf("EØSArbeid", "BostedslandErNorge", "PermittertGrensearbeider", "Sanksjon", "BarnOver16")
             }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
@@ -586,10 +586,19 @@ OppgaveMediatorTest {
     }
 
     @Test
-    fun `Skal publisere søknadsavklaring behov når forslag til vedtak er av type Søknad`() {
+    fun `Skal publisere søknadsavklaring behov når ny oppgave opprettes for Søknad`() {
+        val behandlingId = UUIDv7.ny()
         val søknadId = UUIDv7.ny()
-        settOppOppgaveMediator { datasource, oppgaveMediator ->
-            val oppgave = datasource.lagTestoppgave(tilstand = KLAR_TIL_BEHANDLING)
+        settOppOppgaveMediator(
+            hendelse =
+                SøknadsbehandlingOpprettetHendelse(
+                    søknadId = søknadId,
+                    behandlingId = behandlingId,
+                    ident = testIdent,
+                    opprettet = LocalDateTime.now(),
+                    behandlingskjedeId = behandlingId,
+                ),
+        ) { _, oppgaveMediator ->
             val meldingFørTest = testRapid.inspektør.size
 
             oppgaveMediator.opprettEllerOppdaterOppgave(
@@ -597,7 +606,7 @@ OppgaveMediatorTest {
                     ident = testIdent,
                     behandletHendelseId = søknadId.toString(),
                     behandletHendelseType = "Søknad",
-                    behandlingId = oppgave.behandling.behandlingId,
+                    behandlingId = behandlingId,
                 ),
             )
 
@@ -610,7 +619,6 @@ OppgaveMediatorTest {
             behovMeldinger[0].let { melding ->
                 melding["ident"].asText() shouldBe testIdent
                 melding["søknadId"].asText() shouldBe søknadId.toString()
-                melding["oppgaveId"].asText() shouldBe oppgave.oppgaveId.toString()
                 val behov = melding["@behov"].map { it.asText() }.toSet()
                 behov shouldBe setOf("EØSTilknytning", "Sanksjon", "BarnOver16")
             }
@@ -618,7 +626,7 @@ OppgaveMediatorTest {
     }
 
     @Test
-    fun `Skal ikke publisere søknadsavklaring behov når forslag til vedtak ikke er av type Søknad`() {
+    fun `Skal ikke publisere søknadsavklaring behov ved oppdatering av eksisterende oppgave`() {
         settOppOppgaveMediator { datasource, oppgaveMediator ->
             val oppgave = datasource.lagTestoppgave(tilstand = KLAR_TIL_BEHANDLING)
             val meldingFørTest = testRapid.inspektør.size
@@ -627,8 +635,42 @@ OppgaveMediatorTest {
                 ForslagTilVedtakHendelse(
                     ident = testIdent,
                     behandletHendelseId = UUIDv7.ny().toString(),
-                    behandletHendelseType = "Meldekort",
+                    behandletHendelseType = "Søknad",
                     behandlingId = oppgave.behandling.behandlingId,
+                ),
+            )
+
+            val behovMeldinger =
+                (meldingFørTest until testRapid.inspektør.size)
+                    .map { testRapid.inspektør.message(it) }
+                    .filter { it["@event_name"].asText() == "behov" }
+
+            behovMeldinger.size shouldBe 0
+        }
+    }
+
+    @Test
+    fun `Skal ikke publisere søknadsavklaring behov for ny oppgave som ikke er Søknad`() {
+        val behandlingId = UUIDv7.ny()
+        val søknadId = UUIDv7.ny()
+        settOppOppgaveMediator(
+            hendelse =
+                SøknadsbehandlingOpprettetHendelse(
+                    søknadId = søknadId,
+                    behandlingId = behandlingId,
+                    ident = testIdent,
+                    opprettet = LocalDateTime.now(),
+                    behandlingskjedeId = behandlingId,
+                ),
+        ) { _, oppgaveMediator ->
+            val meldingFørTest = testRapid.inspektør.size
+
+            oppgaveMediator.opprettEllerOppdaterOppgave(
+                ForslagTilVedtakHendelse(
+                    ident = testIdent,
+                    behandletHendelseId = søknadId.toString(),
+                    behandletHendelseType = "Meldekort",
+                    behandlingId = behandlingId,
                 ),
             )
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
@@ -302,7 +302,13 @@ OppgaveMediatorTest {
             behandlingKlient =
                 mockk<BehandlingKlient>().also {
                     coEvery { it.kreverTotrinnskontroll(any(), any()) } returns Result.success(false)
-                    coEvery { it.godkjenn(behandlingId = any(), ident = any(), saksbehandlerToken = any()) } returns Result.success(Unit)
+                    coEvery {
+                        it.godkjenn(
+                            behandlingId = any(),
+                            ident = any(),
+                            saksbehandlerToken = any(),
+                        )
+                    } returns Result.success(Unit)
                 },
         ) { datasource, oppgaveMediator ->
             val oppgave = datasource.lagTestoppgave(UNDER_BEHANDLING)
@@ -599,7 +605,6 @@ OppgaveMediatorTest {
                     behandlingskjedeId = behandlingId,
                 ),
         ) { _, oppgaveMediator ->
-            val meldingFørTest = testRapid.inspektør.size
 
             oppgaveMediator.opprettEllerOppdaterOppgave(
                 ForslagTilVedtakHendelse(
@@ -610,16 +615,11 @@ OppgaveMediatorTest {
                 ),
             )
 
-            val behovMeldinger =
-                (meldingFørTest until testRapid.inspektør.size)
-                    .map { testRapid.inspektør.message(it) }
-                    .filter { it["@event_name"].asText() == "behov" }
-
-            behovMeldinger.size shouldBe 1
-            behovMeldinger[0].let { melding ->
-                melding["ident"].asText() shouldBe testIdent
-                melding["søknadId"].asText() shouldBe søknadId.toString()
-                val behov = melding["@behov"].map { it.asText() }.toSet()
+            testRapid.inspektør.size shouldBe 1
+            testRapid.inspektør.message(0).let { melding ->
+                melding["ident"].asString() shouldBe testIdent
+                melding["søknadId"].asString() shouldBe søknadId.toString()
+                val behov = melding["@behov"].values().map { it.asString() }.toSet()
                 behov shouldBe setOf("EØSTilknytning", "Sanksjon", "BarnOver16")
             }
         }
@@ -629,7 +629,6 @@ OppgaveMediatorTest {
     fun `Skal ikke publisere søknadsavklaring behov ved oppdatering av eksisterende oppgave`() {
         settOppOppgaveMediator { datasource, oppgaveMediator ->
             val oppgave = datasource.lagTestoppgave(tilstand = KLAR_TIL_BEHANDLING)
-            val meldingFørTest = testRapid.inspektør.size
 
             oppgaveMediator.opprettEllerOppdaterOppgave(
                 ForslagTilVedtakHendelse(
@@ -639,13 +638,7 @@ OppgaveMediatorTest {
                     behandlingId = oppgave.behandling.behandlingId,
                 ),
             )
-
-            val behovMeldinger =
-                (meldingFørTest until testRapid.inspektør.size)
-                    .map { testRapid.inspektør.message(it) }
-                    .filter { it["@event_name"].asText() == "behov" }
-
-            behovMeldinger.size shouldBe 0
+            testRapid.inspektør.size shouldBe 0
         }
     }
 
@@ -673,13 +666,7 @@ OppgaveMediatorTest {
                     behandlingId = behandlingId,
                 ),
             )
-
-            val behovMeldinger =
-                (meldingFørTest until testRapid.inspektør.size)
-                    .map { testRapid.inspektør.message(it) }
-                    .filter { it["@event_name"].asText() == "behov" }
-
-            behovMeldinger.size shouldBe 0
+            testRapid.inspektør.size shouldBe 0
         }
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
@@ -4,6 +4,7 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.throwables.shouldThrowWithMessage
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.coEvery
@@ -668,6 +669,71 @@ OppgaveMediatorTest {
                 ),
             )
             testRapid.inspektør.size shouldBe 0
+        }
+    }
+
+    @Test
+    fun `Skal legge til D-nummer emneknagg for søknad med D-nummer ident`() {
+        val dNummerIdent = "42345612345"
+        val behandlingId = UUIDv7.ny()
+        val søknadId = UUIDv7.ny()
+        settOppOppgaveMediator(
+            hendelse =
+                SøknadsbehandlingOpprettetHendelse(
+                    søknadId = søknadId,
+                    behandlingId = behandlingId,
+                    ident = dNummerIdent,
+                    opprettet = LocalDateTime.now(),
+                    behandlingskjedeId = behandlingId,
+                ),
+        ) { datasource, oppgaveMediator ->
+
+            oppgaveMediator.opprettEllerOppdaterOppgave(
+                ForslagTilVedtakHendelse(
+                    ident = dNummerIdent,
+                    behandletHendelseId = søknadId.toString(),
+                    behandletHendelseType = "Søknad",
+                    behandlingId = behandlingId,
+                ),
+            )
+
+            val oppgave =
+                PostgresOppgaveRepository(datasource)
+                    .hentOppgaveIdFor(behandlingId)
+                    .let { PostgresOppgaveRepository(datasource).hentOppgave(it!!) }
+            oppgave.emneknagger shouldContain "D-nummer"
+        }
+    }
+
+    @Test
+    fun `Skal ikke legge til D-nummer emneknagg for søknad med vanlig fødselsnummer`() {
+        val behandlingId = UUIDv7.ny()
+        val søknadId = UUIDv7.ny()
+        settOppOppgaveMediator(
+            hendelse =
+                SøknadsbehandlingOpprettetHendelse(
+                    søknadId = søknadId,
+                    behandlingId = behandlingId,
+                    ident = testIdent,
+                    opprettet = LocalDateTime.now(),
+                    behandlingskjedeId = behandlingId,
+                ),
+        ) { datasource, oppgaveMediator ->
+
+            oppgaveMediator.opprettEllerOppdaterOppgave(
+                ForslagTilVedtakHendelse(
+                    ident = testIdent,
+                    behandletHendelseId = søknadId.toString(),
+                    behandletHendelseType = "Søknad",
+                    behandlingId = behandlingId,
+                ),
+            )
+
+            val oppgave =
+                PostgresOppgaveRepository(datasource)
+                    .hentOppgaveIdFor(behandlingId)
+                    .let { PostgresOppgaveRepository(datasource).hentOppgave(it!!) }
+            oppgave.emneknagger shouldNotContain "D-nummer"
         }
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
@@ -271,8 +271,8 @@ OppgaveMediatorTest {
             it.size shouldBe 4
             for (i in 0 until it.size) {
                 it.message(i).let { message ->
-                    message["@event_name"].asText() shouldBe "saksbehandling_alert"
-                    message["alertType"].asText() shouldBe "BEHANDLING_IKKE_FUNNET"
+                    message["@event_name"].asString() shouldBe "saksbehandling_alert"
+                    message["alertType"].asString() shouldBe "BEHANDLING_IKKE_FUNNET"
                 }
             }
         }
@@ -1160,11 +1160,11 @@ OppgaveMediatorTest {
                 testRapid.inspektør.let { inspektør ->
                     (0 until inspektør.size)
                         .map { inspektør.message(it) }
-                        .single { it["@event_name"].asText() == "avbryt_behandling" }
+                        .single { it["@event_name"].asString() == "avbryt_behandling" }
                 }
-            avbrytMelding["behandlingId"].asText() shouldBe oppgave.behandling.behandlingId.toString()
-            avbrytMelding["ident"].asText() shouldBe oppgave.personIdent()
-            avbrytMelding["årsak"].asText() shouldBe avbrytOppgaveHendelse.årsak.visningsnavn
+            avbrytMelding["behandlingId"].asString() shouldBe oppgave.behandling.behandlingId.toString()
+            avbrytMelding["ident"].asString() shouldBe oppgave.personIdent()
+            avbrytMelding["årsak"].asString() shouldBe avbrytOppgaveHendelse.årsak.visningsnavn
         }
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
@@ -620,7 +620,7 @@ OppgaveMediatorTest {
                 melding["ident"].asString() shouldBe testIdent
                 melding["søknadId"].asString() shouldBe søknadId.toString()
                 val behov = melding["@behov"].values().map { it.asString() }.toSet()
-                behov shouldBe setOf("EØSArbeid", "BostedslandErNorge", "Grensearbeider", "Sanksjon", "BarnOver16")
+                behov shouldBe setOf("EØSArbeid", "BostedslandErNorge", "PermittertGrensearbeider", "Sanksjon", "BarnOver16")
             }
         }
     }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
@@ -620,7 +620,7 @@ OppgaveMediatorTest {
                 melding["ident"].asString() shouldBe testIdent
                 melding["søknadId"].asString() shouldBe søknadId.toString()
                 val behov = melding["@behov"].values().map { it.asString() }.toSet()
-                behov shouldBe setOf("EØSTilknytning", "Sanksjon", "BarnOver16")
+                behov shouldBe setOf("EØSArbeid", "BostedslandErNorge", "Grensearbeider", "Sanksjon", "BarnOver16")
             }
         }
     }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
@@ -630,6 +630,7 @@ OppgaveMediatorTest {
                         "Sanksjon",
                         "BarnOver16",
                         "PlanleggerUtdanning",
+                        "EØSPengestøtte",
                     )
             }
         }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
@@ -622,7 +622,15 @@ OppgaveMediatorTest {
                 melding["søknadId"].asString() shouldBe søknadId.toString()
                 melding["behandlingId"].asString() shouldBe behandlingId.toString()
                 val behov = melding["@behov"].values().map { it.asString() }.toSet()
-                behov shouldBe setOf("EØSArbeid", "BostedslandErNorge", "PermittertGrensearbeider", "Sanksjon", "BarnOver16")
+                behov shouldBe
+                    setOf(
+                        "EØSArbeid",
+                        "BostedslandErNorge",
+                        "PermittertGrensearbeider",
+                        "Sanksjon",
+                        "BarnOver16",
+                        "PlanleggerUtdanning",
+                    )
             }
         }
     }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
@@ -585,6 +585,62 @@ OppgaveMediatorTest {
         }
     }
 
+    @Test
+    fun `Skal publisere søknadsavklaring behov når forslag til vedtak er av type Søknad`() {
+        val søknadId = UUIDv7.ny()
+        settOppOppgaveMediator { datasource, oppgaveMediator ->
+            val oppgave = datasource.lagTestoppgave(tilstand = KLAR_TIL_BEHANDLING)
+            val meldingFørTest = testRapid.inspektør.size
+
+            oppgaveMediator.opprettEllerOppdaterOppgave(
+                ForslagTilVedtakHendelse(
+                    ident = testIdent,
+                    behandletHendelseId = søknadId.toString(),
+                    behandletHendelseType = "Søknad",
+                    behandlingId = oppgave.behandling.behandlingId,
+                ),
+            )
+
+            val behovMeldinger =
+                (meldingFørTest until testRapid.inspektør.size)
+                    .map { testRapid.inspektør.message(it) }
+                    .filter { it["@event_name"].asText() == "behov" }
+
+            behovMeldinger.size shouldBe 1
+            behovMeldinger[0].let { melding ->
+                melding["ident"].asText() shouldBe testIdent
+                melding["søknadId"].asText() shouldBe søknadId.toString()
+                melding["oppgaveId"].asText() shouldBe oppgave.oppgaveId.toString()
+                val behov = melding["@behov"].map { it.asText() }.toSet()
+                behov shouldBe setOf("EØSTilknytning", "Sanksjon", "BarnOver16")
+            }
+        }
+    }
+
+    @Test
+    fun `Skal ikke publisere søknadsavklaring behov når forslag til vedtak ikke er av type Søknad`() {
+        settOppOppgaveMediator { datasource, oppgaveMediator ->
+            val oppgave = datasource.lagTestoppgave(tilstand = KLAR_TIL_BEHANDLING)
+            val meldingFørTest = testRapid.inspektør.size
+
+            oppgaveMediator.opprettEllerOppdaterOppgave(
+                ForslagTilVedtakHendelse(
+                    ident = testIdent,
+                    behandletHendelseId = UUIDv7.ny().toString(),
+                    behandletHendelseType = "Meldekort",
+                    behandlingId = oppgave.behandling.behandlingId,
+                ),
+            )
+
+            val behovMeldinger =
+                (meldingFørTest until testRapid.inspektør.size)
+                    .map { testRapid.inspektør.message(it) }
+                    .filter { it["@event_name"].asText() == "behov" }
+
+            behovMeldinger.size shouldBe 0
+        }
+    }
+
     companion object {
         @JvmStatic
         private fun oppgaveTilstandForSøknad(): Stream<Arguments> =

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
@@ -629,6 +629,7 @@ OppgaveMediatorTest {
     fun `Skal ikke publisere søknadsavklaring behov ved oppdatering av eksisterende oppgave`() {
         settOppOppgaveMediator { datasource, oppgaveMediator ->
             val oppgave = datasource.lagTestoppgave(tilstand = KLAR_TIL_BEHANDLING)
+            val meldingFørTest = testRapid.inspektør.size
 
             oppgaveMediator.opprettEllerOppdaterOppgave(
                 ForslagTilVedtakHendelse(
@@ -638,7 +639,7 @@ OppgaveMediatorTest {
                     behandlingId = oppgave.behandling.behandlingId,
                 ),
             )
-            testRapid.inspektør.size shouldBe 0
+            testRapid.inspektør.size shouldBe meldingFørTest
         }
     }
 
@@ -1155,13 +1156,15 @@ OppgaveMediatorTest {
             avbruttOppgave.tilstandslogg.first().tilstand shouldBe AVBRUTT
             avbruttOppgave.emneknagger.contains(AvbrytBehandling.AVBRUTT_BEHANDLES_I_ARENA.visningsnavn)
             avbruttOppgave.behandlerIdent shouldBe saksbehandler.navIdent
-            testRapid.inspektør.size shouldBe 1
-            testRapid.inspektør.message(0).let { message ->
-                message["@event_name"].asText() shouldBe "avbryt_behandling"
-                message["behandlingId"].asText() shouldBe oppgave.behandling.behandlingId.toString()
-                message["ident"].asText() shouldBe oppgave.personIdent()
-                message["årsak"].asText() shouldBe avbrytOppgaveHendelse.årsak.visningsnavn
-            }
+            val avbrytMelding =
+                testRapid.inspektør.let { inspektør ->
+                    (0 until inspektør.size)
+                        .map { inspektør.message(it) }
+                        .single { it["@event_name"].asText() == "avbryt_behandling" }
+                }
+            avbrytMelding["behandlingId"].asText() shouldBe oppgave.behandling.behandlingId.toString()
+            avbrytMelding["ident"].asText() shouldBe oppgave.personIdent()
+            avbrytMelding["årsak"].asText() shouldBe avbrytOppgaveHendelse.årsak.visningsnavn
         }
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottakTest.kt
@@ -1,0 +1,99 @@
+package no.nav.dagpenger.saksbehandling.mottak
+
+import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.dagpenger.saksbehandling.OppgaveMediator
+import no.nav.dagpenger.saksbehandling.UUIDv7
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class SøknadsavklaringLøsningMottakTest {
+    private val testRapid = TestRapid()
+    private val oppgaveId = UUIDv7.ny()
+
+    @Test
+    fun `Skal legge til emneknagger når alle løsninger er true`() {
+        val oppgaveMediator =
+            mockk<OppgaveMediator>().also {
+                every { it.leggTilEmneknagger(any<UUID>(), any()) } returns Unit
+            }
+        SøknadsavklaringLøsningMottak(testRapid, oppgaveMediator)
+
+        testRapid.sendTestMessage(
+            løsningMelding(
+                eøs = true,
+                sanksjon = true,
+                barnOver16 = true,
+            ),
+        )
+
+        verify(exactly = 1) {
+            oppgaveMediator.leggTilEmneknagger(oppgaveId, setOf("EØS", "Mulig sanksjon", "Barn over 16"))
+        }
+    }
+
+    @Test
+    fun `Skal legge til kun relevante emneknagger`() {
+        val oppgaveMediator =
+            mockk<OppgaveMediator>().also {
+                every { it.leggTilEmneknagger(any<UUID>(), any()) } returns Unit
+            }
+        SøknadsavklaringLøsningMottak(testRapid, oppgaveMediator)
+
+        testRapid.sendTestMessage(
+            løsningMelding(
+                eøs = true,
+                sanksjon = false,
+                barnOver16 = false,
+            ),
+        )
+
+        verify(exactly = 1) {
+            oppgaveMediator.leggTilEmneknagger(oppgaveId, setOf("EØS"))
+        }
+    }
+
+    @Test
+    fun `Skal ikke kalle leggTilEmneknagger når alle løsninger er false`() {
+        val oppgaveMediator =
+            mockk<OppgaveMediator>().also {
+                every { it.leggTilEmneknagger(any<UUID>(), any()) } returns Unit
+            }
+        SøknadsavklaringLøsningMottak(testRapid, oppgaveMediator)
+
+        testRapid.sendTestMessage(
+            løsningMelding(
+                eøs = false,
+                sanksjon = false,
+                barnOver16 = false,
+            ),
+        )
+
+        verify(exactly = 0) { oppgaveMediator.leggTilEmneknagger(any<UUID>(), any()) }
+    }
+
+    private fun løsningMelding(
+        eøs: Boolean,
+        sanksjon: Boolean,
+        barnOver16: Boolean,
+    ): String {
+        //language=JSON
+        return """
+            {
+              "@event_name": "behov",
+              "@behov": ["EØSTilknytning", "Sanksjon", "BarnOver16"],
+              "@final": true,
+              "@løsning": {
+                "EØSTilknytning": { "verdi": $eøs },
+                "Sanksjon": { "verdi": $sanksjon },
+                "BarnOver16": { "verdi": $barnOver16 }
+              },
+              "oppgaveId": "$oppgaveId",
+              "søknadId": "${UUIDv7.ny()}",
+              "ident": "12345678901"
+            }
+            """.trimIndent()
+    }
+}

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottakTest.kt
@@ -29,13 +29,14 @@ class SøknadsavklaringLøsningMottakTest {
                 sanksjon = true,
                 barnOver16 = true,
                 planleggerUtdanning = true,
+                eøsPengestøtte = true,
             ),
         )
 
         verify(exactly = 1) {
             oppgaveMediator.leggTilEmneknagger(
                 oppgaveId,
-                setOf("EØS-inntekt", "Bosatt utland", "Grensearbeider", "Mulig sanksjon", "Barn over 16", "Utdanning"),
+                setOf("EØS-inntekt", "Bosatt utland", "Grensearbeider", "Mulig sanksjon", "Barn over 16", "Utdanning", "EØS-pengestøtte"),
             )
         }
     }
@@ -138,12 +139,13 @@ class SøknadsavklaringLøsningMottakTest {
         sanksjon: Boolean,
         barnOver16: Boolean,
         planleggerUtdanning: Boolean = false,
+        eøsPengestøtte: Boolean = false,
     ): String {
         //language=JSON
         return """
             {
               "@event_name": "behov",
-              "@behov": ["EØSArbeid", "BostedslandErNorge", "PermittertGrensearbeider", "Sanksjon", "BarnOver16", "PlanleggerUtdanning"],
+              "@behov": ["EØSArbeid", "BostedslandErNorge", "PermittertGrensearbeider", "Sanksjon", "BarnOver16", "PlanleggerUtdanning", "EØSPengestøtte"],
               "@final": true,
               "@løsning": {
                 "EØSArbeid": { "verdi": $eøsArbeid },
@@ -151,7 +153,8 @@ class SøknadsavklaringLøsningMottakTest {
                 "PermittertGrensearbeider": { "verdi": $grensearbeider },
                 "Sanksjon": { "verdi": $sanksjon },
                 "BarnOver16": { "verdi": $barnOver16 },
-                "PlanleggerUtdanning": { "verdi": $planleggerUtdanning }
+                "PlanleggerUtdanning": { "verdi": $planleggerUtdanning },
+                "EØSPengestøtte": { "verdi": $eøsPengestøtte }
               },
               "oppgaveId": "$oppgaveId",
               "søknadId": "${UUIDv7.ny()}",

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottakTest.kt
@@ -117,12 +117,12 @@ class SøknadsavklaringLøsningMottakTest {
         return """
             {
               "@event_name": "behov",
-              "@behov": ["EØSArbeid", "BostedslandErNorge", "Grensearbeider", "Sanksjon", "BarnOver16"],
+              "@behov": ["EØSArbeid", "BostedslandErNorge", "PermittertGrensearbeider", "Sanksjon", "BarnOver16"],
               "@final": true,
               "@løsning": {
                 "EØSArbeid": { "verdi": $eøsArbeid },
                 "BostedslandErNorge": { "verdi": $bostedslandErNorge },
-                "Grensearbeider": { "verdi": $grensearbeider },
+                "PermittertGrensearbeider": { "verdi": $grensearbeider },
                 "Sanksjon": { "verdi": $sanksjon },
                 "BarnOver16": { "verdi": $barnOver16 }
               },

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottakTest.kt
@@ -23,14 +23,19 @@ class SøknadsavklaringLøsningMottakTest {
 
         testRapid.sendTestMessage(
             løsningMelding(
-                eøs = true,
+                eøsArbeid = true,
+                bostedslandErNorge = false,
+                grensearbeider = true,
                 sanksjon = true,
                 barnOver16 = true,
             ),
         )
 
         verify(exactly = 1) {
-            oppgaveMediator.leggTilEmneknagger(oppgaveId, setOf("EØS", "Mulig sanksjon", "Barn over 16"))
+            oppgaveMediator.leggTilEmneknagger(
+                oppgaveId,
+                setOf("EØS-inntekt", "Bosatt utland", "Grensearbeider", "Mulig sanksjon", "Barn over 16"),
+            )
         }
     }
 
@@ -44,19 +49,21 @@ class SøknadsavklaringLøsningMottakTest {
 
         testRapid.sendTestMessage(
             løsningMelding(
-                eøs = true,
+                eøsArbeid = true,
+                bostedslandErNorge = true,
+                grensearbeider = false,
                 sanksjon = false,
                 barnOver16 = false,
             ),
         )
 
         verify(exactly = 1) {
-            oppgaveMediator.leggTilEmneknagger(oppgaveId, setOf("EØS"))
+            oppgaveMediator.leggTilEmneknagger(oppgaveId, setOf("EØS-inntekt"))
         }
     }
 
     @Test
-    fun `Skal ikke kalle leggTilEmneknagger når alle løsninger er false`() {
+    fun `Bosatt utland settes når BostedslandErNorge er false`() {
         val oppgaveMediator =
             mockk<OppgaveMediator>().also {
                 every { it.leggTilEmneknagger(any<UUID>(), any()) } returns Unit
@@ -65,7 +72,32 @@ class SøknadsavklaringLøsningMottakTest {
 
         testRapid.sendTestMessage(
             løsningMelding(
-                eøs = false,
+                eøsArbeid = false,
+                bostedslandErNorge = false,
+                grensearbeider = false,
+                sanksjon = false,
+                barnOver16 = false,
+            ),
+        )
+
+        verify(exactly = 1) {
+            oppgaveMediator.leggTilEmneknagger(oppgaveId, setOf("Bosatt utland"))
+        }
+    }
+
+    @Test
+    fun `Skal ikke kalle leggTilEmneknagger når ingen emneknagger matcher`() {
+        val oppgaveMediator =
+            mockk<OppgaveMediator>().also {
+                every { it.leggTilEmneknagger(any<UUID>(), any()) } returns Unit
+            }
+        SøknadsavklaringLøsningMottak(testRapid, oppgaveMediator)
+
+        testRapid.sendTestMessage(
+            løsningMelding(
+                eøsArbeid = false,
+                bostedslandErNorge = true,
+                grensearbeider = false,
                 sanksjon = false,
                 barnOver16 = false,
             ),
@@ -75,7 +107,9 @@ class SøknadsavklaringLøsningMottakTest {
     }
 
     private fun løsningMelding(
-        eøs: Boolean,
+        eøsArbeid: Boolean,
+        bostedslandErNorge: Boolean,
+        grensearbeider: Boolean,
         sanksjon: Boolean,
         barnOver16: Boolean,
     ): String {
@@ -83,10 +117,12 @@ class SøknadsavklaringLøsningMottakTest {
         return """
             {
               "@event_name": "behov",
-              "@behov": ["EØSTilknytning", "Sanksjon", "BarnOver16"],
+              "@behov": ["EØSArbeid", "BostedslandErNorge", "Grensearbeider", "Sanksjon", "BarnOver16"],
               "@final": true,
               "@løsning": {
-                "EØSTilknytning": { "verdi": $eøs },
+                "EØSArbeid": { "verdi": $eøsArbeid },
+                "BostedslandErNorge": { "verdi": $bostedslandErNorge },
+                "Grensearbeider": { "verdi": $grensearbeider },
                 "Sanksjon": { "verdi": $sanksjon },
                 "BarnOver16": { "verdi": $barnOver16 }
               },

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/mottak/SøknadsavklaringLøsningMottakTest.kt
@@ -28,13 +28,14 @@ class SøknadsavklaringLøsningMottakTest {
                 grensearbeider = true,
                 sanksjon = true,
                 barnOver16 = true,
+                planleggerUtdanning = true,
             ),
         )
 
         verify(exactly = 1) {
             oppgaveMediator.leggTilEmneknagger(
                 oppgaveId,
-                setOf("EØS-inntekt", "Bosatt utland", "Grensearbeider", "Mulig sanksjon", "Barn over 16"),
+                setOf("EØS-inntekt", "Bosatt utland", "Grensearbeider", "Mulig sanksjon", "Barn over 16", "Utdanning"),
             )
         }
     }
@@ -86,6 +87,30 @@ class SøknadsavklaringLøsningMottakTest {
     }
 
     @Test
+    fun `Skal legge til Utdanning emneknagg når PlanleggerUtdanning er true`() {
+        val oppgaveMediator =
+            mockk<OppgaveMediator>().also {
+                every { it.leggTilEmneknagger(any<UUID>(), any()) } returns Unit
+            }
+        SøknadsavklaringLøsningMottak(testRapid, oppgaveMediator)
+
+        testRapid.sendTestMessage(
+            løsningMelding(
+                eøsArbeid = false,
+                bostedslandErNorge = true,
+                grensearbeider = false,
+                sanksjon = false,
+                barnOver16 = false,
+                planleggerUtdanning = true,
+            ),
+        )
+
+        verify(exactly = 1) {
+            oppgaveMediator.leggTilEmneknagger(oppgaveId, setOf("Utdanning"))
+        }
+    }
+
+    @Test
     fun `Skal ikke kalle leggTilEmneknagger når ingen emneknagger matcher`() {
         val oppgaveMediator =
             mockk<OppgaveMediator>().also {
@@ -112,19 +137,21 @@ class SøknadsavklaringLøsningMottakTest {
         grensearbeider: Boolean,
         sanksjon: Boolean,
         barnOver16: Boolean,
+        planleggerUtdanning: Boolean = false,
     ): String {
         //language=JSON
         return """
             {
               "@event_name": "behov",
-              "@behov": ["EØSArbeid", "BostedslandErNorge", "PermittertGrensearbeider", "Sanksjon", "BarnOver16"],
+              "@behov": ["EØSArbeid", "BostedslandErNorge", "PermittertGrensearbeider", "Sanksjon", "BarnOver16", "PlanleggerUtdanning"],
               "@final": true,
               "@løsning": {
                 "EØSArbeid": { "verdi": $eøsArbeid },
                 "BostedslandErNorge": { "verdi": $bostedslandErNorge },
                 "PermittertGrensearbeider": { "verdi": $grensearbeider },
                 "Sanksjon": { "verdi": $sanksjon },
-                "BarnOver16": { "verdi": $barnOver16 }
+                "BarnOver16": { "verdi": $barnOver16 },
+                "PlanleggerUtdanning": { "verdi": $planleggerUtdanning }
               },
               "oppgaveId": "$oppgaveId",
               "søknadId": "${UUIDv7.ny()}",

--- a/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/Oppgave.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/Oppgave.kt
@@ -183,6 +183,10 @@ data class Oppgave private constructor(
     val tilstandslogg: OppgaveTilstandslogg
         get() = _tilstandslogg
 
+    fun leggTilEmneknagger(emneknagger: Set<String>) {
+        _emneknagger.addAll(emneknagger)
+    }
+
     fun personIdent() = person.ident
 
     fun tilstand() = this.tilstand


### PR DESCRIPTION
## Hva

Sender ut tre behov (`EØSTilknytning`, `Sanksjon`, `BarnOver16`) via behovsakkumulator-mønsteret når en ny oppgave for en søknad opprettes. Mottar løsningene og setter emneknagger på oppgaven.

## Hvorfor

Saksbehandlere trenger tidlig å kunne se om en søknad inneholder elementer som krever ekstra avklaringer (EØS-tilknytning, mulig sanksjon, barn over 16 år). Emneknaggene vises i oppgavelisten og gjør det enklere å prioritere og filtrere.

## Endringer

### Modell
- `Oppgave.leggTilEmneknagger(emneknagger)` — ny metode for å legge til emneknagger etter opprettelse

### Mediator
- `OppgaveMediator.leggTilEmneknagger(oppgaveId, emneknagger)` — public metode for mottak
- `OppgaveMediator.sendSøknadsavklaringBehov()` — sender behov **kun** ved ny oppgave + `behandletHendelseType == "Søknad"`
- `SøknadsavklaringLøsningMottak` — lytter på `@final: true` løsninger og mapper til emneknagger:
  - `EØSTilknytning: true` → "EØS"
  - `Sanksjon: true` → "Mulig sanksjon"
  - `BarnOver16: true` → "Barn over 16"

### Bevisste valg
- Emneknaggene har **ingen egen kategori** ennå — de havner i `UDEFINERT`. Kategori legges til ved behov.
- Emneknagger legges til asynkront (behov → akkumulator → løsning), så det er et kort vindu der oppgaven finnes uten disse emneknaggene.

## Avhengigheter

Krever at Brukerdialog implementerer behovløsere for `EØSTilknytning`, `Sanksjon` og `BarnOver16`.

## Test

**OppgaveMediatorTest** (3 nye):
- ✅ Ny oppgave + Søknad → behov publiseres med riktige felter
- ❌ Eksisterende oppgave + Søknad → ingen behov
- ❌ Ny oppgave + Meldekort → ingen behov

**SøknadsavklaringLøsningMottakTest** (3 nye):
- ✅ Alle løsninger true → alle 3 emneknagger med riktig oppgaveId
- ✅ Kun EØS true → bare "EØS" emneknagg
- ❌ Alle false → `leggTilEmneknagger` kalles ikke