### PR TITLE
refactor: flytt audit logging fra mediator til API-lag

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -45,7 +45,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     needs: [ build ]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/refaktor/audit-logging-i-api-lag'
     runs-on: ubuntu-latest
     environment: dev-gcp
     permissions:

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/ApplicationBuilder.kt
@@ -14,6 +14,7 @@ import no.nav.dagpenger.saksbehandling.api.Oppslag
 import no.nav.dagpenger.saksbehandling.api.RelevanteJournalpostIdOppslag
 import no.nav.dagpenger.saksbehandling.api.installerApis
 import no.nav.dagpenger.saksbehandling.audit.ApiAuditlogg
+import no.nav.dagpenger.saksbehandling.audit.Auditlogg
 import no.nav.dagpenger.saksbehandling.behandling.BehandlingHttpKlient
 import no.nav.dagpenger.saksbehandling.db.PostgresDataSourceBuilder.dataSource
 import no.nav.dagpenger.saksbehandling.db.PostgresDataSourceBuilder.runMigration
@@ -227,6 +228,33 @@ internal class ApplicationBuilder(
     private val oppgaveTilstandAlertJob: Timer
     val statistikkTjeneste = PostgresSaksbehandlingsstatistikkRepository(dataSource)
     val statistikkV2Tjeneste = PostgresProduksjonsstatistikkRepository(dataSource)
+    private lateinit var auditloggDelegate: Auditlogg
+    private val auditlogg: Auditlogg =
+        object : Auditlogg {
+            override fun les(
+                melding: String,
+                ident: String,
+                saksbehandler: String,
+            ) = auditloggDelegate.les(melding, ident, saksbehandler)
+
+            override fun opprett(
+                melding: String,
+                ident: String,
+                saksbehandler: String,
+            ) = auditloggDelegate.opprett(melding, ident, saksbehandler)
+
+            override fun oppdater(
+                melding: String,
+                ident: String,
+                saksbehandler: String,
+            ) = auditloggDelegate.oppdater(melding, ident, saksbehandler)
+
+            override fun slett(
+                melding: String,
+                ident: String,
+                saksbehandler: String,
+            ) = auditloggDelegate.slett(melding, ident, saksbehandler)
+        }
     private val rapidsConnection: RapidsConnection =
         RapidApplication
             .create(
@@ -244,6 +272,7 @@ internal class ApplicationBuilder(
                             innsendingMediator = innsendingMediator,
                             meldingOmVedtakMediator = meldingOmVedtakMediator,
                             oppfølgingMediator = oppfølgingMediator,
+                            auditlogg = auditlogg,
                         )
                         this.install(KafkaStreamsPlugin) {
                             kafkaStreams =
@@ -267,7 +296,7 @@ internal class ApplicationBuilder(
                 utsendingMediator.setRapidsConnection(rapidsConnection)
                 oppgaveMediator.setRapidsConnection(rapidsConnection)
                 klageMediator.setRapidsConnection(rapidsConnection)
-                klageMediator.setAuditlogg(ApiAuditlogg(AktivitetsloggMediator(), rapidsConnection))
+                auditloggDelegate = ApiAuditlogg(AktivitetsloggMediator(), rapidsConnection)
                 BehandlingOpprettetMottak(rapidsConnection, sakMediator)
                 SøknadBehandlingOpprettetMottak(rapidsConnection, innsendingMediator)
                 BehandlingAvbruttMottak(rapidsConnection, oppgaveMediator)

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/KlageMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/KlageMediator.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import no.nav.dagpenger.saksbehandling.api.Oppslag
-import no.nav.dagpenger.saksbehandling.audit.Auditlogg
 import no.nav.dagpenger.saksbehandling.db.klage.KlageRepository
 import no.nav.dagpenger.saksbehandling.hendelser.AvbruttHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingOpprettetHendelse
@@ -41,14 +40,9 @@ class KlageMediator(
     private val sakMediator: SakMediator,
 ) {
     private lateinit var rapidsConnection: RapidsConnection
-    private lateinit var auditlogg: Auditlogg
 
     fun setRapidsConnection(rapidsConnection: RapidsConnection) {
         this.rapidsConnection = rapidsConnection
-    }
-
-    fun setAuditlogg(auditlogg: Auditlogg) {
-        this.auditlogg = auditlogg
     }
 
     fun hentKlageBehandling(
@@ -59,9 +53,7 @@ class KlageMediator(
             behandlingId = behandlingId,
             saksbehandler = saksbehandler,
         )
-        val klageBehandling = klageRepository.hentKlageBehandling(behandlingId)
-        auditlogg.les("Så en klagebehandling", klageBehandling.personIdent(), saksbehandler.navIdent)
-        return klageBehandling
+        return klageRepository.hentKlageBehandling(behandlingId)
     }
 
     fun opprettKlage(klageMottattHendelse: KlageMottattHendelse): Oppgave {
@@ -147,12 +139,6 @@ class KlageMediator(
             )
         sakMediator.knyttTilSak(behandlingOpprettetHendelse = behandlingOpprettetHendelse)
 
-        auditlogg.opprett(
-            "Opprettet en manuell klage",
-            manuellKlageMottattHendelse.ident,
-            utførtAv.navIdent,
-        )
-
         return runCatching {
             oppgaveMediator
                 .opprettOppgaveForKlageBehandling(
@@ -177,12 +163,11 @@ class KlageMediator(
         opplysningId: UUID,
         verdi: Verdi,
         saksbehandler: Saksbehandler,
-    ) {
+    ): KlageBehandling {
         sjekkTilgangOgEierAvOppgave(behandlingId, saksbehandler)
-        klageRepository.hentKlageBehandling(behandlingId).let { klageBehandling ->
+        return klageRepository.hentKlageBehandling(behandlingId).also { klageBehandling ->
             klageBehandling.svar(opplysningId, verdi)
             klageRepository.lagre(klageBehandling = klageBehandling)
-            auditlogg.oppdater("Oppdaterte en klageopplysning", klageBehandling.personIdent(), saksbehandler.navIdent)
         }
     }
 
@@ -198,11 +183,11 @@ class KlageMediator(
     fun behandlingUtført(
         hendelse: KlageBehandlingUtført,
         saksbehandlerToken: String,
-    ) {
+    ): KlageBehandling {
         val oppgave =
             sjekkTilgangOgEierAvOppgave(behandlingId = hendelse.behandlingId, saksbehandler = hendelse.utførtAv)
 
-        runBlocking {
+        return runBlocking {
             val saksbehandlerDeferred =
                 async(Dispatchers.IO) {
                     oppslag.hentBehandler(
@@ -255,17 +240,13 @@ class KlageMediator(
                         ),
                     ).toJson(),
             )
-            auditlogg.opprett(
-                "Ferdigstilte en klagebehandling",
-                klageBehandling.personIdent(),
-                hendelse.utførtAv.navIdent,
-            )
+            klageBehandling
         }
     }
 
     // TODO : Vurder om man bør bruke AvbrytOppgaveHendelse og sette oppgave til Avbrutt i stedet for Ferdigbehandlet
     // TODO: Alternativt bør AvbruttHendelse renames til AvbrytKlageHendelse, siden den ikke skal brukes på andre type behandlinger
-    fun avbrytKlage(hendelse: AvbruttHendelse) {
+    fun avbrytKlage(hendelse: AvbruttHendelse): KlageBehandling {
         sjekkTilgangOgEierAvOppgave(
             behandlingId = hendelse.behandlingId,
             saksbehandler = hendelse.utførtAv,
@@ -280,8 +261,7 @@ class KlageMediator(
 
         klageRepository.lagre(klageBehandling)
         oppgaveMediator.ferdigstillOppgave(avbruttHendelse = hendelse)
-        // TODO: Fix skrivefeil i auditlogg
-        auditlogg.oppdater("Avbrutte en klage", klageBehandling.personIdent(), hendelse.utførtAv.navIdent)
+        return klageBehandling
     }
 
     fun oversendtTilKlageinstans(hendelse: OversendtKlageinstansHendelse) {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/ApiConfig.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/ApiConfig.kt
@@ -19,6 +19,7 @@ import no.nav.dagpenger.saksbehandling.MeldingOmVedtakMediator
 import no.nav.dagpenger.saksbehandling.OppgaveMediator
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.api.auth.authConfig
+import no.nav.dagpenger.saksbehandling.audit.Auditlogg
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.innsending.InnsendingMediator
 import no.nav.dagpenger.saksbehandling.oppfolging.OppfølgingMediator
@@ -39,6 +40,7 @@ internal fun Application.installerApis(
     innsendingMediator: InnsendingMediator,
     meldingOmVedtakMediator: MeldingOmVedtakMediator,
     oppfølgingMediator: OppfølgingMediator,
+    auditlogg: Auditlogg,
 ) {
     this.authConfig()
     install(CallId) {
@@ -78,19 +80,21 @@ internal fun Application.installerApis(
             oppgaveDTOMapper = oppgaveDTOMapper,
             applicationCallParser = applicationCallParser,
             personMediator = personMediator,
+            auditlogg = auditlogg,
         )
         sakApi(mediator = sakMediator)
         statistikkApi(produksjonsstatistikkRepository)
-        innsendingApi(innsendingMediator, applicationCallParser)
+        innsendingApi(innsendingMediator, applicationCallParser, auditlogg)
         klageApi(
             mediator = klageMediator,
             klageDtoMapper = klageDTOMapper,
             applicationCallParser = applicationCallParser,
+            auditlogg = auditlogg,
         )
         meldingOmVedtakApi(
             meldingOmVedtakMediator = meldingOmVedtakMediator,
             applicationCallParser = applicationCallParser,
         )
-        oppfølgingApi(oppfølgingMediator, applicationCallParser)
+        oppfølgingApi(oppfølgingMediator, applicationCallParser, auditlogg)
     }
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/InnsendingApi.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/InnsendingApi.kt
@@ -16,6 +16,7 @@ import no.nav.dagpenger.saksbehandling.api.models.FerdigstillInnsendingRequestDT
 import no.nav.dagpenger.saksbehandling.api.models.InnsendingDTO
 import no.nav.dagpenger.saksbehandling.api.models.TynnBehandlingDTO
 import no.nav.dagpenger.saksbehandling.api.models.TynnSakDTO
+import no.nav.dagpenger.saksbehandling.audit.Auditlogg
 import no.nav.dagpenger.saksbehandling.hendelser.FerdigstillInnsendingHendelse
 import no.nav.dagpenger.saksbehandling.innsending.Aksjon
 import no.nav.dagpenger.saksbehandling.innsending.Aksjon.Avslutt
@@ -28,16 +29,19 @@ import java.util.UUID
 fun Route.innsendingApi(
     mediator: InnsendingMediator,
     applicationCallParser: ApplicationCallParser,
+    auditlogg: Auditlogg,
 ) {
     route("innsending") {
         authenticate("azureAd") {
             route("{behandlingId}") {
                 get {
+                    val saksbehandler = applicationCallParser.saksbehandler(call)
                     mediator
                         .hentInnsending(
                             innsendingId = call.behandlingId(),
-                            saksbehandler = applicationCallParser.saksbehandler(call),
+                            saksbehandler = saksbehandler,
                         ).let {
+                            auditlogg.les("Så en innsending", it.person.ident, saksbehandler.navIdent)
                             call.respond(
                                 HttpStatusCode.OK,
                                 it.tilInnsendingDTO(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/KlageApi.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/KlageApi.kt
@@ -13,6 +13,7 @@ import no.nav.dagpenger.saksbehandling.Applikasjon
 import no.nav.dagpenger.saksbehandling.KlageMediator
 import no.nav.dagpenger.saksbehandling.api.models.OppdaterKlageOpplysningDTO
 import no.nav.dagpenger.saksbehandling.api.models.OpprettKlageDTO
+import no.nav.dagpenger.saksbehandling.audit.Auditlogg
 import no.nav.dagpenger.saksbehandling.hendelser.AvbruttHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.KlageBehandlingUtført
 import no.nav.dagpenger.saksbehandling.hendelser.KlageMottattHendelse
@@ -24,6 +25,7 @@ fun Route.klageApi(
     mediator: KlageMediator,
     klageDtoMapper: KlageDTOMapper,
     applicationCallParser: ApplicationCallParser,
+    auditlogg: Auditlogg,
 ) {
     authenticate("azureAd-maskin") {
         route("klage/opprett") {
@@ -63,7 +65,7 @@ fun Route.klageApi(
                                 utførtAv = saksbehandler,
                             ),
                     ).let { oppgave ->
-
+                        auditlogg.opprett("Opprettet en manuell klage", klage.personIdent.ident, saksbehandler.navIdent)
                         call.respond(HttpStatusCode.Created, oppgave.tilOppgaveOversiktDTO())
                     }
             }
@@ -81,6 +83,7 @@ fun Route.klageApi(
                             behandlingId = behandlingId,
                             saksbehandler = saksbehandler,
                         )
+                    auditlogg.les("Så en klagebehandling", klageBehandling.personIdent(), saksbehandler.navIdent)
                     val klageDTO =
                         klageDtoMapper.tilDto(
                             klageBehandling = klageBehandling,
@@ -92,13 +95,15 @@ fun Route.klageApi(
                     put {
                         val behandlingId = call.finnUUID("behandlingId")
                         val saksbehandler = applicationCallParser.saksbehandler(call)
-                        mediator.avbrytKlage(
-                            hendelse =
-                                AvbruttHendelse(
-                                    behandlingId = behandlingId,
-                                    utførtAv = saksbehandler,
-                                ),
-                        )
+                        val klageBehandling =
+                            mediator.avbrytKlage(
+                                hendelse =
+                                    AvbruttHendelse(
+                                        behandlingId = behandlingId,
+                                        utførtAv = saksbehandler,
+                                    ),
+                            )
+                        auditlogg.oppdater("Avbrutte en klage", klageBehandling.personIdent(), saksbehandler.navIdent)
                         call.respond(HttpStatusCode.NoContent)
                     }
                 }
@@ -106,14 +111,16 @@ fun Route.klageApi(
                     put {
                         val behandlingId = call.finnUUID("behandlingId")
                         val saksbehandler = applicationCallParser.saksbehandler(call)
-                        mediator.behandlingUtført(
-                            hendelse =
-                                KlageBehandlingUtført(
-                                    behandlingId = behandlingId,
-                                    utførtAv = saksbehandler,
-                                ),
-                            saksbehandlerToken = call.request.jwt(),
-                        )
+                        val klageBehandling =
+                            mediator.behandlingUtført(
+                                hendelse =
+                                    KlageBehandlingUtført(
+                                        behandlingId = behandlingId,
+                                        utførtAv = saksbehandler,
+                                    ),
+                                saksbehandlerToken = call.request.jwt(),
+                            )
+                        auditlogg.opprett("Ferdigstilte en klagebehandling", klageBehandling.personIdent(), saksbehandler.navIdent)
                         call.respond(HttpStatusCode.NoContent)
                     }
                 }
@@ -124,12 +131,14 @@ fun Route.klageApi(
                             val opplysningId = call.finnUUID("opplysningId")
                             val oppdaterKlageOpplysningDTO = call.receive<OppdaterKlageOpplysningDTO>()
                             val saksbehandler = applicationCallParser.saksbehandler(call)
-                            mediator.oppdaterKlageOpplysning(
-                                behandlingId = behandlingId,
-                                opplysningId = opplysningId,
-                                verdi = klageDtoMapper.tilVerdi(oppdaterKlageOpplysningDTO),
-                                saksbehandler = saksbehandler,
-                            )
+                            val klageBehandling =
+                                mediator.oppdaterKlageOpplysning(
+                                    behandlingId = behandlingId,
+                                    opplysningId = opplysningId,
+                                    verdi = klageDtoMapper.tilVerdi(oppdaterKlageOpplysningDTO),
+                                    saksbehandler = saksbehandler,
+                                )
+                            auditlogg.oppdater("Oppdaterte en klageopplysning", klageBehandling.personIdent(), saksbehandler.navIdent)
                             call.respond(HttpStatusCode.NoContent)
                         }
                     }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApi.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApi.kt
@@ -49,6 +49,7 @@ import no.nav.dagpenger.saksbehandling.api.models.ReturnerTilSaksbehandlingDTO
 import no.nav.dagpenger.saksbehandling.api.models.TildeltOppgaveDTO
 import no.nav.dagpenger.saksbehandling.api.models.UtsettOppgaveAarsakDTO
 import no.nav.dagpenger.saksbehandling.api.models.UtsettOppgaveDTO
+import no.nav.dagpenger.saksbehandling.audit.Auditlogg
 import no.nav.dagpenger.saksbehandling.db.oppgave.Søkefilter
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.hendelser.AvbrytOppgaveHendelse
@@ -74,6 +75,7 @@ internal fun Route.oppgaveApi(
     personMediator: PersonMediator,
     oppgaveDTOMapper: OppgaveDTOMapper,
     applicationCallParser: ApplicationCallParser,
+    auditlogg: Auditlogg,
 ) {
     authenticate("azureAd") {
         route("person/personId") {
@@ -93,15 +95,18 @@ internal fun Route.oppgaveApi(
                         .finnOppgaverFor(person.ident, antall = null)
                         .tilOppgaveOversiktDTOListe()
                 val personOversiktDTO = oppgaveDTOMapper.lagPersonOversiktDTO(person, oppgaver)
+                auditlogg.les("Så personoversikt", person.ident, call.navIdent())
                 call.respond(status = HttpStatusCode.OK, personOversiktDTO)
             }
         }
         route("person/oppgaver") {
             post {
+                val personIdentDTO: PersonIdentDTO = call.receive<PersonIdentDTO>()
                 val oppgaver =
                     oppgaveMediator
-                        .finnOppgaverFor(call.receive<PersonIdentDTO>().ident)
+                        .finnOppgaverFor(personIdentDTO.ident)
                         .tilOppgaveOversiktDTOListe()
+                auditlogg.les("Søkte oppgaver for person", personIdentDTO.ident, call.navIdent())
                 call.respond(status = HttpStatusCode.OK, oppgaver)
             }
         }
@@ -148,7 +153,10 @@ internal fun Route.oppgaveApi(
                                     ),
                             )
 
-                        else -> call.respond(HttpStatusCode.OK, oppgaveDTOMapper.lagOppgaveDTO(oppgave))
+                        else -> {
+                            auditlogg.les("Hentet neste oppgave", oppgave.personIdent(), saksbehandler.navIdent)
+                            call.respond(HttpStatusCode.OK, oppgaveDTOMapper.lagOppgaveDTO(oppgave))
+                        }
                     }
                 }
             }
@@ -159,6 +167,7 @@ internal fun Route.oppgaveApi(
                     val oppgaveId = call.finnUUID("oppgaveId")
                     withLoggingContext("oppgaveId" to oppgaveId.toString()) {
                         val oppgave = oppgaveMediator.hentOppgave(oppgaveId, saksbehandler)
+                        auditlogg.les("Så en oppgave", oppgave.personIdent(), saksbehandler.navIdent)
                         val oppgaveDTO = oppgaveDTOMapper.lagOppgaveDTO(oppgave)
                         call.respond(HttpStatusCode.OK, oppgaveDTO)
                     }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/audit/Auditlogg.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/audit/Auditlogg.kt
@@ -24,33 +24,4 @@ interface Auditlogg {
         ident: String,
         saksbehandler: String,
     )
-
-    companion object {
-        val NoOp: Auditlogg =
-            object : Auditlogg {
-                override fun les(
-                    melding: String,
-                    ident: String,
-                    saksbehandler: String,
-                ) {}
-
-                override fun opprett(
-                    melding: String,
-                    ident: String,
-                    saksbehandler: String,
-                ) {}
-
-                override fun oppdater(
-                    melding: String,
-                    ident: String,
-                    saksbehandler: String,
-                ) {}
-
-                override fun slett(
-                    melding: String,
-                    ident: String,
-                    saksbehandler: String,
-                ) {}
-            }
-    }
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/audit/Auditlogg.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/audit/Auditlogg.kt
@@ -24,4 +24,33 @@ interface Auditlogg {
         ident: String,
         saksbehandler: String,
     )
+
+    companion object {
+        val NoOp: Auditlogg =
+            object : Auditlogg {
+                override fun les(
+                    melding: String,
+                    ident: String,
+                    saksbehandler: String,
+                ) {}
+
+                override fun opprett(
+                    melding: String,
+                    ident: String,
+                    saksbehandler: String,
+                ) {}
+
+                override fun oppdater(
+                    melding: String,
+                    ident: String,
+                    saksbehandler: String,
+                ) {}
+
+                override fun slett(
+                    melding: String,
+                    ident: String,
+                    saksbehandler: String,
+                ) {}
+            }
+    }
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingApi.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingApi.kt
@@ -19,6 +19,7 @@ import no.nav.dagpenger.saksbehandling.api.models.OpprettOppfolgingRequestDTO
 import no.nav.dagpenger.saksbehandling.api.models.OpprettOppfolgingResponseDTO
 import no.nav.dagpenger.saksbehandling.api.models.TynnBehandlingDTO
 import no.nav.dagpenger.saksbehandling.api.models.TynnSakDTO
+import no.nav.dagpenger.saksbehandling.audit.Auditlogg
 import no.nav.dagpenger.saksbehandling.hendelser.FerdigstillOppfølgingHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.OpprettOppfølgingHendelse
 import no.nav.dagpenger.saksbehandling.jwt.ApplicationCallParser
@@ -27,6 +28,7 @@ import no.nav.dagpenger.saksbehandling.jwt.jwt
 internal fun Route.oppfølgingApi(
     oppfølgingMediator: OppfølgingMediator,
     applicationCallParser: ApplicationCallParser,
+    auditlogg: Auditlogg,
 ) {
     route("oppfolging") {
         authenticate("azureAd") {
@@ -61,6 +63,7 @@ internal fun Route.oppfølgingApi(
                     val behandlingId = call.finnUUID("behandlingId")
                     val saksbehandler = applicationCallParser.saksbehandler(call)
                     val oppfølging = oppfølgingMediator.hent(behandlingId, saksbehandler)
+                    auditlogg.les("Så en oppfølging", oppfølging.person.ident, saksbehandler.navIdent)
                     val lovligeSaker = oppfølgingMediator.hentAlleSaker(oppfølging.person.ident)
                     call.respond(
                         HttpStatusCode.OK,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
@@ -19,7 +19,6 @@ import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.Type.UNDER_BEHANDLING
 import no.nav.dagpenger.saksbehandling.api.Oppslag
 import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTO
 import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTOEnhetDTO
-import no.nav.dagpenger.saksbehandling.audit.ApiAuditlogg
 import no.nav.dagpenger.saksbehandling.db.Postgres.withMigratedDb
 import no.nav.dagpenger.saksbehandling.db.klage.PostgresKlageRepository
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
@@ -146,37 +145,6 @@ class KlageMediatorTest {
                     sakId = any(),
                 )
             } returns Result.success(html)
-        }
-    private val auditloggMock =
-        mockk<ApiAuditlogg>().also {
-            coEvery {
-                it.opprett(
-                    melding = any(),
-                    ident = any(),
-                    saksbehandler = any(),
-                )
-            } returns Unit
-            coEvery {
-                it.oppdater(
-                    melding = any(),
-                    ident = any(),
-                    saksbehandler = any(),
-                )
-            } returns Unit
-            coEvery {
-                it.les(
-                    melding = any(),
-                    ident = any(),
-                    saksbehandler = any(),
-                )
-            } returns Unit
-            coEvery {
-                it.slett(
-                    melding = any(),
-                    ident = any(),
-                    saksbehandler = any(),
-                )
-            } returns Unit
         }
 
     @Test
@@ -1123,7 +1091,6 @@ class KlageMediatorTest {
                     meldingOmVedtakKlient = meldingOmVedtakKlientMock,
                     sakMediator = sakMediator,
                 ).also {
-                    it.setAuditlogg(auditlogg = auditloggMock)
                     it.setRapidsConnection(rapidsConnection = testRapid)
                 }
             personRepository.lagre(

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/InnsendingApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/InnsendingApiTest.kt
@@ -241,7 +241,7 @@ class InnsendingApiTest {
     }
 
     @Test
-    fun `should audit log READ when viewing innsending`() {
+    fun `Skal auditlogge READ ved visning av innsending`() {
         val auditlogg = TestAuditlogg()
         val innsending = TestHelper.lagInnsending()
         val mediator =

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/InnsendingApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/InnsendingApiTest.kt
@@ -19,6 +19,7 @@ import no.nav.dagpenger.saksbehandling.TestHelper
 import no.nav.dagpenger.saksbehandling.TestHelper.ISO_TIMESTAMP
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.autentisert
+import no.nav.dagpenger.saksbehandling.audit.Auditlogg
 import no.nav.dagpenger.saksbehandling.hendelser.FerdigstillInnsendingHendelse
 import no.nav.dagpenger.saksbehandling.innsending.Aksjon
 import no.nav.dagpenger.saksbehandling.innsending.Innsending
@@ -253,6 +254,7 @@ class InnsendingApiTest {
                     innsendingMediator = innsendingMediator,
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = mockk(relaxed = true),
+                    auditlogg = Auditlogg.NoOp,
                 )
             }
             test()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/InnsendingApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/InnsendingApiTest.kt
@@ -1,6 +1,7 @@
 package no.nav.dagpenger.saksbehandling.api
 
 import io.kotest.assertions.json.shouldEqualSpecifiedJson
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -14,12 +15,14 @@ import io.ktor.server.testing.testApplication
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import no.nav.dagpenger.aktivitetslogg.AuditOperasjon
 import no.nav.dagpenger.saksbehandling.Sak
 import no.nav.dagpenger.saksbehandling.TestHelper
 import no.nav.dagpenger.saksbehandling.TestHelper.ISO_TIMESTAMP
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.autentisert
 import no.nav.dagpenger.saksbehandling.audit.Auditlogg
+import no.nav.dagpenger.saksbehandling.audit.TestAuditlogg
 import no.nav.dagpenger.saksbehandling.hendelser.FerdigstillInnsendingHendelse
 import no.nav.dagpenger.saksbehandling.innsending.Aksjon
 import no.nav.dagpenger.saksbehandling.innsending.Innsending
@@ -237,8 +240,32 @@ class InnsendingApiTest {
         }
     }
 
+    @Test
+    fun `should audit log READ when viewing innsending`() {
+        val auditlogg = TestAuditlogg()
+        val innsending = TestHelper.lagInnsending()
+        val mediator =
+            mockk<InnsendingMediator>().also {
+                every { it.hentInnsending(innsendingId, any()) } returns innsending
+                every { it.hentAlleSaker(any()) } returns emptyList()
+            }
+
+        withInnsendingApi(mediator, auditlogg = auditlogg) {
+            client.get("innsending/$innsendingId") { autentisert() }
+        }
+
+        auditlogg.hendelser shouldHaveSize 1
+        auditlogg.hendelser.first().let {
+            it.operasjon shouldBe AuditOperasjon.READ
+            it.melding shouldBe "Så en innsending"
+            it.ident shouldBe innsending.person.ident
+            it.saksbehandler shouldBe TestHelper.saksbehandler.navIdent
+        }
+    }
+
     private fun withInnsendingApi(
         innsendingMediator: InnsendingMediator,
+        auditlogg: Auditlogg = TestAuditlogg(),
         test: suspend ApplicationTestBuilder.() -> Unit,
     ) {
         testApplication {
@@ -254,7 +281,7 @@ class InnsendingApiTest {
                     innsendingMediator = innsendingMediator,
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = mockk(relaxed = true),
-                    auditlogg = Auditlogg.NoOp,
+                    auditlogg = auditlogg,
                 )
             }
             test()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/KlageApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/KlageApiTest.kt
@@ -14,10 +14,8 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
-import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.dagpenger.saksbehandling.HendelseBehandler
@@ -29,6 +27,7 @@ import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.gyldigMaskinToken
 import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.gyldigSaksbehandlerToken
 import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTO
 import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTOEnhetDTO
+import no.nav.dagpenger.saksbehandling.audit.Auditlogg
 import no.nav.dagpenger.saksbehandling.hendelser.AvbruttHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.KlageBehandlingUtført
 import no.nav.dagpenger.saksbehandling.hendelser.KlageMottattHendelse
@@ -64,6 +63,11 @@ class KlageApiTest {
 
     @Test
     fun `Skal hente klageDTO`() {
+        val klageBehandling =
+            mockk<KlageBehandling>(relaxed = true).also {
+                every { it.behandlingId } returns klageBehandlingId
+                every { it.personIdent() } returns "12345678901"
+            }
         val mediator =
             mockk<KlageMediator>().also {
                 every {
@@ -71,14 +75,7 @@ class KlageApiTest {
                         behandlingId = klageBehandlingId,
                         saksbehandler = TestHelper.saksbehandler,
                     )
-                } returns
-                    KlageBehandling.rehydrer(
-                        behandlingId = klageBehandlingId,
-                        journalpostId = journalpostId,
-                        tilstand = KlageBehandling.Behandles,
-                        behandlendeEnhet = null,
-                        opprettet = opprettet,
-                    )
+                } returns klageBehandling
             }
 
         withKlageApi(mediator) {
@@ -289,7 +286,7 @@ class KlageApiTest {
                     it.avbrytKlage(
                         hendelse = avbruttHendelse,
                     )
-                } just Runs
+                } returns mockk<KlageBehandling>(relaxed = true)
             }
 
         withKlageApi(mediator) {
@@ -315,7 +312,7 @@ class KlageApiTest {
                             ),
                         saksbehandlerToken = saksbehandlerToken,
                     )
-                } just Runs
+                } returns mockk<KlageBehandling>(relaxed = true)
             }
 
         withKlageApi(mediator) {
@@ -343,7 +340,7 @@ class KlageApiTest {
             mockk<KlageMediator>().also {
                 every {
                     it.oppdaterKlageOpplysning(klageBehandlingId, opplysningId, tekstListe, TestHelper.saksbehandler)
-                } returns Unit
+                } returns mockk<KlageBehandling>(relaxed = true)
             }
         withKlageApi(mediator) {
             client
@@ -373,7 +370,7 @@ class KlageApiTest {
             mockk<KlageMediator>().also {
                 every {
                     it.oppdaterKlageOpplysning(klageBehandlingId, opplysningId, tekst, TestHelper.saksbehandler)
-                } returns Unit
+                } returns mockk<KlageBehandling>(relaxed = true)
             }
         withKlageApi(mediator) {
             client
@@ -403,7 +400,7 @@ class KlageApiTest {
             mockk<KlageMediator>().also {
                 every {
                     it.oppdaterKlageOpplysning(klageBehandlingId, opplysningId, boolsk, TestHelper.saksbehandler)
-                } returns Unit
+                } returns mockk<KlageBehandling>(relaxed = true)
             }
         withKlageApi(mediator) {
             client
@@ -433,7 +430,7 @@ class KlageApiTest {
             mockk<KlageMediator>().also {
                 every {
                     it.oppdaterKlageOpplysning(klageBehandlingId, opplysningId, dato, TestHelper.saksbehandler)
-                } returns Unit
+                } returns mockk<KlageBehandling>(relaxed = true)
             }
         withKlageApi(mediator) {
             client
@@ -490,6 +487,7 @@ class KlageApiTest {
                     innsendingMediator = mockk(),
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = mockk(relaxed = true),
+                    auditlogg = Auditlogg.NoOp,
                 )
             }
             test()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/KlageApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/KlageApiTest.kt
@@ -473,7 +473,7 @@ class KlageApiTest {
         }
 
     @Test
-    fun `should audit log READ when viewing klagebehandling`() {
+    fun `Skal auditlogge READ ved visning av klagebehandling`() {
         val auditlogg = TestAuditlogg()
         val klageBehandling =
             mockk<KlageBehandling>(relaxed = true).also {
@@ -499,7 +499,7 @@ class KlageApiTest {
     }
 
     @Test
-    fun `should audit log UPDATE when withdrawing klage`() {
+    fun `Skal auditlogge UPDATE ved avbryt av klage`() {
         val auditlogg = TestAuditlogg()
         val klageBehandling =
             mockk<KlageBehandling>(relaxed = true).also {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/KlageApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/KlageApiTest.kt
@@ -1,6 +1,7 @@
 package no.nav.dagpenger.saksbehandling.api
 
 import io.kotest.assertions.json.shouldEqualSpecifiedJsonIgnoringOrder
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.ktor.client.request.get
@@ -18,6 +19,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.dagpenger.aktivitetslogg.AuditOperasjon
 import no.nav.dagpenger.saksbehandling.HendelseBehandler
 import no.nav.dagpenger.saksbehandling.KlageMediator
 import no.nav.dagpenger.saksbehandling.TestHelper
@@ -28,6 +30,7 @@ import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.gyldigSaksbehandl
 import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTO
 import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTOEnhetDTO
 import no.nav.dagpenger.saksbehandling.audit.Auditlogg
+import no.nav.dagpenger.saksbehandling.audit.TestAuditlogg
 import no.nav.dagpenger.saksbehandling.hendelser.AvbruttHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.KlageBehandlingUtført
 import no.nav.dagpenger.saksbehandling.hendelser.KlageMottattHendelse
@@ -469,9 +472,64 @@ class KlageApiTest {
                 )
         }
 
+    @Test
+    fun `should audit log READ when viewing klagebehandling`() {
+        val auditlogg = TestAuditlogg()
+        val klageBehandling =
+            mockk<KlageBehandling>(relaxed = true).also {
+                every { it.behandlingId } returns klageBehandlingId
+                every { it.personIdent() } returns "12345678901"
+            }
+        val mediator =
+            mockk<KlageMediator>().also {
+                every { it.hentKlageBehandling(klageBehandlingId, any()) } returns klageBehandling
+            }
+
+        withKlageApi(mediator, auditlogg = auditlogg) {
+            client.get("klage/$klageBehandlingId") { autentisert() }
+        }
+
+        auditlogg.hendelser shouldHaveSize 1
+        auditlogg.hendelser.first().let {
+            it.operasjon shouldBe AuditOperasjon.READ
+            it.melding shouldBe "Så en klagebehandling"
+            it.ident shouldBe "12345678901"
+            it.saksbehandler shouldBe TestHelper.saksbehandler.navIdent
+        }
+    }
+
+    @Test
+    fun `should audit log UPDATE when withdrawing klage`() {
+        val auditlogg = TestAuditlogg()
+        val klageBehandling =
+            mockk<KlageBehandling>(relaxed = true).also {
+                every { it.personIdent() } returns "12345678901"
+            }
+        val mediator =
+            mockk<KlageMediator>(relaxed = true).also {
+                every { it.avbrytKlage(any()) } returns klageBehandling
+            }
+
+        withKlageApi(mediator, auditlogg = auditlogg) {
+            client.put("klage/$klageBehandlingId/trekk") {
+                autentisert()
+                header(HttpHeaders.ContentType, "application/json")
+                setBody("""{"årsak": "Klagen er trukket"}""")
+            }
+        }
+
+        auditlogg.hendelser shouldHaveSize 1
+        auditlogg.hendelser.first().let {
+            it.operasjon shouldBe AuditOperasjon.UPDATE
+            it.melding shouldBe "Avbrutte en klage"
+            it.ident shouldBe "12345678901"
+        }
+    }
+
     private fun withKlageApi(
         klageMediator: KlageMediator,
         oppslag: Oppslag = oppslagMock,
+        auditlogg: Auditlogg = TestAuditlogg(),
         test: suspend ApplicationTestBuilder.() -> Unit,
     ) {
         testApplication {
@@ -487,7 +545,7 @@ class KlageApiTest {
                     innsendingMediator = mockk(),
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = mockk(relaxed = true),
-                    auditlogg = Auditlogg.NoOp,
+                    auditlogg = auditlogg,
                 )
             }
             test()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/MeldingOmVedtakApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/MeldingOmVedtakApiTest.kt
@@ -17,7 +17,7 @@ import no.nav.dagpenger.saksbehandling.TestHelper
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.autentisert
 import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.gyldigSaksbehandlerToken
-import no.nav.dagpenger.saksbehandling.audit.Auditlogg
+import no.nav.dagpenger.saksbehandling.audit.TestAuditlogg
 import no.nav.dagpenger.saksbehandling.vedtaksmelding.MeldingOmVedtakKlient.KanIkkeLageMeldingOmVedtak
 import org.junit.jupiter.api.Test
 
@@ -247,7 +247,7 @@ class MeldingOmVedtakApiTest {
                     innsendingMediator = mockk(),
                     meldingOmVedtakMediator = meldingOmVedtakMediator,
                     oppfølgingMediator = mockk(relaxed = true),
-                    auditlogg = Auditlogg.NoOp,
+                    auditlogg = TestAuditlogg(),
                 )
             }
             test()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/MeldingOmVedtakApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/MeldingOmVedtakApiTest.kt
@@ -17,6 +17,7 @@ import no.nav.dagpenger.saksbehandling.TestHelper
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.autentisert
 import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.gyldigSaksbehandlerToken
+import no.nav.dagpenger.saksbehandling.audit.Auditlogg
 import no.nav.dagpenger.saksbehandling.vedtaksmelding.MeldingOmVedtakKlient.KanIkkeLageMeldingOmVedtak
 import org.junit.jupiter.api.Test
 
@@ -246,6 +247,7 @@ class MeldingOmVedtakApiTest {
                     innsendingMediator = mockk(),
                     meldingOmVedtakMediator = meldingOmVedtakMediator,
                     oppfølgingMediator = mockk(relaxed = true),
+                    auditlogg = Auditlogg.NoOp,
                 )
             }
             test()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppfølgingApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppfølgingApiTest.kt
@@ -21,6 +21,7 @@ import no.nav.dagpenger.saksbehandling.TestHelper
 import no.nav.dagpenger.saksbehandling.TestHelper.ISO_TIMESTAMP
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.autentisert
+import no.nav.dagpenger.saksbehandling.audit.Auditlogg
 import no.nav.dagpenger.saksbehandling.hendelser.FerdigstillOppfølgingHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.OpprettOppfølgingHendelse
 import no.nav.dagpenger.saksbehandling.oppfolging.Oppfølging
@@ -477,6 +478,7 @@ class OppfølgingApiTest {
                     innsendingMediator = mockk(relaxed = true),
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = oppfølgingMediator,
+                    auditlogg = Auditlogg.NoOp,
                 )
             }
             test()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppfølgingApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppfølgingApiTest.kt
@@ -465,7 +465,7 @@ class OppfølgingApiTest {
     }
 
     @Test
-    fun `should audit log READ when viewing oppfølging`() {
+    fun `Skal auditlogge READ ved visning av oppfølging`() {
         val auditlogg = TestAuditlogg()
         val oppfølging = TestHelper.lagOppfølging()
         val mediator =

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppfølgingApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppfølgingApiTest.kt
@@ -1,6 +1,7 @@
 package no.nav.dagpenger.saksbehandling.api
 
 import io.kotest.assertions.json.shouldEqualSpecifiedJson
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.ktor.client.request.get
@@ -16,12 +17,14 @@ import io.ktor.server.testing.testApplication
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import no.nav.dagpenger.aktivitetslogg.AuditOperasjon
 import no.nav.dagpenger.saksbehandling.Sak
 import no.nav.dagpenger.saksbehandling.TestHelper
 import no.nav.dagpenger.saksbehandling.TestHelper.ISO_TIMESTAMP
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.autentisert
 import no.nav.dagpenger.saksbehandling.audit.Auditlogg
+import no.nav.dagpenger.saksbehandling.audit.TestAuditlogg
 import no.nav.dagpenger.saksbehandling.hendelser.FerdigstillOppfølgingHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.OpprettOppfølgingHendelse
 import no.nav.dagpenger.saksbehandling.oppfolging.Oppfølging
@@ -461,8 +464,32 @@ class OppfølgingApiTest {
         }
     }
 
+    @Test
+    fun `should audit log READ when viewing oppfølging`() {
+        val auditlogg = TestAuditlogg()
+        val oppfølging = TestHelper.lagOppfølging()
+        val mediator =
+            mockk<OppfølgingMediator>().also {
+                every { it.hent(oppfølging.id, any()) } returns oppfølging
+                every { it.hentAlleSaker(any()) } returns emptyList()
+            }
+
+        withOppfølgingApi(mediator, auditlogg = auditlogg) {
+            client.get("oppfolging/${oppfølging.id}") { autentisert() }
+        }
+
+        auditlogg.hendelser shouldHaveSize 1
+        auditlogg.hendelser.first().let {
+            it.operasjon shouldBe AuditOperasjon.READ
+            it.melding shouldBe "Så en oppfølging"
+            it.ident shouldBe oppfølging.person.ident
+            it.saksbehandler shouldBe TestHelper.saksbehandler.navIdent
+        }
+    }
+
     private fun withOppfølgingApi(
         oppfølgingMediator: OppfølgingMediator,
+        auditlogg: Auditlogg = TestAuditlogg(),
         test: suspend ApplicationTestBuilder.() -> Unit,
     ) {
         testApplication {
@@ -478,7 +505,7 @@ class OppfølgingApiTest {
                     innsendingMediator = mockk(relaxed = true),
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = oppfølgingMediator,
-                    auditlogg = Auditlogg.NoOp,
+                    auditlogg = auditlogg,
                 )
             }
             test()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApiTest.kt
@@ -1713,7 +1713,7 @@ class OppgaveApiTest {
     }
 
     @Test
-    fun `should audit log READ when viewing oppgave`() {
+    fun `Skal auditlogge READ ved visning av oppgave`() {
         val auditlogg = TestAuditlogg()
         val oppgaveId = UUIDv7.ny()
         val oppgave =

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApiTest.kt
@@ -3,6 +3,7 @@ package no.nav.dagpenger.saksbehandling.api
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.assertions.json.shouldEqualSpecifiedJson
 import io.kotest.assertions.json.shouldEqualSpecifiedJsonIgnoringOrder
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.ktor.client.request.delete
@@ -26,6 +27,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import no.nav.dagpenger.aktivitetslogg.AuditOperasjon
 import no.nav.dagpenger.saksbehandling.Configuration
 import no.nav.dagpenger.saksbehandling.Emneknagg.AvbrytBehandling.AVBRUTT_ANNET
 import no.nav.dagpenger.saksbehandling.Emneknagg.PåVent.AVVENT_RAPPORTERINGSFRIST
@@ -73,6 +75,7 @@ import no.nav.dagpenger.saksbehandling.api.models.SakDTO
 import no.nav.dagpenger.saksbehandling.api.models.SikkerhetstiltakDTO
 import no.nav.dagpenger.saksbehandling.api.models.UtlostAvTypeDTO
 import no.nav.dagpenger.saksbehandling.api.models.UtsettOppgaveAarsakDTO
+import no.nav.dagpenger.saksbehandling.audit.TestAuditlogg
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
 import no.nav.dagpenger.saksbehandling.db.oppgave.Periode
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
@@ -1706,6 +1709,35 @@ class OppgaveApiTest {
                     "detail" : "Fant ikke person"
                 }"""
                 }
+        }
+    }
+
+    @Test
+    fun `should audit log READ when viewing oppgave`() {
+        val auditlogg = TestAuditlogg()
+        val oppgaveId = UUIDv7.ny()
+        val oppgave =
+            mockk<Oppgave>(relaxed = true).also {
+                every { it.personIdent() } returns "12345678901"
+            }
+        val oppgaveMediator =
+            mockk<OppgaveMediator>(relaxed = true).also {
+                every { it.hentOppgave(oppgaveId, any()) } returns oppgave
+            }
+
+        OppgaveApiTestHelper.withOppgaveApi(
+            oppgaveMediator = oppgaveMediator,
+            auditlogg = auditlogg,
+        ) {
+            client.get("oppgave/$oppgaveId") { autentisert() }
+        }
+
+        auditlogg.hendelser shouldHaveSize 1
+        auditlogg.hendelser.first().let {
+            it.operasjon shouldBe AuditOperasjon.READ
+            it.melding shouldBe "Så en oppgave"
+            it.ident shouldBe "12345678901"
+            it.saksbehandler shouldBe TestHelper.saksbehandler.navIdent
         }
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApiTestHelper.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApiTestHelper.kt
@@ -4,6 +4,7 @@ import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import io.mockk.mockk
 import no.nav.dagpenger.saksbehandling.OppgaveMediator
+import no.nav.dagpenger.saksbehandling.audit.Auditlogg
 import no.nav.dagpenger.saksbehandling.db.oppgave.OppgaveRepository
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.pdl.PDLKlient
@@ -31,6 +32,7 @@ internal object OppgaveApiTestHelper {
                     innsendingMediator = mockk(relaxed = true),
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = mockk(relaxed = true),
+                    auditlogg = Auditlogg.NoOp,
                 )
             }
             test()
@@ -69,6 +71,7 @@ internal object OppgaveApiTestHelper {
                     innsendingMediator = mockk(relaxed = true),
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = mockk(relaxed = true),
+                    auditlogg = Auditlogg.NoOp,
                 )
             }
             test()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApiTestHelper.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApiTestHelper.kt
@@ -5,6 +5,7 @@ import io.ktor.server.testing.testApplication
 import io.mockk.mockk
 import no.nav.dagpenger.saksbehandling.OppgaveMediator
 import no.nav.dagpenger.saksbehandling.audit.Auditlogg
+import no.nav.dagpenger.saksbehandling.audit.TestAuditlogg
 import no.nav.dagpenger.saksbehandling.db.oppgave.OppgaveRepository
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.pdl.PDLKlient
@@ -17,6 +18,7 @@ internal object OppgaveApiTestHelper {
         oppgaveDTOMapper: OppgaveDTOMapper = mockk<OppgaveDTOMapper>(relaxed = true),
         personMediator: PersonMediator = mockk(relaxed = true),
         oppgaveRepository: OppgaveRepository = mockk<OppgaveRepository>(relaxed = true),
+        auditlogg: Auditlogg = TestAuditlogg(),
         test: suspend ApplicationTestBuilder.() -> Unit,
     ) {
         testApplication {
@@ -32,7 +34,7 @@ internal object OppgaveApiTestHelper {
                     innsendingMediator = mockk(relaxed = true),
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = mockk(relaxed = true),
-                    auditlogg = Auditlogg.NoOp,
+                    auditlogg = auditlogg,
                 )
             }
             test()
@@ -46,6 +48,7 @@ internal object OppgaveApiTestHelper {
         saksbehandlerOppslag: SaksbehandlerOppslag = mockk(relaxed = true),
         oppgaveRepository: OppgaveRepository = mockk<OppgaveRepository>(relaxed = true),
         personMediator: PersonMediator = mockk(relaxed = true),
+        auditlogg: Auditlogg = TestAuditlogg(),
         test: suspend ApplicationTestBuilder.() -> Unit,
     ) {
         testApplication {
@@ -71,7 +74,7 @@ internal object OppgaveApiTestHelper {
                     innsendingMediator = mockk(relaxed = true),
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = mockk(relaxed = true),
-                    auditlogg = Auditlogg.NoOp,
+                    auditlogg = auditlogg,
                 )
             }
             test()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/SakApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/SakApiTest.kt
@@ -13,7 +13,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.gyldigMaskinToken
-import no.nav.dagpenger.saksbehandling.audit.Auditlogg
+import no.nav.dagpenger.saksbehandling.audit.TestAuditlogg
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
 import no.nav.dagpenger.saksbehandling.sak.SakMediator
 import org.junit.jupiter.api.Test
@@ -93,7 +93,7 @@ class SakApiTest {
                     innsendingMediator = mockk(),
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = mockk(relaxed = true),
-                    auditlogg = Auditlogg.NoOp,
+                    auditlogg = TestAuditlogg(),
                 )
             }
             test()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/SakApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/SakApiTest.kt
@@ -13,6 +13,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.gyldigMaskinToken
+import no.nav.dagpenger.saksbehandling.audit.Auditlogg
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
 import no.nav.dagpenger.saksbehandling.sak.SakMediator
 import org.junit.jupiter.api.Test
@@ -92,6 +93,7 @@ class SakApiTest {
                     innsendingMediator = mockk(),
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = mockk(relaxed = true),
+                    auditlogg = Auditlogg.NoOp,
                 )
             }
             test()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/StatuspageTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/StatuspageTest.kt
@@ -14,7 +14,7 @@ import no.nav.dagpenger.saksbehandling.Oppgave
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.ManglendeBeslutterTilgang
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.UlovligTilstandsendringException
-import no.nav.dagpenger.saksbehandling.audit.Auditlogg
+import no.nav.dagpenger.saksbehandling.audit.TestAuditlogg
 import no.nav.dagpenger.saksbehandling.behandling.BehandlingException
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
 import no.nav.dagpenger.saksbehandling.klage.Opplysning
@@ -372,7 +372,7 @@ class StatuspageTest {
             innsendingMediator = mockk(),
             meldingOmVedtakMediator = mockk(relaxed = true),
             oppfølgingMediator = mockk(relaxed = true),
-            auditlogg = Auditlogg.NoOp,
+            auditlogg = TestAuditlogg(),
         )
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/StatuspageTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/StatuspageTest.kt
@@ -14,6 +14,7 @@ import no.nav.dagpenger.saksbehandling.Oppgave
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.ManglendeBeslutterTilgang
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.UlovligTilstandsendringException
+import no.nav.dagpenger.saksbehandling.audit.Auditlogg
 import no.nav.dagpenger.saksbehandling.behandling.BehandlingException
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
 import no.nav.dagpenger.saksbehandling.klage.Opplysning
@@ -371,6 +372,7 @@ class StatuspageTest {
             innsendingMediator = mockk(),
             meldingOmVedtakMediator = mockk(relaxed = true),
             oppfølgingMediator = mockk(relaxed = true),
+            auditlogg = Auditlogg.NoOp,
         )
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/audit/TestAuditlogg.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/audit/TestAuditlogg.kt
@@ -1,0 +1,51 @@
+package no.nav.dagpenger.saksbehandling.audit
+
+import no.nav.dagpenger.aktivitetslogg.AuditOperasjon
+
+class TestAuditlogg : Auditlogg {
+    data class Hendelse(
+        val operasjon: AuditOperasjon,
+        val melding: String,
+        val ident: String,
+        val saksbehandler: String,
+    )
+
+    private val _hendelser = mutableListOf<Hendelse>()
+    val hendelser: List<Hendelse> get() = _hendelser.toList()
+
+    override fun les(
+        melding: String,
+        ident: String,
+        saksbehandler: String,
+    ) {
+        _hendelser.add(Hendelse(AuditOperasjon.READ, melding, ident, saksbehandler))
+    }
+
+    override fun opprett(
+        melding: String,
+        ident: String,
+        saksbehandler: String,
+    ) {
+        _hendelser.add(Hendelse(AuditOperasjon.CREATE, melding, ident, saksbehandler))
+    }
+
+    override fun oppdater(
+        melding: String,
+        ident: String,
+        saksbehandler: String,
+    ) {
+        _hendelser.add(Hendelse(AuditOperasjon.UPDATE, melding, ident, saksbehandler))
+    }
+
+    override fun slett(
+        melding: String,
+        ident: String,
+        saksbehandler: String,
+    ) {
+        _hendelser.add(Hendelse(AuditOperasjon.DELETE, melding, ident, saksbehandler))
+    }
+
+    fun reset() {
+        _hendelser.clear()
+    }
+}

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/statistikk/api/StatistikkApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/statistikk/api/StatistikkApiTest.kt
@@ -14,6 +14,7 @@ import no.nav.dagpenger.saksbehandling.api.MockAzure
 import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.autentisert
 import no.nav.dagpenger.saksbehandling.api.installerApis
 import no.nav.dagpenger.saksbehandling.api.mockAzure
+import no.nav.dagpenger.saksbehandling.audit.Auditlogg
 import no.nav.dagpenger.saksbehandling.statistikk.db.AntallOppgaverForRettighet
 import no.nav.dagpenger.saksbehandling.statistikk.db.AntallOppgaverForTilstandOgRettighet
 import no.nav.dagpenger.saksbehandling.statistikk.db.AntallOppgaverForTilstandOgUtløstAv
@@ -44,6 +45,7 @@ class StatistikkApiTest {
                     innsendingMediator = mockk(),
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = mockk(relaxed = true),
+                    auditlogg = Auditlogg.NoOp,
                 )
             }
 
@@ -85,6 +87,7 @@ class StatistikkApiTest {
                     innsendingMediator = mockk(),
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = mockk(relaxed = true),
+                    auditlogg = Auditlogg.NoOp,
                 )
             }
 
@@ -140,6 +143,7 @@ class StatistikkApiTest {
                     innsendingMediator = mockk(),
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = mockk(relaxed = true),
+                    auditlogg = Auditlogg.NoOp,
                 )
             }
 
@@ -255,6 +259,7 @@ class StatistikkApiTest {
                     innsendingMediator = mockk(),
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = mockk(relaxed = true),
+                    auditlogg = Auditlogg.NoOp,
                 )
             }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/statistikk/api/StatistikkApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/statistikk/api/StatistikkApiTest.kt
@@ -14,7 +14,7 @@ import no.nav.dagpenger.saksbehandling.api.MockAzure
 import no.nav.dagpenger.saksbehandling.api.MockAzure.Companion.autentisert
 import no.nav.dagpenger.saksbehandling.api.installerApis
 import no.nav.dagpenger.saksbehandling.api.mockAzure
-import no.nav.dagpenger.saksbehandling.audit.Auditlogg
+import no.nav.dagpenger.saksbehandling.audit.TestAuditlogg
 import no.nav.dagpenger.saksbehandling.statistikk.db.AntallOppgaverForRettighet
 import no.nav.dagpenger.saksbehandling.statistikk.db.AntallOppgaverForTilstandOgRettighet
 import no.nav.dagpenger.saksbehandling.statistikk.db.AntallOppgaverForTilstandOgUtløstAv
@@ -45,7 +45,7 @@ class StatistikkApiTest {
                     innsendingMediator = mockk(),
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = mockk(relaxed = true),
-                    auditlogg = Auditlogg.NoOp,
+                    auditlogg = TestAuditlogg(),
                 )
             }
 
@@ -87,7 +87,7 @@ class StatistikkApiTest {
                     innsendingMediator = mockk(),
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = mockk(relaxed = true),
-                    auditlogg = Auditlogg.NoOp,
+                    auditlogg = TestAuditlogg(),
                 )
             }
 
@@ -143,7 +143,7 @@ class StatistikkApiTest {
                     innsendingMediator = mockk(),
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = mockk(relaxed = true),
-                    auditlogg = Auditlogg.NoOp,
+                    auditlogg = TestAuditlogg(),
                 )
             }
 
@@ -259,7 +259,7 @@ class StatistikkApiTest {
                     innsendingMediator = mockk(),
                     meldingOmVedtakMediator = mockk(relaxed = true),
                     oppfølgingMediator = mockk(relaxed = true),
-                    auditlogg = Auditlogg.NoOp,
+                    auditlogg = TestAuditlogg(),
                 )
             }
 


### PR DESCRIPTION
## Endringer

Flytter audit logging fra mediator-laget til API-laget, i tråd med prinsippet om at auditlogging skal skje «så langt ute som mulig».

### Hva er gjort

- **Fjernet audit logging fra KlageMediator** — metoder returnerer nå `KlageBehandling` i stedet for `Unit`
- **Lagt til audit logging i API-laget** — OppgaveApi, KlageApi, InnsendingApi og OppfølgingApi auditlogger ved oppslag/endring
- **Opprettet `TestAuditlogg`** — in-memory implementasjon i test sources som erstatter `Auditlogg.NoOp`
- **Verifikasjonstester** — sjekker at riktig audit-operasjon logges i KlageApiTest, InnsendingApiTest, OppfølgingApiTest og OppgaveApiTest

### Motivasjon

Audit logging hører hjemme i API-laget fordi det er der saksbehandlerens oppslag faktisk skjer. Mediatorer bør ikke ha ansvar for å vite om konteksten er et brukeroppslag eller en maskinell operasjon.