### PR TITLE
refactor: introduser DatabaseSession og migrer alle repositories

### DIFF
--- a/dokumentasjon/Metrikker.md
+++ b/dokumentasjon/Metrikker.md
@@ -2,6 +2,13 @@
 
 Oversikt over alle Prometheus-metrikker eksponert av dp-saksbehandling.
 
+## Konvensjoner
+
+- **Prefiks**: Alle metrikker skal ha `dp_saksbehandling_`-prefiks
+- **Automatiske labels fra Nais**: Prometheus legger automatisk til `app`, `team` og `namespace` labels på alle metrikker via scrape-konfigurasjonen. Disse trenger ikke registreres i koden.
+- **Navneformat**: `dp_saksbehandling_<domene>_<beskrivelse>_<enhet/type>` (snake_case)
+- **Help-tekst**: Obligatorisk, kort beskrivelse på norsk eller engelsk
+
 ## Forretningsmetrikker
 
 | Metric | Type | Labels | Beskrivelse | Kilde |
@@ -29,14 +36,13 @@ Oversikt over alle Prometheus-metrikker eksponert av dp-saksbehandling.
 
 | Metric | Type | Labels | Beskrivelse | Kilde |
 |--------|------|--------|-------------|-------|
-| `transactions_committed_total` | Counter | — | Totalt antall committede transaksjoner | `DbMetrics` |
-| `transactions_rolledback_total` | Counter | — | Totalt antall rollback-ede transaksjoner | `DbMetrics` |
-| `transaction_duration_seconds` | Histogram | — | Full transaksjonsvarighet inkludert queries og commit | `DbMetrics` |
-| `commit_duration_seconds` | Histogram | — | Tid brukt på selve DB-commit | `DbMetrics` |
-| `active_transactions` | Gauge | — | Antall aktive transaksjoner akkurat nå | `DbMetrics` |
+| `dp_saksbehandling_transactions_committed_total` | Counter | — | Totalt antall committede transaksjoner | `DbMetrics` |
+| `dp_saksbehandling_transactions_rolledback_total` | Counter | — | Totalt antall rollback-ede transaksjoner | `DbMetrics` |
+| `dp_saksbehandling_transaction_duration_seconds` | Histogram | — | Full transaksjonsvarighet inkludert queries og commit | `DbMetrics` |
+| `dp_saksbehandling_commit_duration_seconds` | Histogram | — | Tid brukt på selve DB-commit | `DbMetrics` |
+| `dp_saksbehandling_active_transactions` | Gauge | — | Antall aktive transaksjoner akkurat nå | `DbMetrics` |
 
 ## Merknader
 
 - Forretningsmetrikker oppdateres av `StatistikkJob` som kjører hvert 5. minutt
-- Databasemetrikker mangler `dp_saksbehandling_`-prefiks (teknisk gjeld, lav prioritet)
 - HikariCP eksponerer egne metrikker automatisk via Prometheus-integrasjonen

--- a/dokumentasjon/Metrikker.md
+++ b/dokumentasjon/Metrikker.md
@@ -1,0 +1,42 @@
+# Metrikker
+
+Oversikt over alle Prometheus-metrikker eksponert av dp-saksbehandling.
+
+## Forretningsmetrikker
+
+| Metric | Type | Labels | Beskrivelse | Kilde |
+|--------|------|--------|-------------|-------|
+| `dp_saksbehandling_oppgave_tilstand_gauge` | Gauge | `tilstand` | Antall oppgaver i hver tilstand | `OppgaveTilstandMetrikker` |
+| `dp_saksbehandling_oppgave_tilstand_siste_24_t_gauge` | Gauge | `tilstand` | Antall oppgaver i hver tilstand siste 24t | `OppgaveTilstandSiste24TimerMetrikker` |
+| `dp_saksbehandling_utsending_tilstand_gauge` | Gauge | `tilstand` | Antall utsendinger i hver tilstand | `UtsendingTilstandMetrikker` |
+
+## API-metrikker
+
+| Metric | Type | Labels | Beskrivelse | Kilde |
+|--------|------|--------|-------------|-------|
+| `dp_saksbehandling_oppgave_api_feil` | Counter | `feiltype` | Antall feil kastet i oppgave-APIet | `StatusPages` |
+
+## Integrasjonsmetrikker
+
+| Metric | Type | Labels | Beskrivelse | Kilde |
+|--------|------|--------|-------------|-------|
+| `dp_saksbehandling_skjerming_oppdateringer` | Counter | `status` | Antall oppdateringer av skjermingsstatus | `SkjermingConsumer` |
+| `dp_saksbehandling_adressebeskyttelse_oppdateringer` | Counter | `status` | Antall oppdateringer av adressebeskyttelsestatus | `AdressebeskyttelseConsumer` |
+| `dp_saksbehandling_saksbehandler_oppslag_cache` | Counter | `treff` | Cache-treff på saksbehandleroppslag | `SaksbehandlerOppslag` |
+| `dp_saksbehandling_saksbehandler_oppslag_duration` | Histogram | — | Tid brukt på oppslag av saksbehandler | `SaksbehandlerOppslag` |
+
+## Databasemetrikker
+
+| Metric | Type | Labels | Beskrivelse | Kilde |
+|--------|------|--------|-------------|-------|
+| `transactions_committed_total` | Counter | — | Totalt antall committede transaksjoner | `DbMetrics` |
+| `transactions_rolledback_total` | Counter | — | Totalt antall rollback-ede transaksjoner | `DbMetrics` |
+| `transaction_duration_seconds` | Histogram | — | Full transaksjonsvarighet inkludert queries og commit | `DbMetrics` |
+| `commit_duration_seconds` | Histogram | — | Tid brukt på selve DB-commit | `DbMetrics` |
+| `active_transactions` | Gauge | — | Antall aktive transaksjoner akkurat nå | `DbMetrics` |
+
+## Merknader
+
+- Forretningsmetrikker oppdateres av `StatistikkJob` som kjører hvert 5. minutt
+- Databasemetrikker mangler `dp_saksbehandling_`-prefiks (teknisk gjeld, lav prioritet)
+- HikariCP eksponerer egne metrikker automatisk via Prometheus-integrasjonen

--- a/dokumentasjon/UnitOfWork-hotspots.md
+++ b/dokumentasjon/UnitOfWork-hotspots.md
@@ -1,0 +1,61 @@
+# UnitOfWork — Hotspots for cross-repository transaksjoner
+
+## Bakgrunn
+
+dp-saksbehandling har flere mediator-flows der multiple repositories skrives sekvensielt uten delt
+transaksjon. Hver `repository.lagre(...)` er sin egen transaksjon. Ved feil mellom stegene kan vi
+ende opp med inkonsistent tilstand i databasen.
+
+Mønsteret fra dp-behandling (`PostgresUnitOfWork` + `DatabaseSession`) løser dette ved å sende én
+felles `Session` gjennom alle repo-kall innenfor en transaksjon.
+
+### Designprinsipp
+
+- **Kun lokale DB-writes** i transaksjonen
+- **Ekstern I/O** (HTTP-kall, Kafka publish) **utenfor** transaksjonsgrensen
+- For DB↔event-konsistens: vurder outbox-pattern
+
+---
+
+## Hotspots
+
+### 🔴 Høy risiko — rene DB-writes som kan samles i én transaksjon
+
+| # | Flow | Fil | Repo-kall (sekvensielle) |
+|---|------|-----|--------------------------|
+| 1 | `OppfølgingMediator.taImot()` | `oppfolging/OppfølgingMediator.kt:31` | `sakMediator.lagreBehandling` → `oppfølgingRepo.lagre` → `oppgaveRepo.lagre` |
+| 2 | `InnsendingMediator.taImotEttersendingTilSøknad()` | `innsending/InnsendingMediator.kt:61` | `innsendingRepo.lagre` → `sakMediator.knytt...` → `oppgaveRepo.lagre` |
+| 3 | `InnsendingMediator.taImotInnsendingPåSisteSak()` | `innsending/InnsendingMediator.kt:81` | `innsendingRepo.lagre` → `sakMediator.knytt...` → `oppgaveRepo.lagre` |
+| 4 | `KlageMediator.opprettManuellKlage()` | `KlageMediator.kt:109` | `klageRepo.lagre` → `sakMediator.knyttTilSak` → `oppgaveRepo.lagre` → `oppgaveRepo.lagre` (tildel) |
+| 5 | `KlageMediator.avbrytKlage()` | `KlageMediator.kt:244` | `klageRepo.lagre` → `oppgaveRepo.lagre` (ferdigstill) |
+
+### 🟡 Medium risiko — blander DB-writes med ekstern I/O
+
+| # | Flow | Fil | Repo-kall | Ekstern I/O |
+|---|------|-----|-----------|-------------|
+| 6 | `KlageMediator.opprettKlage()` | `KlageMediator.kt:54` | `klageRepo.lagre` → `sakMediator.knyttTilSak` → Kafka → `oppgaveRepo.lagre` | Kafka publish mellom steg 2 og 3 |
+| 7 | `OppgaveMediator.ferdigstillOppgaveMedUtsending()` | `OppgaveMediator.kt:581` | `utsendingRepo.lagre` → HTTP → `oppgaveRepo.lagre` | HTTP (godkjenn/beslutt). Har manuell kompensering (slett utsending ved feil) |
+| 8 | `KlageMediator.behandlingUtført()` | `KlageMediator.kt:178` | HTTP → `utsendingRepo.lagre` → `klageRepo.lagre` → Kafka | HTTP (brev) + Kafka publish |
+| 9 | `OppfølgingMediator.ferdigstill()` | `oppfolging/OppfølgingMediator.kt:85` | `oppfølgingRepo.lagre` → [HTTP aksjon] → `oppgaveRepo.lagre` → `oppfølgingRepo.lagre` | HTTP (opprett klage/behandling) — bevisst design, mitigert av OppfølgingAlarmJob |
+| 10 | `InnsendingMediator.ferdigstill()` | `innsending/InnsendingMediator.kt:113` | `innsendingRepo.lagre` → [aksjon] → `oppgaveRepo.lagre` → `innsendingRepo.lagre` | Aksjonen kan inneholde HTTP |
+
+### 🟢 Lav risiko — samme repository eller allerede mitigert
+
+| # | Flow | Fil | Beskrivelse |
+|---|------|-----|-------------|
+| 11 | `OppgaveMediator.håndter(VedtakFattet)` | `OppgaveMediator.kt:691` | 2x `oppgaveRepo.lagre` — samme repo, idempotent |
+| 12 | `OppgaveMediator.opprettEllerOppdaterOppgave()` | `OppgaveMediator.kt:197` | Opptil 2x `oppgaveRepo.lagre` — samme repo |
+
+---
+
+## Anbefalt rekkefølge
+
+1. **Innfør infrastruktur**: `DatabaseSession` + `PostgresUnitOfWork` (etter dp-behandling-mønster)
+2. **Migrer 🔴 hotspots**: Rene DB-writes, ingen ekstern I/O — trygt å samle i transaksjon
+3. **Vurder 🟡 hotspots**: For flows med HTTP/Kafka — vurder om DB-delen kan isoleres i transaksjon med I/O utenfor
+4. **Outbox-pattern**: For flows der DB+event-konsistens er kritisk
+
+## Notater
+
+- `OppfølgingMediator.ferdigstill()` har bevisst split-transaksjon (se Oppfølging.md) — mitigert av OppfølgingAlarmJob
+- `ferdigstillOppgaveMedUtsending()` har allerede compensating delete — fungerer, men er sårbar for app-krasj mellom steg 1 og 3

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/ApplicationBuilder.kt
@@ -16,6 +16,7 @@ import no.nav.dagpenger.saksbehandling.api.installerApis
 import no.nav.dagpenger.saksbehandling.audit.ApiAuditlogg
 import no.nav.dagpenger.saksbehandling.behandling.BehandlingHttpKlient
 import no.nav.dagpenger.saksbehandling.db.PostgresDataSourceBuilder.dataSource
+import no.nav.dagpenger.saksbehandling.db.PostgresDataSourceBuilder.databaseSession
 import no.nav.dagpenger.saksbehandling.db.PostgresDataSourceBuilder.runMigration
 import no.nav.dagpenger.saksbehandling.db.innsending.PostgresInnsendingRepository
 import no.nav.dagpenger.saksbehandling.db.klage.PostgresKlageRepository
@@ -84,7 +85,7 @@ import java.util.Timer
 internal class ApplicationBuilder(
     configuration: Map<String, String>,
 ) : RapidsConnection.StatusListener {
-    private val personRepository = PostgresPersonRepository(dataSource)
+    private val personRepository = PostgresPersonRepository(databaseSession)
     private val pdlKlient =
         PDLHttpKlient(
             url = Configuration.pdlUrl,
@@ -105,11 +106,11 @@ internal class ApplicationBuilder(
             .create(
                 env = configuration,
             ) { server: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>, rapid: KafkaRapid ->
-                val oppgaveRepository = PostgresOppgaveRepository(dataSource)
-                val sakRepository = PostgresSakRepository(dataSource = dataSource)
-                val utsendingRepository = PostgresUtsendingRepository(dataSource)
-                val innsendingRepository = PostgresInnsendingRepository(dataSource)
-                val klageRepository = PostgresKlageRepository(dataSource)
+                val oppgaveRepository = PostgresOppgaveRepository(databaseSession)
+                val sakRepository = PostgresSakRepository(databaseSession)
+                val utsendingRepository = PostgresUtsendingRepository(databaseSession)
+                val innsendingRepository = PostgresInnsendingRepository(databaseSession)
+                val klageRepository = PostgresKlageRepository(databaseSession)
 
                 val behandlingKlient =
                     BehandlingHttpKlient(
@@ -188,7 +189,7 @@ internal class ApplicationBuilder(
                     )
                 val oppfølgingMediator =
                     OppfølgingMediator(
-                        oppfølgingRepository = PostgresOppfølgingRepository(dataSource),
+                        oppfølgingRepository = PostgresOppfølgingRepository(databaseSession),
                         oppfølgingBehandler =
                             OppfølgingBehandler(
                                 klageMediator = klageMediator,
@@ -220,7 +221,7 @@ internal class ApplicationBuilder(
                             oppgaveHistorikkDTOMapper = OppgaveHistorikkDTOMapper(oppgaveRepository, saksbehandlerOppslag),
                             sakMediator = sakMediator,
                         ),
-                    produksjonsstatistikkRepository = PostgresProduksjonsstatistikkRepository(dataSource),
+                    produksjonsstatistikkRepository = PostgresProduksjonsstatistikkRepository(databaseSession),
                     klageMediator = klageMediator,
                     klageDTOMapper = KlageDTOMapper(oppslag),
                     personMediator = personMediator,
@@ -352,7 +353,7 @@ internal class ApplicationBuilder(
                 statistikkJob =
                     StatistikkJob(
                         rapidsConnection = rapid,
-                        saksbehandlingsstatistikkRepository = PostgresSaksbehandlingsstatistikkRepository(dataSource),
+                        saksbehandlingsstatistikkRepository = PostgresSaksbehandlingsstatistikkRepository(databaseSession),
                     ).startJob(
                         startAt = now,
                         period = 5.Minutt,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/DatabaseSession.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/DatabaseSession.kt
@@ -25,6 +25,13 @@ data class DatabaseSession(
             }
         }
     }
+
+    fun <R> withTransaction(transactionBlock: PostgresUnitOfWork.() -> R): R =
+        session { session ->
+            session.connection.underlying.withTransaction {
+                transactionBlock(PostgresUnitOfWork(session))
+            }
+        }
 }
 
 private fun <R> Connection.withTransaction(transactionBlock: () -> R): R {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/DatabaseSession.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/DatabaseSession.kt
@@ -18,15 +18,7 @@ data class DatabaseSession(
 ) {
     fun <R> session(block: (Session) -> R): R = sessionOf(dataSource.value).use(block)
 
-    fun transaction(transactionBlock: PostgresUnitOfWork.() -> Unit) {
-        session { session ->
-            session.connection.underlying.withTransaction {
-                PostgresUnitOfWork(session).apply(transactionBlock)
-            }
-        }
-    }
-
-    fun <R> withTransaction(transactionBlock: PostgresUnitOfWork.() -> R): R =
+    fun <R> transaction(transactionBlock: PostgresUnitOfWork.() -> R): R =
         session { session ->
             session.connection.underlying.withTransaction {
                 transactionBlock(PostgresUnitOfWork(session))
@@ -68,11 +60,10 @@ private fun Connection.commitAndCount() {
 }
 
 private fun Connection.rollbackAndCount() {
-    val timer = DbMetrics.transactionDuration.startTimer()
     try {
         rollback()
         DbMetrics.rollbackCounter.inc()
-    } finally {
-        timer.observeDuration()
+    } catch (e: Exception) {
+        dbLogger.error(e) { "Rollback feilet" }
     }
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/DatabaseSession.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/DatabaseSession.kt
@@ -13,7 +13,7 @@ private val dbLogger = KotlinLogging.logger {}
  * Da unngår vi at applikasjonen kobler seg til databasen ved oppstart, før den faktisk trengs
  * (f.eks. i tester eller komponenter som ikke alltid leser/skriver).
  */
-data class DatabaseSession(
+class DatabaseSession(
     private val dataSource: Lazy<DataSource>,
 ) {
     fun <R> session(block: (Session) -> R): R = sessionOf(dataSource.value).use(block)

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/DatabaseSession.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/DatabaseSession.kt
@@ -58,9 +58,10 @@ private fun Connection.handleCommit() {
 
 private fun Connection.handleRollback(t: Throwable) {
     runCatching {
-        dbLogger.error(t) { "Transaksjonen feilet, ruller tilbake" }
-        DbMetrics.rollbackCounter.inc()
         rollback()
+    }.onSuccess {
+        dbLogger.error(t) { "Transaksjonen feilet, rullet tilbake" }
+        DbMetrics.rollbackCounter.inc()
     }.onFailure {
         dbLogger.error(t) { "Rollback feilet" }
     }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/DatabaseSession.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/DatabaseSession.kt
@@ -1,0 +1,71 @@
+package no.nav.dagpenger.saksbehandling.db
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotliquery.Session
+import kotliquery.sessionOf
+import java.sql.Connection
+import javax.sql.DataSource
+
+private val dbLogger = KotlinLogging.logger {}
+
+/**
+ * [dataSource] er [Lazy] slik at vi utsetter oppretting av connection pool til første spørring.
+ * Da unngår vi at applikasjonen kobler seg til databasen ved oppstart, før den faktisk trengs
+ * (f.eks. i tester eller komponenter som ikke alltid leser/skriver).
+ */
+data class DatabaseSession(
+    private val dataSource: Lazy<DataSource>,
+) {
+    fun <R> session(block: (Session) -> R): R = sessionOf(dataSource.value).use(block)
+
+    fun transaction(transactionBlock: PostgresUnitOfWork.() -> Unit) {
+        session { session ->
+            session.connection.underlying.withTransaction {
+                PostgresUnitOfWork(session).apply(transactionBlock)
+            }
+        }
+    }
+}
+
+private fun <R> Connection.withTransaction(transactionBlock: () -> R): R {
+    val transactionTimer = DbMetrics.transactionDuration.startTimer()
+    val previousValue = autoCommit
+    autoCommit = false
+    try {
+        DbMetrics.activeTransactions.inc()
+
+        val result = transactionBlock()
+
+        commitAndCount()
+
+        return result
+    } catch (err: Exception) {
+        rollbackAndCount()
+        dbLogger.error(err) { "Transaksjonen feilet, ruller tilbake" }
+        throw err
+    } finally {
+        autoCommit = previousValue
+        DbMetrics.activeTransactions.dec()
+        transactionTimer.observeDuration()
+    }
+}
+
+private fun Connection.commitAndCount() {
+    val commitTimer = DbMetrics.commitDuration.startTimer()
+    try {
+        commit()
+        DbMetrics.commitCounter.inc()
+    } finally {
+        commitTimer.observeDuration()
+    }
+}
+
+private fun Connection.rollbackAndCount() {
+    val timer = DbMetrics.transactionDuration.startTimer()
+    try {
+        rollback()
+        DbMetrics.rollbackCounter.inc()
+    } finally {
+        timer.observeDuration()
+    }
+}

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/DatabaseSession.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/DatabaseSession.kt
@@ -30,40 +30,38 @@ private fun <R> Connection.withTransaction(transactionBlock: () -> R): R {
     val transactionTimer = DbMetrics.transactionDuration.startTimer()
     val previousValue = autoCommit
     autoCommit = false
-    try {
+    return runCatching {
         DbMetrics.activeTransactions.inc()
-
         val result = transactionBlock()
-
-        commitAndCount()
-
-        return result
-    } catch (err: Exception) {
-        rollbackAndCount()
-        dbLogger.error(err) { "Transaksjonen feilet, ruller tilbake" }
-        throw err
-    } finally {
+        handleCommit()
+        result
+    }.onFailure { e ->
+        handleRollback(e)
+    }.also {
         autoCommit = previousValue
         DbMetrics.activeTransactions.dec()
         transactionTimer.observeDuration()
-    }
+    }.getOrThrow()
 }
 
-private fun Connection.commitAndCount() {
+private fun Connection.handleCommit() {
     val commitTimer = DbMetrics.commitDuration.startTimer()
-    try {
+    runCatching {
         commit()
+    }.onSuccess {
         DbMetrics.commitCounter.inc()
-    } finally {
         commitTimer.observeDuration()
-    }
+    }.onFailure {
+        dbLogger.error(it) { "Commit feilet" }
+    }.getOrThrow()
 }
 
-private fun Connection.rollbackAndCount() {
-    try {
-        rollback()
+private fun Connection.handleRollback(t: Throwable) {
+    runCatching {
+        dbLogger.error(t) { "Transaksjonen feilet, ruller tilbake" }
         DbMetrics.rollbackCounter.inc()
-    } catch (e: Exception) {
-        dbLogger.error(e) { "Rollback feilet" }
+        rollback()
+    }.onFailure {
+        dbLogger.error(t) { "Rollback feilet" }
     }
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/DbMetrics.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/DbMetrics.kt
@@ -5,38 +5,40 @@ import io.prometheus.metrics.core.metrics.Gauge
 import io.prometheus.metrics.core.metrics.Histogram
 
 internal object DbMetrics {
+    private const val PREFIX = "dp_saksbehandling_"
+
     val commitCounter: Counter =
         Counter
             .builder()
-            .name("transactions_committed_total")
+            .name("${PREFIX}transactions_committed_total")
             .help("Total number of committed transactions")
             .register()
 
     val rollbackCounter: Counter =
         Counter
             .builder()
-            .name("transactions_rolledback_total")
+            .name("${PREFIX}transactions_rolledback_total")
             .help("Total number of rolled-back transactions")
             .register()
 
     val transactionDuration: Histogram =
         Histogram
             .builder()
-            .name("transaction_duration_seconds")
+            .name("${PREFIX}transaction_duration_seconds")
             .help("Full transaction duration including queries and commit")
             .register()
 
     val commitDuration: Histogram =
         Histogram
             .builder()
-            .name("commit_duration_seconds")
+            .name("${PREFIX}commit_duration_seconds")
             .help("Time spent in actual DB commit")
             .register()
 
     val activeTransactions: Gauge =
         Gauge
             .builder()
-            .name("active_transactions")
+            .name("${PREFIX}active_transactions")
             .help("Number of active transactions currently open")
             .register()
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/DbMetrics.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/DbMetrics.kt
@@ -1,0 +1,42 @@
+package no.nav.dagpenger.saksbehandling.db
+
+import io.prometheus.metrics.core.metrics.Counter
+import io.prometheus.metrics.core.metrics.Gauge
+import io.prometheus.metrics.core.metrics.Histogram
+
+internal object DbMetrics {
+    val commitCounter: Counter =
+        Counter
+            .builder()
+            .name("transactions_committed_total")
+            .help("Total number of committed transactions")
+            .register()
+
+    val rollbackCounter: Counter =
+        Counter
+            .builder()
+            .name("transactions_rolledback_total")
+            .help("Total number of rolled-back transactions")
+            .register()
+
+    val transactionDuration: Histogram =
+        Histogram
+            .builder()
+            .name("transaction_duration_seconds")
+            .help("Full transaction duration including queries and commit")
+            .register()
+
+    val commitDuration: Histogram =
+        Histogram
+            .builder()
+            .name("commit_duration_seconds")
+            .help("Time spent in actual DB commit")
+            .register()
+
+    val activeTransactions: Gauge =
+        Gauge
+            .builder()
+            .name("active_transactions")
+            .help("Number of active transactions currently open")
+            .register()
+}

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/PostgresDataSourceBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/PostgresDataSourceBuilder.kt
@@ -16,6 +16,8 @@ internal object PostgresDataSourceBuilder {
 
     private fun getOrThrow(key: String): String = getEnv(key) ?: getSystemProperty(key)
 
+    val databaseSession by lazy { DatabaseSession(lazy { dataSource }) }
+
     val dataSource by lazy {
         HikariDataSource().apply {
             dataSourceClassName = "org.postgresql.ds.PGSimpleDataSource"

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/PostgresDataSourceBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/PostgresDataSourceBuilder.kt
@@ -16,7 +16,7 @@ internal object PostgresDataSourceBuilder {
 
     private fun getOrThrow(key: String): String = getEnv(key) ?: getSystemProperty(key)
 
-    val databaseSession by lazy { DatabaseSession(lazy { dataSource }) }
+    val databaseSession = DatabaseSession(lazy { dataSource })
 
     val dataSource by lazy {
         HikariDataSource().apply {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/PostgresUnitOfWork.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/PostgresUnitOfWork.kt
@@ -2,6 +2,6 @@ package no.nav.dagpenger.saksbehandling.db
 
 import kotliquery.Session
 
-data class PostgresUnitOfWork(
+class PostgresUnitOfWork(
     val session: Session,
 )

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/PostgresUnitOfWork.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/PostgresUnitOfWork.kt
@@ -1,0 +1,7 @@
+package no.nav.dagpenger.saksbehandling.db
+
+import kotliquery.Session
+
+data class PostgresUnitOfWork(
+    val session: Session,
+)

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/innsending/PostgresInnsendingRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/innsending/PostgresInnsendingRepository.kt
@@ -3,91 +3,88 @@ package no.nav.dagpenger.saksbehandling.db.innsending
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotliquery.Row
 import kotliquery.queryOf
-import kotliquery.sessionOf
 import no.nav.dagpenger.saksbehandling.AdressebeskyttelseGradering
 import no.nav.dagpenger.saksbehandling.Person
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
 import no.nav.dagpenger.saksbehandling.hendelser.Kategori
 import no.nav.dagpenger.saksbehandling.innsending.Innsending
 import java.util.UUID
-import javax.sql.DataSource
 
 private val logger = KotlinLogging.logger {}
 private val sikkerlogger = KotlinLogging.logger("tjenestekall")
 
 class PostgresInnsendingRepository(
-    private val dataSource: DataSource,
+    private val databaseSession: DatabaseSession,
 ) : InnsendingRepository {
     override fun lagre(innsending: Innsending) {
-        sessionOf(dataSource).use { session ->
-            session.transaction { tx ->
-                val innsendingResultat = innsending.innsendingResultat()
-                tx.run(
-                    queryOf(
-                        //language=PostgreSQL
-                        statement =
-                            """
-                            INSERT INTO innsending_v1 (
-                                id, 
-                                person_id, 
-                                journalpost_id, 
-                                skjema_kode, 
-                                kategori, 
-                                mottatt, 
-                                soknad_id, 
-                                vurdering, 
-                                tilstand, 
-                                resultat_type, 
-                                resultat_behandling_id,
-                                valgt_sak_id
-                            )
-                            VALUES (
-                                :id, 
-                                :person_id, 
-                                :journalpost_id, 
-                                :skjema_kode, 
-                                :kategori, 
-                                :mottatt, 
-                                :soknad_id, 
-                                :vurdering, 
-                                :tilstand, 
-                                :resultat_type, 
-                                :resultat_behandling_id,
-                                :valgt_sak_id
-                            )
-                            ON CONFLICT (id) 
-                            DO UPDATE 
-                            SET vurdering = :vurdering ,
-                             tilstand = :tilstand ,
-                             resultat_type = :resultat_type ,
-                             resultat_behandling_id = :resultat_behandling_id,
-                             valgt_sak_id = :valgt_sak_id
-                            """.trimIndent(),
-                        paramMap =
-                            mapOf(
-                                "id" to innsending.innsendingId,
-                                "person_id" to innsending.person.id,
-                                "journalpost_id" to innsending.journalpostId,
-                                "skjema_kode" to innsending.skjemaKode,
-                                "kategori" to innsending.kategori.name,
-                                "mottatt" to innsending.mottatt,
-                                "soknad_id" to innsending.søknadId,
-                                "vurdering" to innsending.vurdering(),
-                                "tilstand" to innsending.tilstand(),
-                                "valgt_sak_id" to innsending.valgtSakId(),
-                                "resultat_type" to innsendingResultat?.javaClass?.simpleName,
-                                "resultat_behandling_id" to
-                                    when (innsendingResultat) {
-                                        Innsending.InnsendingResultat.Ingen -> null
-                                        is Innsending.InnsendingResultat.Klage -> innsendingResultat.behandlingId
-                                        is Innsending.InnsendingResultat.RettTilDagpenger -> innsendingResultat.behandlingId
-                                        is Innsending.InnsendingResultat.Oppfølging -> innsendingResultat.behandlingId
-                                        null -> null
-                                    },
-                            ),
-                    ).asUpdate,
-                )
-            }
+        databaseSession.transaction {
+            val innsendingResultat = innsending.innsendingResultat()
+            session.run(
+                queryOf(
+                    //language=PostgreSQL
+                    statement =
+                        """
+                        INSERT INTO innsending_v1 (
+                            id, 
+                            person_id, 
+                            journalpost_id, 
+                            skjema_kode, 
+                            kategori, 
+                            mottatt, 
+                            soknad_id, 
+                            vurdering, 
+                            tilstand, 
+                            resultat_type, 
+                            resultat_behandling_id,
+                            valgt_sak_id
+                        )
+                        VALUES (
+                            :id, 
+                            :person_id, 
+                            :journalpost_id, 
+                            :skjema_kode, 
+                            :kategori, 
+                            :mottatt, 
+                            :soknad_id, 
+                            :vurdering, 
+                            :tilstand, 
+                            :resultat_type, 
+                            :resultat_behandling_id,
+                            :valgt_sak_id
+                        )
+                        ON CONFLICT (id) 
+                        DO UPDATE 
+                        SET vurdering = :vurdering ,
+                         tilstand = :tilstand ,
+                         resultat_type = :resultat_type ,
+                         resultat_behandling_id = :resultat_behandling_id,
+                         valgt_sak_id = :valgt_sak_id
+                        """.trimIndent(),
+                    paramMap =
+                        mapOf(
+                            "id" to innsending.innsendingId,
+                            "person_id" to innsending.person.id,
+                            "journalpost_id" to innsending.journalpostId,
+                            "skjema_kode" to innsending.skjemaKode,
+                            "kategori" to innsending.kategori.name,
+                            "mottatt" to innsending.mottatt,
+                            "soknad_id" to innsending.søknadId,
+                            "vurdering" to innsending.vurdering(),
+                            "tilstand" to innsending.tilstand(),
+                            "valgt_sak_id" to innsending.valgtSakId(),
+                            "resultat_type" to innsendingResultat?.javaClass?.simpleName,
+                            "resultat_behandling_id" to
+                                when (innsendingResultat) {
+                                    Innsending.InnsendingResultat.Ingen -> null
+                                    is Innsending.InnsendingResultat.Klage -> innsendingResultat.behandlingId
+                                    is Innsending.InnsendingResultat.RettTilDagpenger -> innsendingResultat.behandlingId
+                                    is Innsending.InnsendingResultat.Oppfølging -> innsendingResultat.behandlingId
+                                    null -> null
+                                },
+                        ),
+                ).asUpdate,
+            )
         }
     }
 
@@ -95,9 +92,9 @@ class PostgresInnsendingRepository(
         finnInnsending(innsendingId)
             ?: throw DataNotFoundException("Kan ikke finne innsending med id $innsendingId")
 
-    override fun finnInnsendingerForPerson(ident: String): List<Innsending> {
-        sessionOf(dataSource).use { session ->
-            return session.run(
+    override fun finnInnsendingerForPerson(ident: String): List<Innsending> =
+        databaseSession.session { session ->
+            session.run(
                 queryOf(
                     //language=PostgreSQL
                     statement =
@@ -130,11 +127,10 @@ class PostgresInnsendingRepository(
                 }.asList,
             )
         }
-    }
 
-    private fun finnInnsending(innsendingId: UUID): Innsending? {
-        sessionOf(dataSource).use { session ->
-            return session.run(
+    private fun finnInnsending(innsendingId: UUID): Innsending? =
+        databaseSession.session { session ->
+            session.run(
                 queryOf(
                     //language=PostgreSQL
                     statement =
@@ -167,7 +163,6 @@ class PostgresInnsendingRepository(
                 }.asSingle,
             )
         }
-    }
 
     private fun Row.innsending(): Innsending =
         Innsending.rehydrer(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/klage/PostgresKlageRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/klage/PostgresKlageRepository.kt
@@ -2,11 +2,11 @@ package no.nav.dagpenger.saksbehandling.db.klage
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotliquery.Row
-import kotliquery.Session
 import kotliquery.queryOf
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.UgyldigTilstandException
 import no.nav.dagpenger.saksbehandling.Tilstandsendring
 import no.nav.dagpenger.saksbehandling.db.DatabaseSession
+import no.nav.dagpenger.saksbehandling.db.PostgresUnitOfWork
 import no.nav.dagpenger.saksbehandling.db.klage.KlageOpplysningerMapper.tilJson
 import no.nav.dagpenger.saksbehandling.db.klage.KlageOpplysningerMapper.tilKlageOpplysninger
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
@@ -34,7 +34,7 @@ class PostgresKlageRepository(
 ) : KlageRepository {
     override fun lagre(klageBehandling: KlageBehandling) {
         databaseSession.transaction {
-            session.lagre(klageBehandling)
+            lagre(klageBehandling)
         }
     }
 
@@ -74,8 +74,8 @@ class PostgresKlageRepository(
         return klageBehandling
     }
 
-    private fun Session.lagre(klageBehandling: KlageBehandling) {
-        run(
+    private fun PostgresUnitOfWork.lagre(klageBehandling: KlageBehandling) {
+        session.run(
             queryOf(
                 //language=PostgreSQL
                 statement =
@@ -108,7 +108,7 @@ class PostgresKlageRepository(
         lagre(behandlingId = klageBehandling.behandlingId, klageinstansVedtak = klageBehandling.klageinstansVedtak())
     }
 
-    private fun Session.lagre(
+    private fun PostgresUnitOfWork.lagre(
         behandlingId: UUID,
         tilstandslogg: KlageTilstandslogg,
     ) {
@@ -117,13 +117,13 @@ class PostgresKlageRepository(
         }
     }
 
-    private fun Session.lagre(
+    private fun PostgresUnitOfWork.lagre(
         behandlingId: UUID,
         klageinstansVedtak: KlageinstansVedtak?,
     ) {
         klageinstansVedtak?.let { _ ->
-            val journalpostIderArray = this.createArrayOf("text", klageinstansVedtak.journalpostIder)
-            this.run(
+            val journalpostIderArray = session.createArrayOf("text", klageinstansVedtak.journalpostIder)
+            session.run(
                 queryOf(
                     //language=PostgreSQL
                     statement =
@@ -147,11 +147,11 @@ class PostgresKlageRepository(
         }
     }
 
-    private fun Session.lagre(
+    private fun PostgresUnitOfWork.lagre(
         behandlingId: UUID,
         tilstandsendring: Tilstandsendring<KlageTilstand.Type>,
     ) {
-        this.run(
+        session.run(
             queryOf(
                 //language=PostgreSQL
                 statement =

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/klage/PostgresKlageRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/klage/PostgresKlageRepository.kt
@@ -2,7 +2,7 @@ package no.nav.dagpenger.saksbehandling.db.klage
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotliquery.Row
-import kotliquery.TransactionalSession
+import kotliquery.Session
 import kotliquery.queryOf
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.UgyldigTilstandException
 import no.nav.dagpenger.saksbehandling.Tilstandsendring
@@ -33,10 +33,8 @@ class PostgresKlageRepository(
     private val databaseSession: DatabaseSession,
 ) : KlageRepository {
     override fun lagre(klageBehandling: KlageBehandling) {
-        databaseSession.session { session ->
-            session.transaction { tx ->
-                tx.lagre(klageBehandling)
-            }
+        databaseSession.transaction {
+            session.lagre(klageBehandling)
         }
     }
 
@@ -76,7 +74,7 @@ class PostgresKlageRepository(
         return klageBehandling
     }
 
-    private fun TransactionalSession.lagre(klageBehandling: KlageBehandling) {
+    private fun Session.lagre(klageBehandling: KlageBehandling) {
         run(
             queryOf(
                 //language=PostgreSQL
@@ -110,7 +108,7 @@ class PostgresKlageRepository(
         lagre(behandlingId = klageBehandling.behandlingId, klageinstansVedtak = klageBehandling.klageinstansVedtak())
     }
 
-    private fun TransactionalSession.lagre(
+    private fun Session.lagre(
         behandlingId: UUID,
         tilstandslogg: KlageTilstandslogg,
     ) {
@@ -119,7 +117,7 @@ class PostgresKlageRepository(
         }
     }
 
-    private fun TransactionalSession.lagre(
+    private fun Session.lagre(
         behandlingId: UUID,
         klageinstansVedtak: KlageinstansVedtak?,
     ) {
@@ -149,7 +147,7 @@ class PostgresKlageRepository(
         }
     }
 
-    private fun TransactionalSession.lagre(
+    private fun Session.lagre(
         behandlingId: UUID,
         tilstandsendring: Tilstandsendring<KlageTilstand.Type>,
     ) {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/klage/PostgresKlageRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/klage/PostgresKlageRepository.kt
@@ -4,9 +4,9 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotliquery.Row
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
-import kotliquery.sessionOf
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.UgyldigTilstandException
 import no.nav.dagpenger.saksbehandling.Tilstandsendring
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.klage.KlageOpplysningerMapper.tilJson
 import no.nav.dagpenger.saksbehandling.db.klage.KlageOpplysningerMapper.tilKlageOpplysninger
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
@@ -25,16 +25,15 @@ import no.nav.dagpenger.saksbehandling.serder.rehydrerHendelse
 import no.nav.dagpenger.saksbehandling.serder.tilJson
 import org.postgresql.util.PGobject
 import java.util.UUID
-import javax.sql.DataSource
 
 private val logger = KotlinLogging.logger {}
 private val sikkerlogger = KotlinLogging.logger("tjenestekall")
 
 class PostgresKlageRepository(
-    private val datasource: DataSource,
+    private val databaseSession: DatabaseSession,
 ) : KlageRepository {
     override fun lagre(klageBehandling: KlageBehandling) {
-        sessionOf(datasource).use { session ->
+        databaseSession.session { session ->
             session.transaction { tx ->
                 tx.lagre(klageBehandling)
             }
@@ -46,7 +45,7 @@ class PostgresKlageRepository(
 
     private fun finnKlageBehandling(behandlingId: UUID): KlageBehandling? {
         val klageBehandling =
-            sessionOf(datasource).use { session ->
+            databaseSession.session { session ->
                 session.run(
                     queryOf(
                         //language=PostgreSQL
@@ -70,7 +69,7 @@ class PostgresKlageRepository(
                             """.trimIndent(),
                         paramMap = mapOf("behandling_id" to behandlingId),
                     ).map { row ->
-                        row.rehydrerKlageBehandling(datasource)
+                        row.rehydrerKlageBehandling(databaseSession)
                     }.asSingle,
                 )
             }
@@ -182,7 +181,7 @@ class PostgresKlageRepository(
         )
     }
 
-    private fun Row.rehydrerKlageBehandling(dataSource: DataSource): KlageBehandling {
+    private fun Row.rehydrerKlageBehandling(databaseSession: DatabaseSession): KlageBehandling {
         val behandlingId = this.uuid("behandling_id")
         val tilstandAsText = this.string("tilstand")
         val tilstand =
@@ -205,7 +204,7 @@ class PostgresKlageRepository(
         val tilstandslogg =
             hentKlageTilstandslogg(
                 behandlingId = behandlingId,
-                dataSource = dataSource,
+                databaseSession = databaseSession,
             )
         val opprettet = this.localDateTime("opprettet")
         val kavVedtak = this.kaVedtakOrNull()
@@ -245,9 +244,9 @@ class PostgresKlageRepository(
 
     private fun hentKlageTilstandslogg(
         behandlingId: UUID,
-        dataSource: DataSource,
+        databaseSession: DatabaseSession,
     ): KlageTilstandslogg =
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             session
                 .run(
                     queryOf(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppfolging/PostgresOppfølgingRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppfolging/PostgresOppfølgingRepository.kt
@@ -2,100 +2,97 @@ package no.nav.dagpenger.saksbehandling.db.oppfolging
 
 import kotliquery.Row
 import kotliquery.queryOf
-import kotliquery.sessionOf
 import no.nav.dagpenger.saksbehandling.AdressebeskyttelseGradering
 import no.nav.dagpenger.saksbehandling.Person
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
 import no.nav.dagpenger.saksbehandling.oppfolging.Oppfølging
 import no.nav.dagpenger.saksbehandling.serder.objectMapper
 import java.util.UUID
-import javax.sql.DataSource
 
 class PostgresOppfølgingRepository(
-    private val dataSource: DataSource,
+    private val databaseSession: DatabaseSession,
 ) : OppfølgingRepository {
     override fun lagre(oppfølging: Oppfølging) {
-        sessionOf(dataSource).use { session ->
-            session.transaction { tx ->
-                val resultat = oppfølging.resultat()
-                tx.run(
-                    queryOf(
-                        //language=PostgreSQL
-                        statement =
-                            """
-                            INSERT INTO oppfolging_v1 (
-                                id, 
-                                person_id, 
-                                tittel, 
-                                beskrivelse,
-                                strukturert_data,
-                                frist,
-                                opprettet, 
-                                tilstand, 
-                                vurdering,
-                                resultat_type, 
-                                resultat_behandling_id,
-                                valgt_sak_id
-                            )
-                            VALUES (
-                                :id, 
-                                :person_id, 
-                                :tittel, 
-                                :beskrivelse,
-                                :strukturert_data::jsonb,
-                                :frist,
-                                :opprettet, 
-                                :tilstand, 
-                                :vurdering,
-                                :resultat_type, 
-                                :resultat_behandling_id,
-                                :valgt_sak_id
-                            )
-                            ON CONFLICT (id) 
-                            DO UPDATE 
-                            SET tilstand = :tilstand,
-                                vurdering = :vurdering,
-                                resultat_type = :resultat_type,
-                                resultat_behandling_id = :resultat_behandling_id,
-                                valgt_sak_id = :valgt_sak_id
-                            """.trimIndent(),
-                        paramMap =
-                            mapOf(
-                                "id" to oppfølging.id,
-                                "person_id" to oppfølging.person.id,
-                                "tittel" to oppfølging.tittel,
-                                "beskrivelse" to oppfølging.beskrivelse,
-                                "strukturert_data" to
-                                    if (oppfølging.strukturertData.isEmpty()) {
-                                        null
-                                    } else {
-                                        objectMapper.writeValueAsString(oppfølging.strukturertData)
-                                    },
-                                "frist" to oppfølging.frist,
-                                "opprettet" to oppfølging.opprettet,
-                                "tilstand" to oppfølging.tilstand(),
-                                "vurdering" to oppfølging.vurdering(),
-                                "valgt_sak_id" to oppfølging.valgtSakId(),
-                                "resultat_type" to resultat.javaClass.simpleName,
-                                "resultat_behandling_id" to
-                                    when (resultat) {
-                                        Oppfølging.Resultat.Ingen -> null
-                                        is Oppfølging.Resultat.Klage -> resultat.behandlingId
-                                        is Oppfølging.Resultat.RettTilDagpenger -> resultat.behandlingId
-                                        is Oppfølging.Resultat.Oppfølging -> resultat.behandlingId
-                                    },
-                            ),
-                    ).asUpdate,
-                )
-            }
+        databaseSession.transaction {
+            val resultat = oppfølging.resultat()
+            session.run(
+                queryOf(
+                    //language=PostgreSQL
+                    statement =
+                        """
+                        INSERT INTO oppfolging_v1 (
+                            id, 
+                            person_id, 
+                            tittel, 
+                            beskrivelse,
+                            strukturert_data,
+                            frist,
+                            opprettet, 
+                            tilstand, 
+                            vurdering,
+                            resultat_type, 
+                            resultat_behandling_id,
+                            valgt_sak_id
+                        )
+                        VALUES (
+                            :id, 
+                            :person_id, 
+                            :tittel, 
+                            :beskrivelse,
+                            :strukturert_data::jsonb,
+                            :frist,
+                            :opprettet, 
+                            :tilstand, 
+                            :vurdering,
+                            :resultat_type, 
+                            :resultat_behandling_id,
+                            :valgt_sak_id
+                        )
+                        ON CONFLICT (id) 
+                        DO UPDATE 
+                        SET tilstand = :tilstand,
+                            vurdering = :vurdering,
+                            resultat_type = :resultat_type,
+                            resultat_behandling_id = :resultat_behandling_id,
+                            valgt_sak_id = :valgt_sak_id
+                        """.trimIndent(),
+                    paramMap =
+                        mapOf(
+                            "id" to oppfølging.id,
+                            "person_id" to oppfølging.person.id,
+                            "tittel" to oppfølging.tittel,
+                            "beskrivelse" to oppfølging.beskrivelse,
+                            "strukturert_data" to
+                                if (oppfølging.strukturertData.isEmpty()) {
+                                    null
+                                } else {
+                                    objectMapper.writeValueAsString(oppfølging.strukturertData)
+                                },
+                            "frist" to oppfølging.frist,
+                            "opprettet" to oppfølging.opprettet,
+                            "tilstand" to oppfølging.tilstand(),
+                            "vurdering" to oppfølging.vurdering(),
+                            "valgt_sak_id" to oppfølging.valgtSakId(),
+                            "resultat_type" to resultat.javaClass.simpleName,
+                            "resultat_behandling_id" to
+                                when (resultat) {
+                                    Oppfølging.Resultat.Ingen -> null
+                                    is Oppfølging.Resultat.Klage -> resultat.behandlingId
+                                    is Oppfølging.Resultat.RettTilDagpenger -> resultat.behandlingId
+                                    is Oppfølging.Resultat.Oppfølging -> resultat.behandlingId
+                                },
+                        ),
+                ).asUpdate,
+            )
         }
     }
 
     override fun hent(id: UUID): Oppfølging = finn(id) ?: throw DataNotFoundException("Kan ikke finne oppfølging med id $id")
 
-    override fun finn(id: UUID): Oppfølging? {
-        sessionOf(dataSource).use { session ->
-            return session.run(
+    override fun finn(id: UUID): Oppfølging? =
+        databaseSession.session { session ->
+            session.run(
                 queryOf(
                     //language=PostgreSQL
                     statement =
@@ -123,11 +120,10 @@ class PostgresOppfølgingRepository(
                 ).map { row -> row.oppfølging() }.asSingle,
             )
         }
-    }
 
-    override fun finnForPerson(ident: String): List<Oppfølging> {
-        sessionOf(dataSource).use { session ->
-            return session.run(
+    override fun finnForPerson(ident: String): List<Oppfølging> =
+        databaseSession.session { session ->
+            session.run(
                 queryOf(
                     //language=PostgreSQL
                     statement =
@@ -155,7 +151,6 @@ class PostgresOppfølgingRepository(
                 ).map { row -> row.oppfølging() }.asList,
             )
         }
-    }
 
     @Suppress("UNCHECKED_CAST")
     private fun Row.oppfølging(): Oppfølging =

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
@@ -66,7 +66,7 @@ class PostgresOppgaveRepository(
         nesteOppgaveHendelse: NesteOppgaveHendelse,
         filter: TildelNesteOppgaveFilter,
     ): UUID? =
-        databaseSession.withTransaction {
+        databaseSession.transaction {
             val tillatteGraderinger = filter.adressebeskyttelseTilganger.joinToString { "'$it'" }
             val utløstAvTyperAsText = filter.utløstAvTyper.joinToString { "'${it.name}'" }
             val tilstanderAsText = filter.tilstander.joinToString { "'$it'" }
@@ -102,6 +102,7 @@ class PostgresOppgaveRepository(
                             }
                         categoryConditions.joinToString(" ")
                     }
+
                     else -> ""
                 }
 
@@ -323,7 +324,7 @@ class PostgresOppgaveRepository(
         when (val notat = oppgave.tilstand().notat()) {
             null -> throw IllegalStateException("Kan ikke lagre notat for oppgave uten notat")
             else -> {
-                databaseSession.withTransaction {
+                databaseSession.transaction {
                     lagreNotat(
                         notatId = notat.notatId,
                         tilstandsendringId = oppgave.tilstandslogg.first().id,
@@ -337,7 +338,7 @@ class PostgresOppgaveRepository(
     override fun slettNotatFor(oppgave: Oppgave) {
         val tilstandsloggId = oppgave.tilstandslogg.first().id
 
-        databaseSession.session { session ->
+        databaseSession.transaction {
             session.run(
                 queryOf(
                     //language=PostgreSQL

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
@@ -2,7 +2,6 @@ package no.nav.dagpenger.saksbehandling.db.oppgave
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotliquery.Row
-import kotliquery.Session
 import kotliquery.queryOf
 import no.nav.dagpenger.saksbehandling.AdressebeskyttelseGradering
 import no.nav.dagpenger.saksbehandling.Behandling
@@ -38,6 +37,7 @@ import no.nav.dagpenger.saksbehandling.OppgaveTilstandslogg
 import no.nav.dagpenger.saksbehandling.Person
 import no.nav.dagpenger.saksbehandling.Tilstandsendring
 import no.nav.dagpenger.saksbehandling.db.DatabaseSession
+import no.nav.dagpenger.saksbehandling.db.PostgresUnitOfWork
 import no.nav.dagpenger.saksbehandling.db.oppgave.Periode.Companion.UBEGRENSET_PERIODE
 import no.nav.dagpenger.saksbehandling.hendelser.Hendelse
 import no.nav.dagpenger.saksbehandling.hendelser.NesteOppgaveHendelse
@@ -221,7 +221,7 @@ class PostgresOppgaveRepository(
                     }.asSingle,
                 )
             oppgaveIdOgTilstandType?.let {
-                session.lagre(
+                lagre(
                     it.first,
                     Tilstandsendring(
                         tilstand = it.second,
@@ -234,7 +234,7 @@ class PostgresOppgaveRepository(
 
     override fun lagre(oppgave: Oppgave) {
         databaseSession.transaction {
-            session.lagre(oppgave)
+            lagre(oppgave)
         }
     }
 
@@ -323,8 +323,8 @@ class PostgresOppgaveRepository(
         when (val notat = oppgave.tilstand().notat()) {
             null -> throw IllegalStateException("Kan ikke lagre notat for oppgave uten notat")
             else -> {
-                databaseSession.session { session ->
-                    session.lagreNotat(
+                databaseSession.withTransaction {
+                    lagreNotat(
                         notatId = notat.notatId,
                         tilstandsendringId = oppgave.tilstandslogg.first().id,
                         tekst = notat.hentTekst(),
@@ -686,8 +686,8 @@ private fun hentTilstandsloggForOppgave(
             ).let { OppgaveTilstandslogg(it) }
     }
 
-private fun Session.lagre(oppgave: Oppgave) {
-    run(
+private fun PostgresUnitOfWork.lagre(oppgave: Oppgave) {
+    session.run(
         queryOf(
             //language=PostgreSQL
             statement =
@@ -746,13 +746,13 @@ private fun Session.lagre(oppgave: Oppgave) {
     }
 }
 
-private fun Session.lagreNotat(
+private fun PostgresUnitOfWork.lagreNotat(
     notatId: UUID,
     tilstandsendringId: UUID,
     tekst: String,
     skrevetAv: String,
 ): LocalDateTime =
-    run(
+    session.run(
         queryOf(
             //language=PostgreSQL
             statement =
@@ -776,11 +776,11 @@ private fun Session.lagreNotat(
         "Kunne ikke lagre notat for tilstandsendringId: $tilstandsendringId",
     )
 
-private fun Session.lagre(
+private fun PostgresUnitOfWork.lagre(
     oppgaveId: UUID,
     emneknagger: Set<String>,
 ) {
-    run(
+    session.run(
         queryOf(
             //language=PostgreSQL
             statement =
@@ -793,7 +793,7 @@ private fun Session.lagre(
         ).asUpdate,
     )
     emneknagger.forEach { emneknagg ->
-        run(
+        session.run(
             queryOf(
                 //language=PostgreSQL
                 statement =
@@ -810,11 +810,11 @@ private fun Session.lagre(
     }
 }
 
-private fun Session.lagre(
+private fun PostgresUnitOfWork.lagre(
     oppgaveId: UUID,
     tilstandsendring: Tilstandsendring<Type>,
 ) {
-    this.run(
+    session.run(
         queryOf(
             //language=PostgreSQL
             statement =
@@ -842,7 +842,7 @@ private fun Session.lagre(
     )
 }
 
-private fun Session.lagre(
+private fun PostgresUnitOfWork.lagre(
     oppgaveId: UUID,
     tilstandslogg: OppgaveTilstandslogg,
 ) {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
@@ -339,13 +339,7 @@ class PostgresOppgaveRepository(
         val tilstandsloggId = oppgave.tilstandslogg.first().id
 
         databaseSession.transaction {
-            session.run(
-                queryOf(
-                    //language=PostgreSQL
-                    statement = "DELETE FROM notat_v1 WHERE oppgave_tilstand_logg_id = :oppgave_tilstand_logg_id",
-                    paramMap = mapOf("oppgave_tilstand_logg_id" to tilstandsloggId),
-                ).asUpdate,
-            )
+            slettNotat(tilstandsloggId)
         }
     }
 
@@ -776,6 +770,16 @@ private fun PostgresUnitOfWork.lagreNotat(
     ) ?: throw KanIkkeLagreNotatException(
         "Kunne ikke lagre notat for tilstandsendringId: $tilstandsendringId",
     )
+
+private fun PostgresUnitOfWork.slettNotat(tilstandsloggId: UUID) {
+    session.run(
+        queryOf(
+            //language=PostgreSQL
+            statement = "DELETE FROM notat_v1 WHERE oppgave_tilstand_logg_id = :oppgave_tilstand_logg_id",
+            paramMap = mapOf("oppgave_tilstand_logg_id" to tilstandsloggId),
+        ).asUpdate,
+    )
+}
 
 private fun PostgresUnitOfWork.lagre(
     oppgaveId: UUID,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
@@ -3,7 +3,6 @@ package no.nav.dagpenger.saksbehandling.db.oppgave
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotliquery.Row
 import kotliquery.Session
-import kotliquery.TransactionalSession
 import kotliquery.queryOf
 import no.nav.dagpenger.saksbehandling.AdressebeskyttelseGradering
 import no.nav.dagpenger.saksbehandling.Behandling
@@ -67,59 +66,58 @@ class PostgresOppgaveRepository(
         nesteOppgaveHendelse: NesteOppgaveHendelse,
         filter: TildelNesteOppgaveFilter,
     ): UUID? =
-        databaseSession.session { session ->
-            session.transaction { tx ->
-                val tillatteGraderinger = filter.adressebeskyttelseTilganger.joinToString { "'$it'" }
-                val utløstAvTyperAsText = filter.utløstAvTyper.joinToString { "'${it.name}'" }
-                val tilstanderAsText = filter.tilstander.joinToString { "'$it'" }
-                val utløstAvTypeClause =
-                    if (filter.utløstAvTyper.isNotEmpty()) {
-                        " AND beha.utlost_av IN ($utløstAvTyperAsText) "
-                    } else {
-                        ""
+        databaseSession.withTransaction {
+            val tillatteGraderinger = filter.adressebeskyttelseTilganger.joinToString { "'$it'" }
+            val utløstAvTyperAsText = filter.utløstAvTyper.joinToString { "'${it.name}'" }
+            val tilstanderAsText = filter.tilstander.joinToString { "'$it'" }
+            val utløstAvTypeClause =
+                if (filter.utløstAvTyper.isNotEmpty()) {
+                    " AND beha.utlost_av IN ($utløstAvTyperAsText) "
+                } else {
+                    ""
+                }
+            val tilstandClause =
+                if (filter.tilstander.isNotEmpty()) {
+                    " AND oppg.tilstand IN ($tilstanderAsText) "
+                } else {
+                    ""
+                }
+
+            // language=SQL
+            val emneknaggClause =
+                when {
+                    filter.emneknaggGruppertPerKategori.isNotEmpty() -> {
+                        // AND mellom kategorier, OR innenfor samme kategori
+                        val categoryConditions =
+                            filter.emneknaggGruppertPerKategori.map { (_, emneknagger) ->
+                                val emneknaggList = emneknagger.joinToString { "'$it'" }
+                                """
+                                AND EXISTS(
+                                    SELECT 1
+                                    FROM   emneknagg_v1 emne
+                                    WHERE  emne.oppgave_id = oppg.id
+                                    AND    emne.emneknagg IN ($emneknaggList)
+                                )
+                                """.trimIndent()
+                            }
+                        categoryConditions.joinToString(" ")
                     }
-                val tilstandClause =
-                    if (filter.tilstander.isNotEmpty()) {
-                        " AND oppg.tilstand IN ($tilstanderAsText) "
-                    } else {
-                        ""
-                    }
+                    else -> ""
+                }
 
-                // language=SQL
-                val emneknaggClause =
-                    when {
-                        filter.emneknaggGruppertPerKategori.isNotEmpty() -> {
-                            // AND mellom kategorier, OR innenfor samme kategori
-                            val categoryConditions =
-                                filter.emneknaggGruppertPerKategori.map { (_, emneknagger) ->
-                                    val emneknaggList = emneknagger.joinToString { "'$it'" }
-                                    """
-                                    AND EXISTS(
-                                        SELECT 1
-                                        FROM   emneknagg_v1 emne
-                                        WHERE  emne.oppgave_id = oppg.id
-                                        AND    emne.emneknagg IN ($emneknaggList)
-                                    )
-                                    """.trimIndent()
-                                }
-                            categoryConditions.joinToString(" ")
-                        }
-                        else -> ""
-                    }
+            // Oppdaterer saksbehandler_ident og tilstand avhengig av om oppgaven som hentes som neste er klar til
+            // behandling eller klar til kontroll. Pålogget saksbehandler må ha rettighet til aktuell oppgave.
+            // Det sjekkes derfor mot tilganger i utplukket.
 
-                // Oppdaterer saksbehandler_ident og tilstand avhengig av om oppgaven som hentes som neste er klar til
-                // behandling eller klar til kontroll. Pålogget saksbehandler må ha rettighet til aktuell oppgave.
-                // Det sjekkes derfor mot tilganger i utplukket.
+            // language=SQL
+            val withStatement =
+                """
+                WITH neste_oppgave AS ( WITH alle_oppgaver AS (
+                """.trimIndent()
 
-                // language=SQL
-                val withStatement =
-                    """
-                    WITH neste_oppgave AS ( WITH alle_oppgaver AS (
-                    """.trimIndent()
-
-                // language=SQL
-                val selectKlarTilBehandlingOppgaver =
-                    """
+            // language=SQL
+            val selectKlarTilBehandlingOppgaver =
+                """
                     SELECT   oppg.*
                     FROM     oppgave_v1    oppg
                     JOIN     behandling_v1 beha ON beha.id = oppg.behandling_id
@@ -133,12 +131,12 @@ class PostgresOppgaveRepository(
                     AND      pers.adressebeskyttelse_gradering IN ($tillatteGraderinger)
                     """ + utløstAvTypeClause + tilstandClause + emneknaggClause
 
-                // language=SQL
-                val unionAll = """UNION ALL"""
+            // language=SQL
+            val unionAll = """UNION ALL"""
 
-                // language=SQL
-                val selectKlarTilKontrollOppgaver =
-                    """
+            // language=SQL
+            val selectKlarTilKontrollOppgaver =
+                """
                     SELECT  oppg.*
                     FROM    oppgave_v1    oppg
                     JOIN    behandling_v1 beha ON beha.id = oppg.behandling_id
@@ -167,23 +165,23 @@ class PostgresOppgaveRepository(
                     AND     pers.adressebeskyttelse_gradering IN ($tillatteGraderinger) 
                     AND     logg.hendelse->'utførtAv'->>'navIdent'::text != :navIdent
                 """ + utløstAvTypeClause + tilstandClause + emneknaggClause +
-                        """
-                        )
-                        """.trimIndent()
-
-                // language=SQL
-                val selectAlleAktuelleOppgaverOrderByOpprettet =
                     """
-                        SELECT *
-                        FROM   alle_oppgaver alop
-                        ORDER BY alop.opprettet, alop.id
-                        FETCH FIRST 1 ROWS ONLY
                     )
                     """.trimIndent()
 
-                // language=SQL
-                val updateNesteOppgave =
-                    """
+            // language=SQL
+            val selectAlleAktuelleOppgaverOrderByOpprettet =
+                """
+                    SELECT *
+                    FROM   alle_oppgaver alop
+                    ORDER BY alop.opprettet, alop.id
+                    FETCH FIRST 1 ROWS ONLY
+                )
+                """.trimIndent()
+
+            // language=SQL
+            val updateNesteOppgave =
+                """
                 UPDATE oppgave_v1 oppu
                 SET    saksbehandler_ident = :saksbehandler_ident
                      , tilstand            = CASE oppu.tilstand
@@ -194,52 +192,49 @@ class PostgresOppgaveRepository(
                 WHERE next.id = oppu.id
                 RETURNING *
                 """
-                val statement =
-                    withStatement +
-                        selectKlarTilBehandlingOppgaver +
-                        unionAll +
-                        selectKlarTilKontrollOppgaver +
-                        selectAlleAktuelleOppgaverOrderByOpprettet +
-                        updateNesteOppgave
+            val statement =
+                withStatement +
+                    selectKlarTilBehandlingOppgaver +
+                    unionAll +
+                    selectKlarTilKontrollOppgaver +
+                    selectAlleAktuelleOppgaverOrderByOpprettet +
+                    updateNesteOppgave
 
-                sikkerlogger.info { "Henter oppgaver med SQL i tildelNesteOppgave: $statement - Filter = $filter" }
+            sikkerlogger.info { "Henter oppgaver med SQL i tildelNesteOppgave: $statement - Filter = $filter" }
 
-                val oppgaveIdOgTilstandType: Pair<UUID, Type>? =
-                    tx.run(
-                        queryOf(
-                            statement = statement,
-                            paramMap =
-                                mapOf(
-                                    "saksbehandler_ident" to nesteOppgaveHendelse.ansvarligIdent,
-                                    "fom" to filter.periode.fom,
-                                    "tom_pluss_1_dag" to filter.periode.tom.plusDays(1),
-                                    "har_tilgang_til_egne_ansatte" to filter.egneAnsatteTilgang,
-                                    "har_beslutter_rolle" to filter.harBeslutterRolle,
-                                    "navIdent" to filter.navIdent,
-                                ),
-                        ).map { row ->
-                            val tilstandType = Type.valueOf(row.string("tilstand"))
-                            Pair(row.uuid("id"), tilstandType)
-                        }.asSingle,
-                    )
-                oppgaveIdOgTilstandType?.let {
-                    tx.lagre(
-                        it.first,
-                        Tilstandsendring(
-                            tilstand = it.second,
-                            hendelse = nesteOppgaveHendelse,
-                        ),
-                    )
-                }
-                oppgaveIdOgTilstandType?.first
+            val oppgaveIdOgTilstandType: Pair<UUID, Type>? =
+                session.run(
+                    queryOf(
+                        statement = statement,
+                        paramMap =
+                            mapOf(
+                                "saksbehandler_ident" to nesteOppgaveHendelse.ansvarligIdent,
+                                "fom" to filter.periode.fom,
+                                "tom_pluss_1_dag" to filter.periode.tom.plusDays(1),
+                                "har_tilgang_til_egne_ansatte" to filter.egneAnsatteTilgang,
+                                "har_beslutter_rolle" to filter.harBeslutterRolle,
+                                "navIdent" to filter.navIdent,
+                            ),
+                    ).map { row ->
+                        val tilstandType = Type.valueOf(row.string("tilstand"))
+                        Pair(row.uuid("id"), tilstandType)
+                    }.asSingle,
+                )
+            oppgaveIdOgTilstandType?.let {
+                session.lagre(
+                    it.first,
+                    Tilstandsendring(
+                        tilstand = it.second,
+                        hendelse = nesteOppgaveHendelse,
+                    ),
+                )
             }
+            oppgaveIdOgTilstandType?.first
         }
 
     override fun lagre(oppgave: Oppgave) {
-        databaseSession.session { session ->
-            session.transaction { tx ->
-                tx.lagre(oppgave)
-            }
+        databaseSession.transaction {
+            session.lagre(oppgave)
         }
     }
 
@@ -691,7 +686,7 @@ private fun hentTilstandsloggForOppgave(
             ).let { OppgaveTilstandslogg(it) }
     }
 
-private fun TransactionalSession.lagre(oppgave: Oppgave) {
+private fun Session.lagre(oppgave: Oppgave) {
     run(
         queryOf(
             //language=PostgreSQL
@@ -781,7 +776,7 @@ private fun Session.lagreNotat(
         "Kunne ikke lagre notat for tilstandsendringId: $tilstandsendringId",
     )
 
-private fun TransactionalSession.lagre(
+private fun Session.lagre(
     oppgaveId: UUID,
     emneknagger: Set<String>,
 ) {
@@ -815,7 +810,7 @@ private fun TransactionalSession.lagre(
     }
 }
 
-private fun TransactionalSession.lagre(
+private fun Session.lagre(
     oppgaveId: UUID,
     tilstandsendring: Tilstandsendring<Type>,
 ) {
@@ -847,7 +842,7 @@ private fun TransactionalSession.lagre(
     )
 }
 
-private fun TransactionalSession.lagre(
+private fun Session.lagre(
     oppgaveId: UUID,
     tilstandslogg: OppgaveTilstandslogg,
 ) {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
@@ -5,7 +5,6 @@ import kotliquery.Row
 import kotliquery.Session
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
-import kotliquery.sessionOf
 import no.nav.dagpenger.saksbehandling.AdressebeskyttelseGradering
 import no.nav.dagpenger.saksbehandling.Behandling
 import no.nav.dagpenger.saksbehandling.HendelseBehandler
@@ -39,6 +38,7 @@ import no.nav.dagpenger.saksbehandling.Oppgave.UnderKontroll
 import no.nav.dagpenger.saksbehandling.OppgaveTilstandslogg
 import no.nav.dagpenger.saksbehandling.Person
 import no.nav.dagpenger.saksbehandling.Tilstandsendring
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.oppgave.Periode.Companion.UBEGRENSET_PERIODE
 import no.nav.dagpenger.saksbehandling.hendelser.Hendelse
 import no.nav.dagpenger.saksbehandling.hendelser.NesteOppgaveHendelse
@@ -48,13 +48,12 @@ import org.postgresql.util.PGobject
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
-import javax.sql.DataSource
 
 private val logger = KotlinLogging.logger {}
 private val sikkerlogger = KotlinLogging.logger("tjenestekall")
 
 class PostgresOppgaveRepository(
-    private val dataSource: DataSource,
+    private val databaseSession: DatabaseSession,
 ) : OppgaveRepository {
     override fun tildelOgHentNesteOppgave(
         nesteOppgaveHendelse: NesteOppgaveHendelse,
@@ -68,7 +67,7 @@ class PostgresOppgaveRepository(
         nesteOppgaveHendelse: NesteOppgaveHendelse,
         filter: TildelNesteOppgaveFilter,
     ): UUID? =
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             session.transaction { tx ->
                 val tillatteGraderinger = filter.adressebeskyttelseTilganger.joinToString { "'$it'" }
                 val utløstAvTyperAsText = filter.utløstAvTyper.joinToString { "'${it.name}'" }
@@ -237,7 +236,7 @@ class PostgresOppgaveRepository(
         }
 
     override fun lagre(oppgave: Oppgave) {
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             session.transaction { tx ->
                 tx.lagre(oppgave)
             }
@@ -255,7 +254,7 @@ class PostgresOppgaveRepository(
         ).oppgaver
 
     override fun hentOppgaveIdFor(behandlingId: UUID): UUID? =
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -286,7 +285,7 @@ class PostgresOppgaveRepository(
         ).oppgaver.singleOrNull()
 
     override fun personSkjermesSomEgneAnsatte(oppgaveId: UUID): Boolean? =
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -305,7 +304,7 @@ class PostgresOppgaveRepository(
         }
 
     override fun adresseGraderingForPerson(oppgaveId: UUID): AdressebeskyttelseGradering =
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -323,13 +322,13 @@ class PostgresOppgaveRepository(
             )
         } ?: throw DataNotFoundException("Fant ikke person for oppgave med id $oppgaveId")
 
-    override fun finnNotat(oppgaveTilstandLoggId: UUID): Notat? = finnNotat(oppgaveTilstandLoggId, dataSource)
+    override fun finnNotat(oppgaveTilstandLoggId: UUID): Notat? = finnNotat(oppgaveTilstandLoggId, databaseSession)
 
     override fun lagreNotatFor(oppgave: Oppgave): LocalDateTime =
         when (val notat = oppgave.tilstand().notat()) {
             null -> throw IllegalStateException("Kan ikke lagre notat for oppgave uten notat")
             else -> {
-                sessionOf(dataSource).use { session ->
+                databaseSession.session { session ->
                     session.lagreNotat(
                         notatId = notat.notatId,
                         tilstandsendringId = oppgave.tilstandslogg.first().id,
@@ -343,7 +342,7 @@ class PostgresOppgaveRepository(
     override fun slettNotatFor(oppgave: Oppgave) {
         val tilstandsloggId = oppgave.tilstandslogg.first().id
 
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -355,7 +354,7 @@ class PostgresOppgaveRepository(
     }
 
     override fun finnOppgaverPåVentMedUtgåttFrist(frist: LocalDate): List<UUID> =
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -381,7 +380,7 @@ class PostgresOppgaveRepository(
         ident: String,
         søknadId: UUID,
     ): Type? =
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -437,7 +436,7 @@ class PostgresOppgaveRepository(
     )
 
     override fun søk(søkeFilter: Søkefilter): OppgaveSøkResultat =
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             val tilstanderAsText = søkeFilter.tilstander.joinToString { "'$it'" }
             val tilstandClause =
                 when (søkeFilter.tilstander.isNotEmpty()) {
@@ -585,14 +584,14 @@ class PostgresOppgaveRepository(
                 session.run(
                     queryOf(statement = oppgaverQuery, paramMap = paramMap)
                         .map { row ->
-                            row.rehydrerOppgave(dataSource)
+                            row.rehydrerOppgave(databaseSession)
                         }.asList,
                 )
             OppgaveSøkResultat(oppgaver = oppgaver, totaltAntallOppgaver = antallOppgaver)
         }
 
     override fun hentDistinkteEmneknagger(): Set<String> =
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             session
                 .run(
                     queryOf(
@@ -615,10 +614,10 @@ private fun rehydrerTilstandsendringHendelse(
 
 private fun hentEmneknaggerForOppgave(
     oppgaveId: UUID,
-    dataSource: DataSource,
+    databaseSession: DatabaseSession,
 ): Set<String> =
-    sessionOf(dataSource)
-        .use { session ->
+    databaseSession
+        .session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -637,9 +636,9 @@ private fun hentEmneknaggerForOppgave(
 
 private fun finnNotat(
     oppgaveTilstandLoggId: UUID,
-    dataSource: DataSource,
+    databaseSession: DatabaseSession,
 ): Notat? =
-    sessionOf(dataSource).use { session ->
+    databaseSession.session { session ->
         session.run(
             queryOf(
                 //language=PostgreSQL
@@ -663,9 +662,9 @@ private fun finnNotat(
 
 private fun hentTilstandsloggForOppgave(
     oppgaveId: UUID,
-    dataSource: DataSource,
+    databaseSession: DatabaseSession,
 ): OppgaveTilstandslogg =
-    sessionOf(dataSource).use { session ->
+    databaseSession.session { session ->
         session
             .run(
                 queryOf(
@@ -857,7 +856,7 @@ private fun TransactionalSession.lagre(
     }
 }
 
-private fun Row.rehydrerOppgave(dataSource: DataSource): Oppgave {
+private fun Row.rehydrerOppgave(databaseSession: DatabaseSession): Oppgave {
     val oppgaveId = this.uuid("oppgave_id")
     val person =
         Person(
@@ -866,7 +865,7 @@ private fun Row.rehydrerOppgave(dataSource: DataSource): Oppgave {
             skjermesSomEgneAnsatte = this.boolean("skjermes_som_egne_ansatte"),
             adressebeskyttelseGradering = this.adresseBeskyttelseGradering(),
         )
-    val tilstandslogg = hentTilstandsloggForOppgave(oppgaveId, dataSource)
+    val tilstandslogg = hentTilstandsloggForOppgave(oppgaveId, databaseSession)
 
     val tilstand =
         runCatching {
@@ -877,7 +876,7 @@ private fun Row.rehydrerOppgave(dataSource: DataSource): Oppgave {
                 PAA_VENT -> PåVent
                 AVVENTER_LÅS_AV_BEHANDLING -> AvventerLåsAvBehandling
                 KLAR_TIL_KONTROLL -> KlarTilKontroll
-                UNDER_KONTROLL -> UnderKontroll(finnNotat(tilstandslogg.first().id, dataSource))
+                UNDER_KONTROLL -> UnderKontroll(finnNotat(tilstandslogg.first().id, databaseSession))
                 AVVENTER_OPPLÅSING_AV_BEHANDLING -> AvventerOpplåsingAvBehandling
                 FERDIG_BEHANDLET -> FerdigBehandlet
                 AVBRUTT -> Avbrutt
@@ -891,7 +890,7 @@ private fun Row.rehydrerOppgave(dataSource: DataSource): Oppgave {
         oppgaveId = oppgaveId,
         behandlerIdent = this.stringOrNull("saksbehandler_ident"),
         opprettet = this.localDateTime("oppgave_opprettet"),
-        emneknagger = hentEmneknaggerForOppgave(oppgaveId, dataSource),
+        emneknagger = hentEmneknaggerForOppgave(oppgaveId, databaseSession),
         tilstand = tilstand,
         utsattTil = this.localDateOrNull("utsatt_til"),
         tilstandslogg = tilstandslogg,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/person/PostgresPersonRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/person/PostgresPersonRepository.kt
@@ -102,7 +102,8 @@ class PostgresPersonRepository(
     override fun hentPerson(id: UUID) = finnPerson(id) ?: throw DataNotFoundException("Kan ikke finne person med id $id")
 
     override fun hentPersonForBehandlingId(behandlingId: UUID) =
-        finnPersonForBehandlingId(behandlingId) ?: throw DataNotFoundException("Kan ikke finne person fra behandlingId $behandlingId")
+        finnPersonForBehandlingId(behandlingId)
+            ?: throw DataNotFoundException("Kan ikke finne person fra behandlingId $behandlingId")
 
     override fun lagre(person: Person) =
         databaseSession.transaction {
@@ -113,7 +114,7 @@ class PostgresPersonRepository(
         fnr: String,
         skjermet: Boolean,
     ): Int =
-        return databaseSession.session { session ->
+        databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -136,7 +137,7 @@ class PostgresPersonRepository(
         fnr: String,
         adresseBeskyttelseGradering: AdressebeskyttelseGradering,
     ): Int =
-        return databaseSession.session { session ->
+        databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/person/PostgresPersonRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/person/PostgresPersonRepository.kt
@@ -2,7 +2,7 @@ package no.nav.dagpenger.saksbehandling.db.person
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotliquery.Row
-import kotliquery.TransactionalSession
+import kotliquery.Session
 import kotliquery.queryOf
 import no.nav.dagpenger.saksbehandling.AdressebeskyttelseGradering
 import no.nav.dagpenger.saksbehandling.Person
@@ -105,10 +105,8 @@ class PostgresPersonRepository(
         finnPersonForBehandlingId(behandlingId) ?: throw DataNotFoundException("Kan ikke finne person fra behandlingId $behandlingId")
 
     override fun lagre(person: Person) =
-        databaseSession.session { session ->
-            session.transaction { tx ->
-                tx.lagre(person)
-            }
+        databaseSession.transaction {
+            session.lagre(person)
         }
 
     override fun oppdaterSkjermingStatus(
@@ -178,7 +176,7 @@ class PostgresPersonRepository(
     }
 }
 
-private fun TransactionalSession.lagre(person: Person) {
+private fun Session.lagre(person: Person) {
     run(
         queryOf(
             //language=PostgreSQL

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/person/PostgresPersonRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/person/PostgresPersonRepository.kt
@@ -2,12 +2,12 @@ package no.nav.dagpenger.saksbehandling.db.person
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotliquery.Row
-import kotliquery.Session
 import kotliquery.queryOf
 import no.nav.dagpenger.saksbehandling.AdressebeskyttelseGradering
 import no.nav.dagpenger.saksbehandling.Person
 import no.nav.dagpenger.saksbehandling.adressebeskyttelse.AdressebeskyttelseRepository
 import no.nav.dagpenger.saksbehandling.db.DatabaseSession
+import no.nav.dagpenger.saksbehandling.db.PostgresUnitOfWork
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
 import no.nav.dagpenger.saksbehandling.skjerming.SkjermingRepository
 import java.util.UUID
@@ -106,7 +106,7 @@ class PostgresPersonRepository(
 
     override fun lagre(person: Person) =
         databaseSession.transaction {
-            session.lagre(person)
+            lagre(person)
         }
 
     override fun oppdaterSkjermingStatus(
@@ -176,8 +176,8 @@ class PostgresPersonRepository(
     }
 }
 
-private fun Session.lagre(person: Person) {
-    run(
+private fun PostgresUnitOfWork.lagre(person: Person) {
+    session.run(
         queryOf(
             //language=PostgreSQL
             statement =

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/person/PostgresPersonRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/person/PostgresPersonRepository.kt
@@ -4,26 +4,25 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotliquery.Row
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
-import kotliquery.sessionOf
 import no.nav.dagpenger.saksbehandling.AdressebeskyttelseGradering
 import no.nav.dagpenger.saksbehandling.Person
 import no.nav.dagpenger.saksbehandling.adressebeskyttelse.AdressebeskyttelseRepository
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
 import no.nav.dagpenger.saksbehandling.skjerming.SkjermingRepository
 import java.util.UUID
-import javax.sql.DataSource
 
 private val sikkerlogg = KotlinLogging.logger("tjenestekall")
 
 class PostgresPersonRepository(
-    private val dataSource: DataSource,
+    private val databaseSession: DatabaseSession,
 ) : PersonRepository,
     SkjermingRepository,
     AdressebeskyttelseRepository {
     override fun finnPerson(ident: String): Person? {
         sikkerlogg.info { "Søker etter person med ident $ident" }
-        sessionOf(dataSource).use { session ->
-            return session.run(
+        return databaseSession.session { session ->
+            session.run(
                 queryOf(
                     //language=PostgreSQL
                     statement =
@@ -45,8 +44,8 @@ class PostgresPersonRepository(
 
     override fun finnPerson(id: UUID): Person? {
         sikkerlogg.info { "Søker etter person med id $id" }
-        sessionOf(dataSource).use { session ->
-            return session.run(
+        return databaseSession.session { session ->
+            session.run(
                 queryOf(
                     //language=PostgreSQL
                     statement =
@@ -68,8 +67,8 @@ class PostgresPersonRepository(
 
     fun finnPersonForBehandlingId(behandlingId: UUID): Person? {
         sikkerlogg.info { "Søker etter person med behandlingId $behandlingId" }
-        sessionOf(dataSource).use { session ->
-            return session.run(
+        return databaseSession.session { session ->
+            session.run(
                 queryOf(
                     //language=PostgreSQL
                     statement =
@@ -105,19 +104,18 @@ class PostgresPersonRepository(
     override fun hentPersonForBehandlingId(behandlingId: UUID) =
         finnPersonForBehandlingId(behandlingId) ?: throw DataNotFoundException("Kan ikke finne person fra behandlingId $behandlingId")
 
-    override fun lagre(person: Person) {
-        sessionOf(dataSource).use { session ->
+    override fun lagre(person: Person) =
+        databaseSession.session { session ->
             session.transaction { tx ->
                 tx.lagre(person)
             }
         }
-    }
 
     override fun oppdaterSkjermingStatus(
         fnr: String,
         skjermet: Boolean,
     ): Int =
-        sessionOf(dataSource).use { session ->
+        return databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -140,7 +138,7 @@ class PostgresPersonRepository(
         fnr: String,
         adresseBeskyttelseGradering: AdressebeskyttelseGradering,
     ): Int =
-        sessionOf(dataSource).use { session ->
+        return databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -161,7 +159,7 @@ class PostgresPersonRepository(
 
     override fun eksistererIDPsystem(fnrs: Set<String>): Set<String> {
         val identer = fnrs.joinToString { "'$it'" }
-        return sessionOf(dataSource).use { session ->
+        return databaseSession.session { session ->
             session
                 .run(
                     queryOf(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/sak/PostgresSakRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/sak/PostgresSakRepository.kt
@@ -2,7 +2,7 @@ package no.nav.dagpenger.saksbehandling.db.sak
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotliquery.Row
-import kotliquery.TransactionalSession
+import kotliquery.Session
 import kotliquery.queryOf
 import no.nav.dagpenger.saksbehandling.AdressebeskyttelseGradering
 import no.nav.dagpenger.saksbehandling.Behandling
@@ -25,13 +25,11 @@ class PostgresSakRepository(
     private val databaseSession: DatabaseSession,
 ) : SakRepository {
     override fun lagre(sakHistorikk: SakHistorikk) {
-        databaseSession.session { session ->
-            session.transaction { tx ->
-                tx.lagreSakHistorikk(
-                    personId = sakHistorikk.person.id,
-                    saker = sakHistorikk.alleSaker(),
-                )
-            }
+        databaseSession.transaction {
+            session.lagreSakHistorikk(
+                personId = sakHistorikk.person.id,
+                saker = sakHistorikk.alleSaker(),
+            )
         }
     }
 
@@ -196,14 +194,14 @@ class PostgresSakRepository(
             ) ?: throw DataNotFoundException("Kan ikke finne dagpenger sak for behandlingId $behandlingId")
         }
 
-    private fun TransactionalSession.lagreSakHistorikk(
+    private fun Session.lagreSakHistorikk(
         personId: UUID,
         saker: List<Sak>,
     ) {
         saker.forEach { sak -> this.lagreSak(personId, sak) }
     }
 
-    private fun TransactionalSession.lagreSak(
+    private fun Session.lagreSak(
         personId: UUID,
         sak: Sak,
     ) {
@@ -234,7 +232,7 @@ class PostgresSakRepository(
         )
     }
 
-    private fun TransactionalSession.lagreBehandlinger(
+    private fun Session.lagreBehandlinger(
         personId: UUID,
         sakId: UUID,
         behandlinger: List<Behandling>,
@@ -248,7 +246,7 @@ class PostgresSakRepository(
         }
     }
 
-    private fun TransactionalSession.lagreHendelse(
+    private fun Session.lagreHendelse(
         behandlingId: UUID,
         hendelse: Hendelse,
     ) {
@@ -282,14 +280,12 @@ class PostgresSakRepository(
         sakId: UUID?,
         behandling: Behandling,
     ) {
-        databaseSession.session { session ->
-            session.transaction { tx ->
-                tx.lagreBehandling(
-                    personId = personId,
-                    sakId = sakId,
-                    behandling = behandling,
-                )
-            }
+        databaseSession.transaction {
+            session.lagreBehandling(
+                personId = personId,
+                sakId = sakId,
+                behandling = behandling,
+            )
         }
     }
 
@@ -341,7 +337,7 @@ class PostgresSakRepository(
         }
     }
 
-    private fun TransactionalSession.lagreBehandling(
+    private fun Session.lagreBehandling(
         personId: UUID,
         sakId: UUID?,
         behandling: Behandling,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/sak/PostgresSakRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/sak/PostgresSakRepository.kt
@@ -4,29 +4,28 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotliquery.Row
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
-import kotliquery.sessionOf
 import no.nav.dagpenger.saksbehandling.AdressebeskyttelseGradering
 import no.nav.dagpenger.saksbehandling.Behandling
 import no.nav.dagpenger.saksbehandling.HendelseBehandler
 import no.nav.dagpenger.saksbehandling.Person
 import no.nav.dagpenger.saksbehandling.Sak
 import no.nav.dagpenger.saksbehandling.SakHistorikk
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
 import no.nav.dagpenger.saksbehandling.hendelser.Hendelse
 import no.nav.dagpenger.saksbehandling.serder.tilJson
 import org.postgresql.util.PGobject
 import java.util.UUID
-import javax.sql.DataSource
 import kotlin.collections.forEach
 
 private val logger = KotlinLogging.logger {}
 private val sikkerlogger = KotlinLogging.logger("tjenestekall")
 
 class PostgresSakRepository(
-    private val dataSource: DataSource,
+    private val databaseSession: DatabaseSession,
 ) : SakRepository {
     override fun lagre(sakHistorikk: SakHistorikk) {
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             session.transaction { tx ->
                 tx.lagreSakHistorikk(
                     personId = sakHistorikk.person.id,
@@ -42,8 +41,8 @@ class PostgresSakRepository(
     override fun finnSakHistorikk(ident: String): SakHistorikk? {
         val sakHistorikk = mutableListOf<SakHistorikk>()
 
-        sessionOf(dataSource).use { session ->
-            return session.run(
+        return databaseSession.session { session ->
+            session.run(
                 queryOf(
                     //language=PostgreSQL
                     statement =
@@ -81,7 +80,7 @@ class PostgresSakRepository(
     }
 
     override fun finnSisteDagpengeSakId(ident: String): UUID? =
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -123,7 +122,7 @@ class PostgresSakRepository(
         søknadId: UUID,
         ident: String,
     ): UUID? =
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -153,7 +152,7 @@ class PostgresSakRepository(
         }
 
     override fun hentSakIdForBehandlingId(behandlingId: UUID): UUID =
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -175,7 +174,7 @@ class PostgresSakRepository(
         }
 
     override fun hentDagpengerSakIdForBehandlingId(behandlingId: UUID): UUID =
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -283,7 +282,7 @@ class PostgresSakRepository(
         sakId: UUID?,
         behandling: Behandling,
     ) {
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             session.transaction { tx ->
                 tx.lagreBehandling(
                     personId = personId,
@@ -298,7 +297,7 @@ class PostgresSakRepository(
         sakId: UUID,
         arenaSakId: String,
     ) {
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -322,7 +321,7 @@ class PostgresSakRepository(
         sakId: UUID,
         erDpSak: Boolean,
     ) {
-        sessionOf(dataSource).use { session ->
+        databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/sak/PostgresSakRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/sak/PostgresSakRepository.kt
@@ -2,7 +2,6 @@ package no.nav.dagpenger.saksbehandling.db.sak
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotliquery.Row
-import kotliquery.Session
 import kotliquery.queryOf
 import no.nav.dagpenger.saksbehandling.AdressebeskyttelseGradering
 import no.nav.dagpenger.saksbehandling.Behandling
@@ -11,6 +10,7 @@ import no.nav.dagpenger.saksbehandling.Person
 import no.nav.dagpenger.saksbehandling.Sak
 import no.nav.dagpenger.saksbehandling.SakHistorikk
 import no.nav.dagpenger.saksbehandling.db.DatabaseSession
+import no.nav.dagpenger.saksbehandling.db.PostgresUnitOfWork
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
 import no.nav.dagpenger.saksbehandling.hendelser.Hendelse
 import no.nav.dagpenger.saksbehandling.serder.tilJson
@@ -26,7 +26,7 @@ class PostgresSakRepository(
 ) : SakRepository {
     override fun lagre(sakHistorikk: SakHistorikk) {
         databaseSession.transaction {
-            session.lagreSakHistorikk(
+            lagreSakHistorikk(
                 personId = sakHistorikk.person.id,
                 saker = sakHistorikk.alleSaker(),
             )
@@ -194,18 +194,18 @@ class PostgresSakRepository(
             ) ?: throw DataNotFoundException("Kan ikke finne dagpenger sak for behandlingId $behandlingId")
         }
 
-    private fun Session.lagreSakHistorikk(
+    private fun PostgresUnitOfWork.lagreSakHistorikk(
         personId: UUID,
         saker: List<Sak>,
     ) {
         saker.forEach { sak -> this.lagreSak(personId, sak) }
     }
 
-    private fun Session.lagreSak(
+    private fun PostgresUnitOfWork.lagreSak(
         personId: UUID,
         sak: Sak,
     ) {
-        run(
+        session.run(
             queryOf(
                 //language=PostgreSQL
                 statement =
@@ -232,7 +232,7 @@ class PostgresSakRepository(
         )
     }
 
-    private fun Session.lagreBehandlinger(
+    private fun PostgresUnitOfWork.lagreBehandlinger(
         personId: UUID,
         sakId: UUID,
         behandlinger: List<Behandling>,
@@ -246,11 +246,11 @@ class PostgresSakRepository(
         }
     }
 
-    private fun Session.lagreHendelse(
+    private fun PostgresUnitOfWork.lagreHendelse(
         behandlingId: UUID,
         hendelse: Hendelse,
     ) {
-        run(
+        session.run(
             queryOf(
                 //language=PostgreSQL
                 statement =
@@ -281,7 +281,7 @@ class PostgresSakRepository(
         behandling: Behandling,
     ) {
         databaseSession.transaction {
-            session.lagreBehandling(
+            lagreBehandling(
                 personId = personId,
                 sakId = sakId,
                 behandling = behandling,
@@ -337,12 +337,12 @@ class PostgresSakRepository(
         }
     }
 
-    private fun Session.lagreBehandling(
+    private fun PostgresUnitOfWork.lagreBehandling(
         personId: UUID,
         sakId: UUID?,
         behandling: Behandling,
     ) {
-        run(
+        session.run(
             queryOf(
                 //language=PostgreSQL
                 statement =

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/statistikk/db/PostgresProduksjonsstatistikkRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/statistikk/db/PostgresProduksjonsstatistikkRepository.kt
@@ -1,7 +1,6 @@
 package no.nav.dagpenger.saksbehandling.statistikk.db
 
 import kotliquery.queryOf
-import kotliquery.sessionOf
 import no.nav.dagpenger.saksbehandling.Emneknagg.Regelknagg.RETTIGHET_KONKURS
 import no.nav.dagpenger.saksbehandling.Emneknagg.Regelknagg.RETTIGHET_ORDINÆR
 import no.nav.dagpenger.saksbehandling.Emneknagg.Regelknagg.RETTIGHET_PERMITTERT
@@ -9,15 +8,15 @@ import no.nav.dagpenger.saksbehandling.Emneknagg.Regelknagg.RETTIGHET_PERMITTERT
 import no.nav.dagpenger.saksbehandling.Emneknagg.Regelknagg.RETTIGHET_VERNEPLIKT
 import no.nav.dagpenger.saksbehandling.HendelseBehandler
 import no.nav.dagpenger.saksbehandling.Oppgave
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.statistikk.ProduksjonsstatistikkFilter
 import java.time.LocalDateTime
-import javax.sql.DataSource
 
 class PostgresProduksjonsstatistikkRepository(
-    private val dataSource: DataSource,
+    private val databaseSession: DatabaseSession,
 ) : ProduksjonsstatistikkRepository {
     override fun hentAntallBrevSendt(): Int =
-        sessionOf(dataSource = dataSource).use { session ->
+        databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -36,7 +35,7 @@ class PostgresProduksjonsstatistikkRepository(
             produksjonsstatistikkFilter.utløstAvTyper.ifEmpty {
                 HendelseBehandler.entries.toSet()
             }
-        return sessionOf(dataSource = dataSource).use { session ->
+        return databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -90,7 +89,7 @@ class PostgresProduksjonsstatistikkRepository(
                 Oppgave.Tilstand.Type.søkbareTilstander
                     .toSet()
             }
-        return sessionOf(dataSource = dataSource).use { session ->
+        return databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -136,7 +135,7 @@ class PostgresProduksjonsstatistikkRepository(
                 )
             }
 
-        return sessionOf(dataSource = dataSource).use { session ->
+        return databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -205,7 +204,7 @@ class PostgresProduksjonsstatistikkRepository(
                 Oppgave.Tilstand.Type.søkbareTilstander
                     .toSet()
             }
-        return sessionOf(dataSource = dataSource).use { session ->
+        return databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -257,7 +256,7 @@ class PostgresProduksjonsstatistikkRepository(
                 Oppgave.Tilstand.Type.søkbareTilstander
                     .toSet()
             }
-        return sessionOf(dataSource = dataSource).use { session ->
+        return databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -311,7 +310,7 @@ class PostgresProduksjonsstatistikkRepository(
                 Oppgave.Tilstand.Type.søkbareTilstander
                     .toSet()
             }
-        return sessionOf(dataSource = dataSource).use { session ->
+        return databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/statistikk/db/PostgresSaksbehandlingsstatistikkRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/statistikk/db/PostgresSaksbehandlingsstatistikkRepository.kt
@@ -1,17 +1,16 @@
 package no.nav.dagpenger.saksbehandling.statistikk.db
 
 import kotliquery.queryOf
-import kotliquery.sessionOf
 import no.nav.dagpenger.saksbehandling.Configuration
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.statistikk.OppgaveITilstand
 import java.util.UUID
-import javax.sql.DataSource
 
 class PostgresSaksbehandlingsstatistikkRepository(
-    private val dataSource: DataSource,
+    private val databaseSession: DatabaseSession,
 ) : SaksbehandlingsstatistikkRepository {
-    override fun tidligereTilstandsendringerErOverført(): Boolean {
-        sessionOf(dataSource = dataSource).use { session ->
+    override fun tidligereTilstandsendringerErOverført(): Boolean =
+        databaseSession.session { session ->
             val count =
                 session.run(
                     queryOf(
@@ -26,20 +25,18 @@ class PostgresSaksbehandlingsstatistikkRepository(
                         row.int("count")
                     }.asSingle,
                 )
-            return count == 0
+            count == 0
         }
-    }
 
     // Henter oppgavetilstander som skal sendes til statistikk.
     // Går ikke lenger tilbake i tid enn det finnes behandlinger i behandlinger_mart på BigQuery, derfor begrensningen
     // på beh.id >= '019928dc-f521-7723-8ff6-f07154f5097d' (som er den første behandlingen i behandlinger_mart).
     override fun oppgaveTilstandsendringer(): List<OppgaveITilstand> =
-        sessionOf(dataSource = dataSource)
-            .use { session ->
-                session.run(
-                    queryOf(
-                        //language=PostgreSQL
-                        statement = """
+        databaseSession.session { session ->
+            session.run(
+                queryOf(
+                    //language=PostgreSQL
+                    statement = """
                         INSERT
                         INTO  saksbehandling_statistikk_v1 (
                               tilstand_id
@@ -121,36 +118,36 @@ class PostgresSaksbehandlingsstatistikkRepository(
                             LIMIT 1000
                         RETURNING   *
                         """,
-                    ).map { row ->
-                        OppgaveITilstand(
-                            oppgaveId = row.uuid("oppgave_id"),
-                            mottatt = row.localDateTime("mottatt"),
-                            sakId = row.uuid("sak_id"),
-                            behandlingId = row.uuid("behandling_id"),
-                            personIdent = row.string("person_ident"),
-                            saksbehandlerIdent = row.stringOrNull("saksbehandler_ident"),
-                            beslutterIdent = row.stringOrNull("beslutter_ident"),
-                            versjon = Configuration.versjon,
-                            tilstandsendring =
-                                OppgaveITilstand.Tilstandsendring(
-                                    sekvensnummer = row.long("sekvensnummer"),
-                                    tilstandsendringId = row.uuid("tilstand_id"),
-                                    tilstand = row.string("tilstand"),
-                                    tidspunkt = row.localDateTime("tilstand_tidspunkt"),
-                                ),
-                            utløstAv = row.string("utlost_av"),
-                            behandlingResultat = row.stringOrNull("behandling_resultat"),
-                            behandlingÅrsak = row.stringOrNull("behandling_aarsak"),
-                            fagsystem = row.stringOrNull("fagsystem"),
-                            arenaSakId = row.stringOrNull("arena_sak_id"),
-                            resultatBegrunnelse = row.stringOrNull("resultat_begrunnelse"),
-                        )
-                    }.asList,
-                )
-            }
+                ).map { row ->
+                    OppgaveITilstand(
+                        oppgaveId = row.uuid("oppgave_id"),
+                        mottatt = row.localDateTime("mottatt"),
+                        sakId = row.uuid("sak_id"),
+                        behandlingId = row.uuid("behandling_id"),
+                        personIdent = row.string("person_ident"),
+                        saksbehandlerIdent = row.stringOrNull("saksbehandler_ident"),
+                        beslutterIdent = row.stringOrNull("beslutter_ident"),
+                        versjon = Configuration.versjon,
+                        tilstandsendring =
+                            OppgaveITilstand.Tilstandsendring(
+                                sekvensnummer = row.long("sekvensnummer"),
+                                tilstandsendringId = row.uuid("tilstand_id"),
+                                tilstand = row.string("tilstand"),
+                                tidspunkt = row.localDateTime("tilstand_tidspunkt"),
+                            ),
+                        utløstAv = row.string("utlost_av"),
+                        behandlingResultat = row.stringOrNull("behandling_resultat"),
+                        behandlingÅrsak = row.stringOrNull("behandling_aarsak"),
+                        fagsystem = row.stringOrNull("fagsystem"),
+                        arenaSakId = row.stringOrNull("arena_sak_id"),
+                        resultatBegrunnelse = row.stringOrNull("resultat_begrunnelse"),
+                    )
+                }.asList,
+            )
+        }
 
     override fun markerTilstandsendringerSomOverført(tilstandId: UUID): Int =
-        sessionOf(dataSource = dataSource).use { session ->
+        databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/utsending/db/PostgresUtsendingRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/utsending/db/PostgresUtsendingRepository.kt
@@ -20,60 +20,58 @@ class PostgresUtsendingRepository(
     private val databaseSession: DatabaseSession,
 ) : UtsendingRepository {
     override fun lagre(utsending: Utsending) {
-        databaseSession.session { session ->
-            session.transaction { tx ->
-                utsending.sak()?.let { tx.lagreUtsendingSak(it) }
-                tx.run(
-                    queryOf(
-                        //language=PostgreSQL
-                        statement =
-                            """
-                            INSERT INTO utsending_v1(
-                                id, 
-                                behandling_id, 
-                                tilstand, 
-                                brev, 
-                                pdf_urn, 
-                                journalpost_id, 
-                                distribusjon_id, 
-                                utsending_sak_id, 
-                                type
-                            ) 
-                            VALUES(
-                                :id, 
-                                :behandling_id, 
-                                :tilstand, 
-                                :brev, 
-                                :pdf_urn, 
-                                :journalpost_id, 
-                                :distribusjon_id, 
-                                :utsending_sak_id, 
-                                :type
-                            ) 
-                            ON CONFLICT (id) DO UPDATE SET 
-                                tilstand = :tilstand,
-                                brev = :brev,
-                                pdf_urn = :pdf_urn,
-                                journalpost_id = :journalpost_id,
-                                distribusjon_id = :distribusjon_id,
-                                utsending_sak_id = :utsending_sak_id,
-                                type = :type
-                            """.trimIndent(),
-                        paramMap =
-                            mapOf(
-                                "id" to utsending.id,
-                                "behandling_id" to utsending.behandlingId,
-                                "tilstand" to utsending.tilstand().type.name,
-                                "brev" to utsending.brev(),
-                                "pdf_urn" to utsending.pdfUrn()?.toString(),
-                                "journalpost_id" to utsending.journalpostId(),
-                                "distribusjon_id" to utsending.distribusjonId(),
-                                "utsending_sak_id" to utsending.sak()?.id,
-                                "type" to utsending.type.name,
-                            ),
-                    ).asUpdate,
-                )
-            }
+        databaseSession.transaction {
+            utsending.sak()?.let { session.lagreUtsendingSak(it) }
+            session.run(
+                queryOf(
+                    //language=PostgreSQL
+                    statement =
+                        """
+                        INSERT INTO utsending_v1(
+                            id, 
+                            behandling_id, 
+                            tilstand, 
+                            brev, 
+                            pdf_urn, 
+                            journalpost_id, 
+                            distribusjon_id, 
+                            utsending_sak_id, 
+                            type
+                        ) 
+                        VALUES(
+                            :id, 
+                            :behandling_id, 
+                            :tilstand, 
+                            :brev, 
+                            :pdf_urn, 
+                            :journalpost_id, 
+                            :distribusjon_id, 
+                            :utsending_sak_id, 
+                            :type
+                        ) 
+                        ON CONFLICT (id) DO UPDATE SET 
+                            tilstand = :tilstand,
+                            brev = :brev,
+                            pdf_urn = :pdf_urn,
+                            journalpost_id = :journalpost_id,
+                            distribusjon_id = :distribusjon_id,
+                            utsending_sak_id = :utsending_sak_id,
+                            type = :type
+                        """.trimIndent(),
+                    paramMap =
+                        mapOf(
+                            "id" to utsending.id,
+                            "behandling_id" to utsending.behandlingId,
+                            "tilstand" to utsending.tilstand().type.name,
+                            "brev" to utsending.brev(),
+                            "pdf_urn" to utsending.pdfUrn()?.toString(),
+                            "journalpost_id" to utsending.journalpostId(),
+                            "distribusjon_id" to utsending.distribusjonId(),
+                            "utsending_sak_id" to utsending.sak()?.id,
+                            "type" to utsending.type.name,
+                        ),
+                ).asUpdate,
+            )
         }
     }
 

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/utsending/db/PostgresUtsendingRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/utsending/db/PostgresUtsendingRepository.kt
@@ -1,10 +1,10 @@
 package no.nav.dagpenger.saksbehandling.utsending.db
 
 import kotliquery.Row
-import kotliquery.Session
 import kotliquery.queryOf
 import no.nav.dagpenger.saksbehandling.UtsendingSak
 import no.nav.dagpenger.saksbehandling.db.DatabaseSession
+import no.nav.dagpenger.saksbehandling.db.PostgresUnitOfWork
 import no.nav.dagpenger.saksbehandling.utsending.Utsending
 import no.nav.dagpenger.saksbehandling.utsending.Utsending.Tilstand
 import no.nav.dagpenger.saksbehandling.utsending.Utsending.Tilstand.Type.Avbrutt
@@ -21,7 +21,7 @@ class PostgresUtsendingRepository(
 ) : UtsendingRepository {
     override fun lagre(utsending: Utsending) {
         databaseSession.transaction {
-            utsending.sak()?.let { session.lagreUtsendingSak(it) }
+            utsending.sak()?.let { lagreUtsendingSak(it) }
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -167,8 +167,8 @@ class PostgresUtsendingRepository(
         }
 }
 
-private fun Session.lagreUtsendingSak(utsendingSak: UtsendingSak) {
-    this.run(
+private fun PostgresUnitOfWork.lagreUtsendingSak(utsendingSak: UtsendingSak) {
+    session.run(
         queryOf(
             //language=PostgreSQL
             statement =

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/utsending/db/PostgresUtsendingRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/utsending/db/PostgresUtsendingRepository.kt
@@ -152,7 +152,7 @@ class PostgresUtsendingRepository(
         }
 
     override fun slettUtsending(utsendingId: UUID): Int =
-        sessionOf(ds).use { session ->
+        databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/utsending/db/PostgresUtsendingRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/utsending/db/PostgresUtsendingRepository.kt
@@ -3,8 +3,8 @@ package no.nav.dagpenger.saksbehandling.utsending.db
 import kotliquery.Row
 import kotliquery.Session
 import kotliquery.queryOf
-import kotliquery.sessionOf
 import no.nav.dagpenger.saksbehandling.UtsendingSak
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.utsending.Utsending
 import no.nav.dagpenger.saksbehandling.utsending.Utsending.Tilstand
 import no.nav.dagpenger.saksbehandling.utsending.Utsending.Tilstand.Type.Avbrutt
@@ -15,13 +15,12 @@ import no.nav.dagpenger.saksbehandling.utsending.Utsending.Tilstand.Type.Distrib
 import no.nav.dagpenger.saksbehandling.utsending.Utsending.Tilstand.Type.VenterPåVedtak
 import no.nav.dagpenger.saksbehandling.utsending.UtsendingType
 import java.util.UUID
-import javax.sql.DataSource
 
 class PostgresUtsendingRepository(
-    private val ds: DataSource,
+    private val databaseSession: DatabaseSession,
 ) : UtsendingRepository {
     override fun lagre(utsending: Utsending) {
-        sessionOf(ds).use { session ->
+        databaseSession.session { session ->
             session.transaction { tx ->
                 utsending.sak()?.let { tx.lagreUtsendingSak(it) }
                 tx.run(
@@ -79,7 +78,7 @@ class PostgresUtsendingRepository(
     }
 
     override fun utsendingFinnesForBehandling(behandlingId: UUID): Boolean =
-        sessionOf(ds).use { session ->
+        databaseSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -98,9 +97,9 @@ class PostgresUtsendingRepository(
         finnUtsendingForBehandlingId(behandlingId)
             ?: throw UtsendingIkkeFunnet("Fant ikke utsending for behandlingId: $behandlingId")
 
-    override fun finnUtsendingForBehandlingId(behandlingId: UUID): Utsending? {
-        sessionOf(ds).use { session ->
-            return session.run(
+    override fun finnUtsendingForBehandlingId(behandlingId: UUID): Utsending? =
+        databaseSession.session { session ->
+            session.run(
                 queryOf(
                     //language=PostgreSQL
                     statement =
@@ -143,7 +142,6 @@ class PostgresUtsendingRepository(
                 }.asSingle,
             )
         }
-    }
 
     private fun Row.rehydrerUtsendingTilstand(kolonneNavn: String): Tilstand =
         when (Tilstand.Type.valueOf(this.string(kolonneNavn))) {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
@@ -25,6 +25,7 @@ import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.db.person.PostgresPersonRepository
 import no.nav.dagpenger.saksbehandling.db.sak.PostgresSakRepository
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.AvbruttHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.KlageBehandlingUtført
 import no.nav.dagpenger.saksbehandling.hendelser.KlageMottattHendelse
@@ -1063,19 +1064,19 @@ class KlageMediatorTest {
         test: (KlageMediator, OppgaveMediator, UUID) -> Unit,
     ) {
         withMigratedDb { dataSource ->
-            val personRepository = PostgresPersonRepository(dataSource)
+            val personRepository = PostgresPersonRepository(testDatabaseSession(dataSource))
             val personMediator = PersonMediator(personRepository = personRepository, oppslagMock)
 
             val sakMediator =
                 SakMediator(
                     personMediator = personMediator,
-                    sakRepository = PostgresSakRepository(dataSource = dataSource),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(dataSource)),
                     rapidsConnection = testRapid,
                 )
 
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(dataSource),
+                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(dataSource)),
                     behandlingKlient = mockk(),
                     utsendingMediator = utsendingMediator,
                     sakMediator = sakMediator,
@@ -1083,7 +1084,7 @@ class KlageMediatorTest {
                 )
             val klageMediator =
                 KlageMediator(
-                    klageRepository = PostgresKlageRepository(dataSource),
+                    klageRepository = PostgresKlageRepository(testDatabaseSession(dataSource)),
                     oppgaveMediator = oppgaveMediator,
                     utsendingMediator = utsendingMediator,
                     oppslag = oppslagMock,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
@@ -19,13 +19,13 @@ import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.Type.UNDER_BEHANDLING
 import no.nav.dagpenger.saksbehandling.api.Oppslag
 import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTO
 import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTOEnhetDTO
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.Postgres.withMigratedDb
 import no.nav.dagpenger.saksbehandling.db.klage.PostgresKlageRepository
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.db.person.PostgresPersonRepository
 import no.nav.dagpenger.saksbehandling.db.sak.PostgresSakRepository
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.AvbruttHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.KlageBehandlingUtført
 import no.nav.dagpenger.saksbehandling.hendelser.KlageMottattHendelse
@@ -1064,19 +1064,19 @@ class KlageMediatorTest {
         test: (KlageMediator, OppgaveMediator, UUID) -> Unit,
     ) {
         withMigratedDb { dataSource ->
-            val personRepository = PostgresPersonRepository(testDatabaseSession(dataSource))
+            val personRepository = PostgresPersonRepository(DatabaseSession(lazy { dataSource }))
             val personMediator = PersonMediator(personRepository = personRepository, oppslagMock)
 
             val sakMediator =
                 SakMediator(
                     personMediator = personMediator,
-                    sakRepository = PostgresSakRepository(testDatabaseSession(dataSource)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { dataSource })),
                     rapidsConnection = testRapid,
                 )
 
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(dataSource)),
+                    oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(lazy { dataSource })),
                     behandlingKlient = mockk(),
                     utsendingMediator = utsendingMediator,
                     sakMediator = sakMediator,
@@ -1084,7 +1084,7 @@ class KlageMediatorTest {
                 )
             val klageMediator =
                 KlageMediator(
-                    klageRepository = PostgresKlageRepository(testDatabaseSession(dataSource)),
+                    klageRepository = PostgresKlageRepository(DatabaseSession(lazy { dataSource })),
                     oppgaveMediator = oppgaveMediator,
                     utsendingMediator = utsendingMediator,
                     oppslag = oppslagMock,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
@@ -52,6 +52,7 @@ import no.nav.dagpenger.saksbehandling.behandling.BehandlingException
 import no.nav.dagpenger.saksbehandling.behandling.BehandlingKlient
 import no.nav.dagpenger.saksbehandling.behandling.BehandlingKreverIkkeTotrinnskontrollException
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.Postgres.withMigratedDb
 import no.nav.dagpenger.saksbehandling.db.PostgresDataSourceBuilder.dataSource
 import no.nav.dagpenger.saksbehandling.db.innsending.PostgresInnsendingRepository
@@ -60,7 +61,6 @@ import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.db.person.PostgresPersonRepository
 import no.nav.dagpenger.saksbehandling.db.sak.PostgresSakRepository
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.AvbrytOppgaveHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingAvbruttHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingOpprettetHendelse
@@ -707,9 +707,9 @@ OppgaveMediatorTest {
             )
 
             val oppgave =
-                PostgresOppgaveRepository(testDatabaseSession(datasource))
+                PostgresOppgaveRepository(DatabaseSession(lazy { datasource }))
                     .hentOppgaveIdFor(behandlingId)
-                    .let { PostgresOppgaveRepository(testDatabaseSession(datasource)).hentOppgave(it!!) }
+                    .let { PostgresOppgaveRepository(DatabaseSession(lazy { datasource })).hentOppgave(it!!) }
             oppgave.emneknagger shouldContain "D-nummer"
         }
     }
@@ -739,9 +739,9 @@ OppgaveMediatorTest {
             )
 
             val oppgave =
-                PostgresOppgaveRepository(testDatabaseSession(datasource))
+                PostgresOppgaveRepository(DatabaseSession(lazy { datasource }))
                     .hentOppgaveIdFor(behandlingId)
-                    .let { PostgresOppgaveRepository(testDatabaseSession(datasource)).hentOppgave(it!!) }
+                    .let { PostgresOppgaveRepository(DatabaseSession(lazy { datasource })).hentOppgave(it!!) }
             oppgave.emneknagger shouldNotContain "D-nummer"
         }
     }
@@ -912,7 +912,7 @@ OppgaveMediatorTest {
         ) { datasource, oppgaveMediator ->
             val utsendingMediator =
                 UtsendingMediator(
-                    utsendingRepository = PostgresUtsendingRepository(testDatabaseSession(datasource)),
+                    utsendingRepository = PostgresUtsendingRepository(DatabaseSession(lazy { datasource })),
                     brevProdusent = mockk(),
                     rapidsConnection = mockk(relaxed = true),
                 )
@@ -1026,7 +1026,7 @@ OppgaveMediatorTest {
             oppgaveFraDB.tilstand().type shouldBe UNDER_BEHANDLING
 
             UtsendingMediator(
-                utsendingRepository = PostgresUtsendingRepository(testDatabaseSession(datasource)),
+                utsendingRepository = PostgresUtsendingRepository(DatabaseSession(lazy { datasource })),
                 brevProdusent = mockk(),
                 rapidsConnection = mockk(relaxed = true),
             ).also { utsendingMediator ->
@@ -1585,7 +1585,7 @@ OppgaveMediatorTest {
         DBTestHelper.withOppgave(oppgave) { ds ->
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(ds)),
+                    oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(lazy { ds })),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = mockk(),
@@ -1656,18 +1656,18 @@ OppgaveMediatorTest {
             val sakMediator =
                 SakMediator(
                     personMediator = personMediatorMock,
-                    sakRepository = PostgresSakRepository(testDatabaseSession(it)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { it })),
                     rapidsConnection = mockk(relaxed = true),
                 )
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(it)),
+                    oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(lazy { it })),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = sakMediator,
                     rapidsConnection = mockk(relaxed = true),
                 )
-            val innsendingRepository = PostgresInnsendingRepository(testDatabaseSession(it))
+            val innsendingRepository = PostgresInnsendingRepository(DatabaseSession(lazy { it }))
             val innsendingMediator =
                 InnsendingMediator(
                     sakMediator = sakMediator,
@@ -1743,7 +1743,7 @@ OppgaveMediatorTest {
         behandlingId: UUID = UUIDv7.ny(),
         søknadId: UUID = UUIDv7.ny(),
     ): Oppgave {
-        val personRepository = PostgresPersonRepository(testDatabaseSession(this))
+        val personRepository = PostgresPersonRepository(DatabaseSession(lazy { this }))
         val sakMediator =
             SakMediator(
                 personMediator =
@@ -1751,13 +1751,13 @@ OppgaveMediatorTest {
                         personRepository = personRepository,
                         oppslag = oppslagMock,
                     ),
-                sakRepository = PostgresSakRepository(testDatabaseSession(dataSource)),
+                sakRepository = PostgresSakRepository(DatabaseSession(lazy { dataSource })),
                 rapidsConnection = testRapid,
             )
 
         val oppgaveMediator =
             OppgaveMediator(
-                oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(this)),
+                oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(lazy { this })),
                 behandlingKlient = behandlingKlientMock,
                 utsendingMediator = mockk(),
                 sakMediator = sakMediator,
@@ -1848,20 +1848,20 @@ OppgaveMediatorTest {
                 SakMediator(
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(testDatabaseSession(dataSource)),
+                            personRepository = PostgresPersonRepository(DatabaseSession(lazy { dataSource })),
                             oppslag = oppslagMock,
                         ),
-                    sakRepository = PostgresSakRepository(testDatabaseSession(dataSource)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { dataSource })),
                     rapidsConnection = testRapid,
                 )
 
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(datasource)),
+                    oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(lazy { datasource })),
                     behandlingKlient = behandlingKlient,
                     utsendingMediator =
                         UtsendingMediator(
-                            utsendingRepository = PostgresUtsendingRepository(testDatabaseSession(datasource)),
+                            utsendingRepository = PostgresUtsendingRepository(DatabaseSession(lazy { datasource })),
                             brevProdusent = mockk(),
                             rapidsConnection = testRapid,
                         ),

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
@@ -1039,7 +1039,7 @@ OppgaveMediatorTest {
                 saksbehandler = saksbehandler,
             )
             UtsendingMediator(
-                utsendingRepository = PostgresUtsendingRepository(datasource),
+                utsendingRepository = PostgresUtsendingRepository(DatabaseSession(lazy { datasource })),
                 brevProdusent = mockk(),
                 rapidsConnection = mockk(relaxed = true),
             ).also { utsendingMediator ->

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
@@ -60,6 +60,7 @@ import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.db.person.PostgresPersonRepository
 import no.nav.dagpenger.saksbehandling.db.sak.PostgresSakRepository
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.AvbrytOppgaveHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingAvbruttHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingOpprettetHendelse
@@ -706,9 +707,9 @@ OppgaveMediatorTest {
             )
 
             val oppgave =
-                PostgresOppgaveRepository(datasource)
+                PostgresOppgaveRepository(testDatabaseSession(datasource))
                     .hentOppgaveIdFor(behandlingId)
-                    .let { PostgresOppgaveRepository(datasource).hentOppgave(it!!) }
+                    .let { PostgresOppgaveRepository(testDatabaseSession(datasource)).hentOppgave(it!!) }
             oppgave.emneknagger shouldContain "D-nummer"
         }
     }
@@ -738,9 +739,9 @@ OppgaveMediatorTest {
             )
 
             val oppgave =
-                PostgresOppgaveRepository(datasource)
+                PostgresOppgaveRepository(testDatabaseSession(datasource))
                     .hentOppgaveIdFor(behandlingId)
-                    .let { PostgresOppgaveRepository(datasource).hentOppgave(it!!) }
+                    .let { PostgresOppgaveRepository(testDatabaseSession(datasource)).hentOppgave(it!!) }
             oppgave.emneknagger shouldNotContain "D-nummer"
         }
     }
@@ -911,7 +912,7 @@ OppgaveMediatorTest {
         ) { datasource, oppgaveMediator ->
             val utsendingMediator =
                 UtsendingMediator(
-                    utsendingRepository = PostgresUtsendingRepository(datasource),
+                    utsendingRepository = PostgresUtsendingRepository(testDatabaseSession(datasource)),
                     brevProdusent = mockk(),
                     rapidsConnection = mockk(relaxed = true),
                 )
@@ -1025,7 +1026,7 @@ OppgaveMediatorTest {
             oppgaveFraDB.tilstand().type shouldBe UNDER_BEHANDLING
 
             UtsendingMediator(
-                utsendingRepository = PostgresUtsendingRepository(datasource),
+                utsendingRepository = PostgresUtsendingRepository(testDatabaseSession(datasource)),
                 brevProdusent = mockk(),
                 rapidsConnection = mockk(relaxed = true),
             ).also { utsendingMediator ->
@@ -1584,7 +1585,7 @@ OppgaveMediatorTest {
         DBTestHelper.withOppgave(oppgave) { ds ->
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(ds),
+                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(ds)),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = mockk(),
@@ -1655,18 +1656,18 @@ OppgaveMediatorTest {
             val sakMediator =
                 SakMediator(
                     personMediator = personMediatorMock,
-                    sakRepository = PostgresSakRepository(it),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(it)),
                     rapidsConnection = mockk(relaxed = true),
                 )
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(it),
+                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(it)),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = sakMediator,
                     rapidsConnection = mockk(relaxed = true),
                 )
-            val innsendingRepository = PostgresInnsendingRepository(it)
+            val innsendingRepository = PostgresInnsendingRepository(testDatabaseSession(it))
             val innsendingMediator =
                 InnsendingMediator(
                     sakMediator = sakMediator,
@@ -1742,7 +1743,7 @@ OppgaveMediatorTest {
         behandlingId: UUID = UUIDv7.ny(),
         søknadId: UUID = UUIDv7.ny(),
     ): Oppgave {
-        val personRepository = PostgresPersonRepository(this)
+        val personRepository = PostgresPersonRepository(testDatabaseSession(this))
         val sakMediator =
             SakMediator(
                 personMediator =
@@ -1750,13 +1751,13 @@ OppgaveMediatorTest {
                         personRepository = personRepository,
                         oppslag = oppslagMock,
                     ),
-                sakRepository = PostgresSakRepository(dataSource),
+                sakRepository = PostgresSakRepository(testDatabaseSession(dataSource)),
                 rapidsConnection = testRapid,
             )
 
         val oppgaveMediator =
             OppgaveMediator(
-                oppgaveRepository = PostgresOppgaveRepository(this),
+                oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(this)),
                 behandlingKlient = behandlingKlientMock,
                 utsendingMediator = mockk(),
                 sakMediator = sakMediator,
@@ -1847,20 +1848,20 @@ OppgaveMediatorTest {
                 SakMediator(
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(dataSource),
+                            personRepository = PostgresPersonRepository(testDatabaseSession(dataSource)),
                             oppslag = oppslagMock,
                         ),
-                    sakRepository = PostgresSakRepository(dataSource),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(dataSource)),
                     rapidsConnection = testRapid,
                 )
 
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(datasource),
+                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(datasource)),
                     behandlingKlient = behandlingKlient,
                     utsendingMediator =
                         UtsendingMediator(
-                            utsendingRepository = PostgresUtsendingRepository(datasource),
+                            utsendingRepository = PostgresUtsendingRepository(testDatabaseSession(datasource)),
                             brevProdusent = mockk(),
                             rapidsConnection = testRapid,
                         ),

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/DBTestHelper.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/DBTestHelper.kt
@@ -16,6 +16,7 @@ import no.nav.dagpenger.saksbehandling.db.person.PersonRepository
 import no.nav.dagpenger.saksbehandling.db.person.PostgresPersonRepository
 import no.nav.dagpenger.saksbehandling.db.sak.PostgresSakRepository
 import no.nav.dagpenger.saksbehandling.db.sak.SakRepository
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.TomHendelse
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
@@ -24,9 +25,9 @@ import javax.sql.DataSource
 
 class DBTestHelper private constructor(
     private val ds: DataSource,
-) : SakRepository by PostgresSakRepository(ds),
-    OppgaveRepository by PostgresOppgaveRepository(ds),
-    PersonRepository by PostgresPersonRepository(ds) {
+) : SakRepository by PostgresSakRepository(testDatabaseSession(ds)),
+    OppgaveRepository by PostgresOppgaveRepository(testDatabaseSession(ds)),
+    PersonRepository by PostgresPersonRepository(testDatabaseSession(ds)) {
     companion object {
         val sakId = UUIDv7.ny()
         val søknadId = UUIDv7.ny()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/DBTestHelper.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/DBTestHelper.kt
@@ -10,13 +10,13 @@ import no.nav.dagpenger.saksbehandling.Person
 import no.nav.dagpenger.saksbehandling.Sak
 import no.nav.dagpenger.saksbehandling.SakHistorikk
 import no.nav.dagpenger.saksbehandling.UUIDv7
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.oppgave.OppgaveRepository
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
 import no.nav.dagpenger.saksbehandling.db.person.PersonRepository
 import no.nav.dagpenger.saksbehandling.db.person.PostgresPersonRepository
 import no.nav.dagpenger.saksbehandling.db.sak.PostgresSakRepository
 import no.nav.dagpenger.saksbehandling.db.sak.SakRepository
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.TomHendelse
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
@@ -25,9 +25,9 @@ import javax.sql.DataSource
 
 class DBTestHelper private constructor(
     private val ds: DataSource,
-) : SakRepository by PostgresSakRepository(testDatabaseSession(ds)),
-    OppgaveRepository by PostgresOppgaveRepository(testDatabaseSession(ds)),
-    PersonRepository by PostgresPersonRepository(testDatabaseSession(ds)) {
+) : SakRepository by PostgresSakRepository(DatabaseSession(lazy { ds })),
+    OppgaveRepository by PostgresOppgaveRepository(DatabaseSession(lazy { ds })),
+    PersonRepository by PostgresPersonRepository(DatabaseSession(lazy { ds })) {
     companion object {
         val sakId = UUIDv7.ny()
         val søknadId = UUIDv7.ny()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/Postgres.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/Postgres.kt
@@ -5,6 +5,8 @@ import org.flywaydb.core.internal.configuration.ConfigUtils
 import org.testcontainers.postgresql.PostgreSQLContainer
 import javax.sql.DataSource
 
+internal fun testDatabaseSession(ds: DataSource) = DatabaseSession(lazy { ds })
+
 internal object Postgres {
     val instance by lazy {
         PostgreSQLContainer("postgres:18.1").apply {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/Postgres.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/Postgres.kt
@@ -5,8 +5,6 @@ import org.flywaydb.core.internal.configuration.ConfigUtils
 import org.testcontainers.postgresql.PostgreSQLContainer
 import javax.sql.DataSource
 
-internal fun testDatabaseSession(ds: DataSource) = DatabaseSession(lazy { ds })
-
 internal object Postgres {
     val instance by lazy {
         PostgreSQLContainer("postgres:18.1").apply {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/PostgresTriggerTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/PostgresTriggerTest.kt
@@ -5,8 +5,8 @@ import kotliquery.queryOf
 import kotliquery.sessionOf
 import no.nav.dagpenger.saksbehandling.Oppgave
 import no.nav.dagpenger.saksbehandling.TestHelper
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import org.junit.jupiter.api.Test
 import java.sql.Timestamp
 import java.util.UUID
@@ -16,7 +16,7 @@ class PostgresTriggerTest {
     @Test
     fun `Når en oppgave endres så skal endret_tidspunkt oppdateres`() {
         DBTestHelper.withOppgave(TestHelper.testOppgave) { ds ->
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             repo.lagre(TestHelper.testOppgave)
             val endretTidspunkt = ds.hentEndretTidspunkt(TestHelper.testOppgave.oppgaveId)
             Thread.sleep(100)

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/PostgresTriggerTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/PostgresTriggerTest.kt
@@ -6,6 +6,7 @@ import kotliquery.sessionOf
 import no.nav.dagpenger.saksbehandling.Oppgave
 import no.nav.dagpenger.saksbehandling.TestHelper
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import org.junit.jupiter.api.Test
 import java.sql.Timestamp
 import java.util.UUID
@@ -15,7 +16,7 @@ class PostgresTriggerTest {
     @Test
     fun `Når en oppgave endres så skal endret_tidspunkt oppdateres`() {
         DBTestHelper.withOppgave(TestHelper.testOppgave) { ds ->
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             repo.lagre(TestHelper.testOppgave)
             val endretTidspunkt = ds.hentEndretTidspunkt(TestHelper.testOppgave.oppgaveId)
             Thread.sleep(100)

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/innsending/PostgresInnsendingRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/innsending/PostgresInnsendingRepositoryTest.kt
@@ -4,7 +4,7 @@ import io.kotest.matchers.shouldBe
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper.Companion.testPerson
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.Kategori
 import no.nav.dagpenger.saksbehandling.innsending.Innsending
 import org.junit.jupiter.api.Test
@@ -36,7 +36,7 @@ class PostgresInnsendingRepositoryTest {
                         ),
                     valgtSakId = null,
                 )
-            val repository = PostgresInnsendingRepository(testDatabaseSession(ds))
+            val repository = PostgresInnsendingRepository(DatabaseSession(lazy { ds }))
             repository.lagre(innsending = innsending)
 
             repository.hent(innsending.innsendingId).also { dbInnsending ->

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/innsending/PostgresInnsendingRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/innsending/PostgresInnsendingRepositoryTest.kt
@@ -4,6 +4,7 @@ import io.kotest.matchers.shouldBe
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper.Companion.testPerson
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.Kategori
 import no.nav.dagpenger.saksbehandling.innsending.Innsending
 import org.junit.jupiter.api.Test
@@ -35,7 +36,7 @@ class PostgresInnsendingRepositoryTest {
                         ),
                     valgtSakId = null,
                 )
-            val repository = PostgresInnsendingRepository(ds)
+            val repository = PostgresInnsendingRepository(testDatabaseSession(ds))
             repository.lagre(innsending = innsending)
 
             repository.hent(innsending.innsendingId).also { dbInnsending ->

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/klage/PostgresKlageRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/klage/PostgresKlageRepositoryTest.kt
@@ -11,11 +11,11 @@ import no.nav.dagpenger.saksbehandling.Person
 import no.nav.dagpenger.saksbehandling.Tilstandsendring
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.api.Oppslag
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.Postgres.withMigratedDb
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.db.person.PostgresPersonRepository
 import no.nav.dagpenger.saksbehandling.db.sak.PostgresSakRepository
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.KlageMottattHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.SøknadsbehandlingOpprettetHendelse
@@ -50,7 +50,7 @@ class PostgresKlageRepositoryTest {
                         PersonMediator(
                             personRepository =
                                 PostgresPersonRepository(
-                                    testDatabaseSession(ds),
+                                    DatabaseSession(lazy { ds }),
                                 ),
                             oppslag =
                                 mockk<Oppslag>().also {
@@ -59,7 +59,7 @@ class PostgresKlageRepositoryTest {
                                         AdressebeskyttelseGradering.UGRADERT
                                 },
                         ),
-                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
                     rapidsConnection = mockk(relaxed = true),
                 )
 
@@ -93,7 +93,7 @@ class PostgresKlageRepositoryTest {
                         type = HendelseBehandler.Intern.Klage,
                     ),
             )
-            val klageRepository = PostgresKlageRepository(testDatabaseSession(ds))
+            val klageRepository = PostgresKlageRepository(DatabaseSession(lazy { ds }))
 
             test(klageRepository, sak.sakId)
         }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/klage/PostgresKlageRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/klage/PostgresKlageRepositoryTest.kt
@@ -15,6 +15,7 @@ import no.nav.dagpenger.saksbehandling.db.Postgres.withMigratedDb
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.db.person.PostgresPersonRepository
 import no.nav.dagpenger.saksbehandling.db.sak.PostgresSakRepository
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.KlageMottattHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.SøknadsbehandlingOpprettetHendelse
@@ -49,7 +50,7 @@ class PostgresKlageRepositoryTest {
                         PersonMediator(
                             personRepository =
                                 PostgresPersonRepository(
-                                    dataSource = ds,
+                                    testDatabaseSession(ds),
                                 ),
                             oppslag =
                                 mockk<Oppslag>().also {
@@ -58,7 +59,7 @@ class PostgresKlageRepositoryTest {
                                         AdressebeskyttelseGradering.UGRADERT
                                 },
                         ),
-                    sakRepository = PostgresSakRepository(dataSource = ds),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
                     rapidsConnection = mockk(relaxed = true),
                 )
 
@@ -92,7 +93,7 @@ class PostgresKlageRepositoryTest {
                         type = HendelseBehandler.Intern.Klage,
                     ),
             )
-            val klageRepository = PostgresKlageRepository(datasource = ds)
+            val klageRepository = PostgresKlageRepository(testDatabaseSession(ds))
 
             test(klageRepository, sak.sakId)
         }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/oppfolging/PostgresOppfølgingRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/oppfolging/PostgresOppfølgingRepositoryTest.kt
@@ -4,9 +4,9 @@ import io.kotest.matchers.shouldBe
 import no.nav.dagpenger.saksbehandling.AdressebeskyttelseGradering
 import no.nav.dagpenger.saksbehandling.Person
 import no.nav.dagpenger.saksbehandling.UUIDv7
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.Postgres.withMigratedDb
 import no.nav.dagpenger.saksbehandling.db.person.PostgresPersonRepository
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.oppfolging.Oppfølging
 import no.nav.dagpenger.saksbehandling.oppfolging.OppfølgingAksjon
 import org.junit.jupiter.api.Test
@@ -24,8 +24,8 @@ class PostgresOppfølgingRepositoryTest {
     @Test
     fun `Skal lagre og hente oppfølging`() {
         withMigratedDb { ds ->
-            val personRepository = PostgresPersonRepository(testDatabaseSession(ds))
-            val repository = PostgresOppfølgingRepository(testDatabaseSession(ds))
+            val personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds }))
+            val repository = PostgresOppfølgingRepository(DatabaseSession(lazy { ds }))
 
             personRepository.lagre(testPerson)
 
@@ -51,8 +51,8 @@ class PostgresOppfølgingRepositoryTest {
     @Test
     fun `Skal oppdatere oppfølging ved ferdigstilling`() {
         withMigratedDb { ds ->
-            val personRepository = PostgresPersonRepository(testDatabaseSession(ds))
-            val repository = PostgresOppfølgingRepository(testDatabaseSession(ds))
+            val personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds }))
+            val repository = PostgresOppfølgingRepository(DatabaseSession(lazy { ds }))
 
             personRepository.lagre(testPerson)
 
@@ -85,8 +85,8 @@ class PostgresOppfølgingRepositoryTest {
     @Test
     fun `Skal lagre og hente oppgave med klage-resultat`() {
         withMigratedDb { ds ->
-            val personRepository = PostgresPersonRepository(testDatabaseSession(ds))
-            val repository = PostgresOppfølgingRepository(testDatabaseSession(ds))
+            val personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds }))
+            val repository = PostgresOppfølgingRepository(DatabaseSession(lazy { ds }))
 
             personRepository.lagre(testPerson)
 
@@ -114,8 +114,8 @@ class PostgresOppfølgingRepositoryTest {
     @Test
     fun `Skal lagre og hente oppgave med RettTilDagpenger-resultat`() {
         withMigratedDb { ds ->
-            val personRepository = PostgresPersonRepository(testDatabaseSession(ds))
-            val repository = PostgresOppfølgingRepository(testDatabaseSession(ds))
+            val personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds }))
+            val repository = PostgresOppfølgingRepository(DatabaseSession(lazy { ds }))
 
             personRepository.lagre(testPerson)
 
@@ -145,8 +145,8 @@ class PostgresOppfølgingRepositoryTest {
     @Test
     fun `Skal finne oppgaver for person`() {
         withMigratedDb { ds ->
-            val personRepository = PostgresPersonRepository(testDatabaseSession(ds))
-            val repository = PostgresOppfølgingRepository(testDatabaseSession(ds))
+            val personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds }))
+            val repository = PostgresOppfølgingRepository(DatabaseSession(lazy { ds }))
 
             personRepository.lagre(testPerson)
 
@@ -174,7 +174,7 @@ class PostgresOppfølgingRepositoryTest {
     @Test
     fun `Skal returnere null ved finn med ukjent id`() {
         withMigratedDb { ds ->
-            val repository = PostgresOppfølgingRepository(testDatabaseSession(ds))
+            val repository = PostgresOppfølgingRepository(DatabaseSession(lazy { ds }))
 
             val resultat = repository.finn(UUID.randomUUID())
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/oppfolging/PostgresOppfølgingRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/oppfolging/PostgresOppfølgingRepositoryTest.kt
@@ -6,6 +6,7 @@ import no.nav.dagpenger.saksbehandling.Person
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.db.Postgres.withMigratedDb
 import no.nav.dagpenger.saksbehandling.db.person.PostgresPersonRepository
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.oppfolging.Oppfølging
 import no.nav.dagpenger.saksbehandling.oppfolging.OppfølgingAksjon
 import org.junit.jupiter.api.Test
@@ -23,8 +24,8 @@ class PostgresOppfølgingRepositoryTest {
     @Test
     fun `Skal lagre og hente oppfølging`() {
         withMigratedDb { ds ->
-            val personRepository = PostgresPersonRepository(ds)
-            val repository = PostgresOppfølgingRepository(ds)
+            val personRepository = PostgresPersonRepository(testDatabaseSession(ds))
+            val repository = PostgresOppfølgingRepository(testDatabaseSession(ds))
 
             personRepository.lagre(testPerson)
 
@@ -50,8 +51,8 @@ class PostgresOppfølgingRepositoryTest {
     @Test
     fun `Skal oppdatere oppfølging ved ferdigstilling`() {
         withMigratedDb { ds ->
-            val personRepository = PostgresPersonRepository(ds)
-            val repository = PostgresOppfølgingRepository(ds)
+            val personRepository = PostgresPersonRepository(testDatabaseSession(ds))
+            val repository = PostgresOppfølgingRepository(testDatabaseSession(ds))
 
             personRepository.lagre(testPerson)
 
@@ -84,8 +85,8 @@ class PostgresOppfølgingRepositoryTest {
     @Test
     fun `Skal lagre og hente oppgave med klage-resultat`() {
         withMigratedDb { ds ->
-            val personRepository = PostgresPersonRepository(ds)
-            val repository = PostgresOppfølgingRepository(ds)
+            val personRepository = PostgresPersonRepository(testDatabaseSession(ds))
+            val repository = PostgresOppfølgingRepository(testDatabaseSession(ds))
 
             personRepository.lagre(testPerson)
 
@@ -113,8 +114,8 @@ class PostgresOppfølgingRepositoryTest {
     @Test
     fun `Skal lagre og hente oppgave med RettTilDagpenger-resultat`() {
         withMigratedDb { ds ->
-            val personRepository = PostgresPersonRepository(ds)
-            val repository = PostgresOppfølgingRepository(ds)
+            val personRepository = PostgresPersonRepository(testDatabaseSession(ds))
+            val repository = PostgresOppfølgingRepository(testDatabaseSession(ds))
 
             personRepository.lagre(testPerson)
 
@@ -144,8 +145,8 @@ class PostgresOppfølgingRepositoryTest {
     @Test
     fun `Skal finne oppgaver for person`() {
         withMigratedDb { ds ->
-            val personRepository = PostgresPersonRepository(ds)
-            val repository = PostgresOppfølgingRepository(ds)
+            val personRepository = PostgresPersonRepository(testDatabaseSession(ds))
+            val repository = PostgresOppfølgingRepository(testDatabaseSession(ds))
 
             personRepository.lagre(testPerson)
 
@@ -173,7 +174,7 @@ class PostgresOppfølgingRepositoryTest {
     @Test
     fun `Skal returnere null ved finn med ukjent id`() {
         withMigratedDb { ds ->
-            val repository = PostgresOppfølgingRepository(ds)
+            val repository = PostgresOppfølgingRepository(testDatabaseSession(ds))
 
             val resultat = repository.finn(UUID.randomUUID())
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepositoryTest.kt
@@ -31,6 +31,7 @@ import no.nav.dagpenger.saksbehandling.Tilstandsendring
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.adressebeskyttelseTilganger
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.GodkjentBehandlingHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.NesteOppgaveHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.NotatHendelse
@@ -69,7 +70,7 @@ class PostgresOppgaveRepositoryTest {
             )
 
         DBTestHelper.Companion.withBehandling(behandling = behandling) { ds ->
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             val saksbehandler =
                 Saksbehandler(
                     navIdent = "NAVIdent2",
@@ -105,7 +106,7 @@ class PostgresOppgaveRepositoryTest {
             person = testPerson,
             behandlinger = listOf(søknadBehandlingKlarTilBehandling, søknadBehandlingKlarTilKontroll),
         ) { ds ->
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
 
             lagOppgave(
                 tilstand = Oppgave.KlarTilBehandling,
@@ -177,7 +178,7 @@ class PostgresOppgaveRepositoryTest {
             person = testPerson,
             behandlinger = listOf(klageBehandling, søknadBehandling),
         ) { ds ->
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
 
             lagOppgave(
                 tilstand = Oppgave.KlarTilBehandling,
@@ -256,7 +257,7 @@ class PostgresOppgaveRepositoryTest {
                     ),
             )
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
 
             val saksbehandlerUtenTilgangTilEgneAnsatte =
                 Saksbehandler(
@@ -347,7 +348,7 @@ class PostgresOppgaveRepositoryTest {
                     tilganger = emptySet(),
                 )
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             val nesteOppgave =
                 repo.tildelOgHentNesteOppgave(
                     nesteOppgaveHendelse =
@@ -412,7 +413,7 @@ class PostgresOppgaveRepositoryTest {
                     emneknagger = setOf("Testknagg"),
                 )
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             val saksbehandler =
                 Saksbehandler(
                     navIdent = "NAVIdent",
@@ -516,7 +517,7 @@ class PostgresOppgaveRepositoryTest {
                     tilstandslogg = tilstandsloggUnderBehandling,
                 )
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
 
             repo.tildelOgHentNesteOppgave(
                 nesteOppgaveHendelse =
@@ -749,7 +750,7 @@ class PostgresOppgaveRepositoryTest {
                     navIdent = testSaksbehandler.navIdent,
                 )
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             repo
                 .tildelOgHentNesteOppgave(
                     nesteOppgaveHendelse =
@@ -980,7 +981,7 @@ class PostgresOppgaveRepositoryTest {
             this.leggTilOppgave(tilstand = Oppgave.KlarTilBehandling, opprettet = iGår.atStartOfDay())
 
             val repo =
-                PostgresOppgaveRepository(ds)
+                PostgresOppgaveRepository(testDatabaseSession(ds))
                     .tildelOgHentNesteOppgave(
                         nesteOppgaveHendelse =
                             NesteOppgaveHendelse(
@@ -1007,7 +1008,7 @@ class PostgresOppgaveRepositoryTest {
     @Test
     fun `Skal kunne lagre en oppgave flere ganger`() {
         DBTestHelper.withOppgave(oppgave = TestHelper.testOppgave) { ds ->
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             shouldNotThrowAny {
                 repo.lagre(TestHelper.testOppgave)
                 repo.lagre(TestHelper.testOppgave)
@@ -1033,7 +1034,7 @@ class PostgresOppgaveRepositoryTest {
                     utførtAv = beslutter,
                 ),
             )
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             repo.lagre(testOppgave)
             val oppgaveFraDatabase = repo.hentOppgave(testOppgave.oppgaveId)
 
@@ -1046,7 +1047,7 @@ class PostgresOppgaveRepositoryTest {
         val oppgave = lagOppgave(tilstand = Oppgave.KlarTilKontroll)
         DBTestHelper.withOppgave(oppgave) { ds ->
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             oppgave.tildel(
                 SettOppgaveAnsvarHendelse(
                     oppgaveId = oppgave.oppgaveId,
@@ -1076,7 +1077,7 @@ class PostgresOppgaveRepositoryTest {
         val oppgave = lagOppgave(tilstand = Oppgave.KlarTilKontroll)
         DBTestHelper.withOppgave(oppgave) { ds ->
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             oppgave.tildel(
                 SettOppgaveAnsvarHendelse(
                     oppgaveId = oppgave.oppgaveId,
@@ -1107,7 +1108,7 @@ class PostgresOppgaveRepositoryTest {
         val testOppgave = lagOppgave(behandling = behandling, person = testPerson)
 
         DBTestHelper.withBehandling(behandling = behandling, person = testPerson) { ds ->
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             repo.lagre(testOppgave)
             val oppgaveFraDatabase = repo.hentOppgave(testOppgave.oppgaveId)
             oppgaveFraDatabase shouldBe testOppgave
@@ -1133,7 +1134,7 @@ class PostgresOppgaveRepositoryTest {
                     utførtAv = beslutter,
                 ),
             )
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             repo.lagre(testOppgave)
 
             val oppgaveFraDatabase = repo.hentOppgave(testOppgave.oppgaveId)
@@ -1186,7 +1187,7 @@ class PostgresOppgaveRepositoryTest {
         val testOppgave = lagOppgave(tilstandslogg = tilstandslogg, oppgaveId = oppgaveIdTest)
         DBTestHelper.withOppgave(testOppgave) { ds ->
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             val oppgaveFraDatabase = repo.hentOppgave(testOppgave.oppgaveId)
             oppgaveFraDatabase.tilstandslogg.size shouldBe testOppgave.tilstandslogg.size
             oppgaveFraDatabase.tilstandslogg.forEachIndexed { index, tilstandsendring ->
@@ -1204,7 +1205,7 @@ class PostgresOppgaveRepositoryTest {
     fun `Skal kunne endre tilstand på en oppgave`() {
         val testOppgave = lagOppgave(tilstand = Oppgave.KlarTilBehandling)
         DBTestHelper.withOppgave(testOppgave) { ds ->
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
 
             repo.lagre(testOppgave)
             repo.hentOppgave(testOppgave.oppgaveId).tilstand().type shouldBe KLAR_TIL_BEHANDLING
@@ -1219,7 +1220,7 @@ class PostgresOppgaveRepositoryTest {
         val testOppgave = lagOppgave(tilstand = Oppgave.UnderBehandling)
         val utsattTil = LocalDate.now().plusDays(1)
         DBTestHelper.withOppgave(testOppgave) { ds ->
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             repo.lagre(
                 testOppgave.copy(
                     tilstand = Oppgave.PåVent,
@@ -1239,7 +1240,7 @@ class PostgresOppgaveRepositoryTest {
             val oppgaveOpprettet = this.leggTilOppgave(tilstand = Oppgave.Opprettet, type = HendelseBehandler.Intern.Innsending)
             val oppgaveKlarTilBehandling = this.leggTilOppgave(tilstand = Oppgave.KlarTilBehandling)
             val oppgaveFerdigBehandlet = this.leggTilOppgave(tilstand = Oppgave.FerdigBehandlet)
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
 
             repo.hentAlleOppgaverMedTilstand(Oppgave.Tilstand.Type.OPPRETTET).let { oppgaver ->
                 oppgaver.size shouldBe 1
@@ -1271,7 +1272,7 @@ class PostgresOppgaveRepositoryTest {
                     opprettet = opprettetNå,
                 )
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             repo
                 .søk(
                     søkeFilter =
@@ -1303,7 +1304,7 @@ class PostgresOppgaveRepositoryTest {
             )
 
         DBTestHelper.withMigratedDb { ds ->
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             val oppgave1TilOla =
                 this.leggTilOppgave(person = ola, tilstand = Oppgave.KlarTilBehandling, opprettet = opprettetNå)
             val oppgave2TilOla =
@@ -1351,7 +1352,7 @@ class PostgresOppgaveRepositoryTest {
         DBTestHelper.withBehandling(
             behandling = behandling,
         ) { ds ->
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             val oppgave =
                 lagOppgave(
                     oppgaveId = UUIDv7.ny(),
@@ -1410,7 +1411,7 @@ class PostgresOppgaveRepositoryTest {
                     behandling = behandling,
                     person = person,
                 )
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             repo.lagre(oppgave = oppgave)
 
             repo.oppgaveTilstandForSøknad(
@@ -1431,7 +1432,7 @@ class PostgresOppgaveRepositoryTest {
         val oppgave = lagOppgave(behandling = behandling)
 
         DBTestHelper.withBehandling(behandling = behandling) { ds ->
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             repo.lagre(oppgave)
             repo.hentOppgaveIdFor(behandlingId = behandling.behandlingId) shouldBe oppgave.oppgaveId
             repo.hentOppgaveIdFor(behandlingId = UUIDv7.ny()) shouldBe null
@@ -1445,7 +1446,7 @@ class PostgresOppgaveRepositoryTest {
             val oppgave2 = this.leggTilOppgave(emneknagger = setOf("hubba"), opprettet = opprettetNå)
             val oppgave3 = this.leggTilOppgave(emneknagger = emptySet(), opprettet = opprettetNå)
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             repo
                 .søk(
                     Søkefilter(
@@ -1521,7 +1522,7 @@ class PostgresOppgaveRepositoryTest {
                 emneknagger = setOf(Emneknagg.Regelknagg.INNVILGELSE.visningsnavn),
             )
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             repo
                 .søk(
                     Søkefilter(
@@ -1580,7 +1581,7 @@ class PostgresOppgaveRepositoryTest {
             val nestEldsteOppgave = this.leggTilOppgave(opprettet = opprettetNå.minusDays(3))
             val eldsteOppgave = this.leggTilOppgave(opprettet = opprettetNå.minusDays(7))
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             repo
                 .søk(
                     Søkefilter(
@@ -1660,7 +1661,7 @@ class PostgresOppgaveRepositoryTest {
             val nestEldsteOppgave = this.leggTilOppgave(opprettet = opprettetNå.minusDays(3))
             val eldsteOppgave = this.leggTilOppgave(opprettet = opprettetNå.minusDays(7))
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
 
             // Default sortering (uten å oppgi sortering) skal gi eldste først
             repo
@@ -1763,7 +1764,7 @@ class PostgresOppgaveRepositoryTest {
                     tilstand = Oppgave.KlarTilBehandling,
                 )
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
 
             repo
                 .søk(
@@ -1821,7 +1822,7 @@ class PostgresOppgaveRepositoryTest {
                     tilstand = Oppgave.UnderBehandling,
                 )
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
 
             repo
                 .søk(
@@ -1875,7 +1876,7 @@ class PostgresOppgaveRepositoryTest {
                     tilstand = Oppgave.KlarTilBehandling,
                 )
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
 
             repo
                 .søk(
@@ -1916,7 +1917,7 @@ class PostgresOppgaveRepositoryTest {
                 opprettet = opprettetNå.minusDays(1),
             )
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             repo
                 .søk(
                     Søkefilter(
@@ -2024,7 +2025,7 @@ class PostgresOppgaveRepositoryTest {
             this.leggTilOppgave(tilstand = Oppgave.KlarTilBehandling, opprettet = iForgårsSåSeintPåDagenSomMulig)
             this.leggTilOppgave(tilstand = Oppgave.KlarTilBehandling, opprettet = iDagSåTidligPåDagenSomMulig)
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             val oppgaver =
                 repo.søk(
                     Søkefilter(
@@ -2048,7 +2049,7 @@ class PostgresOppgaveRepositoryTest {
             val oppgaveIGår = this.leggTilOppgave(tilstand = Oppgave.KlarTilBehandling, opprettet = iGår.atStartOfDay())
             val oppgave3 = this.leggTilOppgave(tilstand = Oppgave.KlarTilBehandling, opprettet = iDag.atStartOfDay())
 
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             val oppgaver =
                 repo.søk(
                     Søkefilter(
@@ -2067,7 +2068,7 @@ class PostgresOppgaveRepositoryTest {
     @Test
     fun `Skal hente en oppgave basert på behandlingId`() {
         DBTestHelper.withOppgave(oppgave = TestHelper.testOppgave) { ds ->
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             repo.hentOppgaveFor(TestHelper.testOppgave.behandling.behandlingId) shouldBe TestHelper.testOppgave
 
             shouldThrow<DataNotFoundException> {
@@ -2079,7 +2080,7 @@ class PostgresOppgaveRepositoryTest {
     @Test
     fun `Skal finne en oppgave basert på behandlingId hvis den finnes`() {
         DBTestHelper.withOppgave(TestHelper.testOppgave) { ds ->
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             repo.finnOppgaveFor(TestHelper.testOppgave.behandling.behandlingId) shouldBe TestHelper.testOppgave
             repo.finnOppgaveFor(behandlingId = UUIDv7.ny()) shouldBe null
         }
@@ -2095,7 +2096,7 @@ class PostgresOppgaveRepositoryTest {
                     ),
             )
         DBTestHelper.withOppgave(oppgave = oppgave) { ds ->
-            PostgresOppgaveRepository(ds)
+            PostgresOppgaveRepository(testDatabaseSession(ds))
                 .adresseGraderingForPerson(oppgave.oppgaveId) shouldBe STRENGT_FORTROLIG
         }
     }
@@ -2115,7 +2116,7 @@ class PostgresOppgaveRepositoryTest {
                 tilstandslogg = OppgaveTilstandslogg(tilstandsendring),
             )
         DBTestHelper.withBehandling(behandling = behandling) { ds ->
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             repo.lagre(testOppgave)
             val oppgaveFraDatabase = repo.hentOppgave(testOppgave.oppgaveId)
             oppgaveFraDatabase.tilstandslogg shouldBe testOppgave.tilstandslogg
@@ -2140,7 +2141,7 @@ class PostgresOppgaveRepositoryTest {
             )
 
         DBTestHelper.Companion.withBehandlinger(behandlinger = listOf(behandling1, behandling2)) { ds ->
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             val oppgave1 =
                 lagOppgave(
                     tilstand = Oppgave.KlarTilBehandling,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepositoryTest.kt
@@ -31,7 +31,7 @@ import no.nav.dagpenger.saksbehandling.Tilstandsendring
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.adressebeskyttelseTilganger
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.GodkjentBehandlingHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.NesteOppgaveHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.NotatHendelse
@@ -70,7 +70,7 @@ class PostgresOppgaveRepositoryTest {
             )
 
         DBTestHelper.Companion.withBehandling(behandling = behandling) { ds ->
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             val saksbehandler =
                 Saksbehandler(
                     navIdent = "NAVIdent2",
@@ -106,7 +106,7 @@ class PostgresOppgaveRepositoryTest {
             person = testPerson,
             behandlinger = listOf(søknadBehandlingKlarTilBehandling, søknadBehandlingKlarTilKontroll),
         ) { ds ->
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
 
             lagOppgave(
                 tilstand = Oppgave.KlarTilBehandling,
@@ -178,7 +178,7 @@ class PostgresOppgaveRepositoryTest {
             person = testPerson,
             behandlinger = listOf(klageBehandling, søknadBehandling),
         ) { ds ->
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
 
             lagOppgave(
                 tilstand = Oppgave.KlarTilBehandling,
@@ -257,7 +257,7 @@ class PostgresOppgaveRepositoryTest {
                     ),
             )
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
 
             val saksbehandlerUtenTilgangTilEgneAnsatte =
                 Saksbehandler(
@@ -348,7 +348,7 @@ class PostgresOppgaveRepositoryTest {
                     tilganger = emptySet(),
                 )
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             val nesteOppgave =
                 repo.tildelOgHentNesteOppgave(
                     nesteOppgaveHendelse =
@@ -413,7 +413,7 @@ class PostgresOppgaveRepositoryTest {
                     emneknagger = setOf("Testknagg"),
                 )
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             val saksbehandler =
                 Saksbehandler(
                     navIdent = "NAVIdent",
@@ -517,7 +517,7 @@ class PostgresOppgaveRepositoryTest {
                     tilstandslogg = tilstandsloggUnderBehandling,
                 )
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
 
             repo.tildelOgHentNesteOppgave(
                 nesteOppgaveHendelse =
@@ -750,7 +750,7 @@ class PostgresOppgaveRepositoryTest {
                     navIdent = testSaksbehandler.navIdent,
                 )
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             repo
                 .tildelOgHentNesteOppgave(
                     nesteOppgaveHendelse =
@@ -981,7 +981,7 @@ class PostgresOppgaveRepositoryTest {
             this.leggTilOppgave(tilstand = Oppgave.KlarTilBehandling, opprettet = iGår.atStartOfDay())
 
             val repo =
-                PostgresOppgaveRepository(testDatabaseSession(ds))
+                PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
                     .tildelOgHentNesteOppgave(
                         nesteOppgaveHendelse =
                             NesteOppgaveHendelse(
@@ -1008,7 +1008,7 @@ class PostgresOppgaveRepositoryTest {
     @Test
     fun `Skal kunne lagre en oppgave flere ganger`() {
         DBTestHelper.withOppgave(oppgave = TestHelper.testOppgave) { ds ->
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             shouldNotThrowAny {
                 repo.lagre(TestHelper.testOppgave)
                 repo.lagre(TestHelper.testOppgave)
@@ -1034,7 +1034,7 @@ class PostgresOppgaveRepositoryTest {
                     utførtAv = beslutter,
                 ),
             )
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             repo.lagre(testOppgave)
             val oppgaveFraDatabase = repo.hentOppgave(testOppgave.oppgaveId)
 
@@ -1047,7 +1047,7 @@ class PostgresOppgaveRepositoryTest {
         val oppgave = lagOppgave(tilstand = Oppgave.KlarTilKontroll)
         DBTestHelper.withOppgave(oppgave) { ds ->
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             oppgave.tildel(
                 SettOppgaveAnsvarHendelse(
                     oppgaveId = oppgave.oppgaveId,
@@ -1077,7 +1077,7 @@ class PostgresOppgaveRepositoryTest {
         val oppgave = lagOppgave(tilstand = Oppgave.KlarTilKontroll)
         DBTestHelper.withOppgave(oppgave) { ds ->
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             oppgave.tildel(
                 SettOppgaveAnsvarHendelse(
                     oppgaveId = oppgave.oppgaveId,
@@ -1108,7 +1108,7 @@ class PostgresOppgaveRepositoryTest {
         val testOppgave = lagOppgave(behandling = behandling, person = testPerson)
 
         DBTestHelper.withBehandling(behandling = behandling, person = testPerson) { ds ->
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             repo.lagre(testOppgave)
             val oppgaveFraDatabase = repo.hentOppgave(testOppgave.oppgaveId)
             oppgaveFraDatabase shouldBe testOppgave
@@ -1134,7 +1134,7 @@ class PostgresOppgaveRepositoryTest {
                     utførtAv = beslutter,
                 ),
             )
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             repo.lagre(testOppgave)
 
             val oppgaveFraDatabase = repo.hentOppgave(testOppgave.oppgaveId)
@@ -1187,7 +1187,7 @@ class PostgresOppgaveRepositoryTest {
         val testOppgave = lagOppgave(tilstandslogg = tilstandslogg, oppgaveId = oppgaveIdTest)
         DBTestHelper.withOppgave(testOppgave) { ds ->
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             val oppgaveFraDatabase = repo.hentOppgave(testOppgave.oppgaveId)
             oppgaveFraDatabase.tilstandslogg.size shouldBe testOppgave.tilstandslogg.size
             oppgaveFraDatabase.tilstandslogg.forEachIndexed { index, tilstandsendring ->
@@ -1205,7 +1205,7 @@ class PostgresOppgaveRepositoryTest {
     fun `Skal kunne endre tilstand på en oppgave`() {
         val testOppgave = lagOppgave(tilstand = Oppgave.KlarTilBehandling)
         DBTestHelper.withOppgave(testOppgave) { ds ->
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
 
             repo.lagre(testOppgave)
             repo.hentOppgave(testOppgave.oppgaveId).tilstand().type shouldBe KLAR_TIL_BEHANDLING
@@ -1220,7 +1220,7 @@ class PostgresOppgaveRepositoryTest {
         val testOppgave = lagOppgave(tilstand = Oppgave.UnderBehandling)
         val utsattTil = LocalDate.now().plusDays(1)
         DBTestHelper.withOppgave(testOppgave) { ds ->
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             repo.lagre(
                 testOppgave.copy(
                     tilstand = Oppgave.PåVent,
@@ -1240,7 +1240,7 @@ class PostgresOppgaveRepositoryTest {
             val oppgaveOpprettet = this.leggTilOppgave(tilstand = Oppgave.Opprettet, type = HendelseBehandler.Intern.Innsending)
             val oppgaveKlarTilBehandling = this.leggTilOppgave(tilstand = Oppgave.KlarTilBehandling)
             val oppgaveFerdigBehandlet = this.leggTilOppgave(tilstand = Oppgave.FerdigBehandlet)
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
 
             repo.hentAlleOppgaverMedTilstand(Oppgave.Tilstand.Type.OPPRETTET).let { oppgaver ->
                 oppgaver.size shouldBe 1
@@ -1272,7 +1272,7 @@ class PostgresOppgaveRepositoryTest {
                     opprettet = opprettetNå,
                 )
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             repo
                 .søk(
                     søkeFilter =
@@ -1304,7 +1304,7 @@ class PostgresOppgaveRepositoryTest {
             )
 
         DBTestHelper.withMigratedDb { ds ->
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             val oppgave1TilOla =
                 this.leggTilOppgave(person = ola, tilstand = Oppgave.KlarTilBehandling, opprettet = opprettetNå)
             val oppgave2TilOla =
@@ -1352,7 +1352,7 @@ class PostgresOppgaveRepositoryTest {
         DBTestHelper.withBehandling(
             behandling = behandling,
         ) { ds ->
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             val oppgave =
                 lagOppgave(
                     oppgaveId = UUIDv7.ny(),
@@ -1411,7 +1411,7 @@ class PostgresOppgaveRepositoryTest {
                     behandling = behandling,
                     person = person,
                 )
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             repo.lagre(oppgave = oppgave)
 
             repo.oppgaveTilstandForSøknad(
@@ -1432,7 +1432,7 @@ class PostgresOppgaveRepositoryTest {
         val oppgave = lagOppgave(behandling = behandling)
 
         DBTestHelper.withBehandling(behandling = behandling) { ds ->
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             repo.lagre(oppgave)
             repo.hentOppgaveIdFor(behandlingId = behandling.behandlingId) shouldBe oppgave.oppgaveId
             repo.hentOppgaveIdFor(behandlingId = UUIDv7.ny()) shouldBe null
@@ -1446,7 +1446,7 @@ class PostgresOppgaveRepositoryTest {
             val oppgave2 = this.leggTilOppgave(emneknagger = setOf("hubba"), opprettet = opprettetNå)
             val oppgave3 = this.leggTilOppgave(emneknagger = emptySet(), opprettet = opprettetNå)
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             repo
                 .søk(
                     Søkefilter(
@@ -1522,7 +1522,7 @@ class PostgresOppgaveRepositoryTest {
                 emneknagger = setOf(Emneknagg.Regelknagg.INNVILGELSE.visningsnavn),
             )
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             repo
                 .søk(
                     Søkefilter(
@@ -1581,7 +1581,7 @@ class PostgresOppgaveRepositoryTest {
             val nestEldsteOppgave = this.leggTilOppgave(opprettet = opprettetNå.minusDays(3))
             val eldsteOppgave = this.leggTilOppgave(opprettet = opprettetNå.minusDays(7))
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             repo
                 .søk(
                     Søkefilter(
@@ -1661,7 +1661,7 @@ class PostgresOppgaveRepositoryTest {
             val nestEldsteOppgave = this.leggTilOppgave(opprettet = opprettetNå.minusDays(3))
             val eldsteOppgave = this.leggTilOppgave(opprettet = opprettetNå.minusDays(7))
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
 
             // Default sortering (uten å oppgi sortering) skal gi eldste først
             repo
@@ -1764,7 +1764,7 @@ class PostgresOppgaveRepositoryTest {
                     tilstand = Oppgave.KlarTilBehandling,
                 )
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
 
             repo
                 .søk(
@@ -1822,7 +1822,7 @@ class PostgresOppgaveRepositoryTest {
                     tilstand = Oppgave.UnderBehandling,
                 )
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
 
             repo
                 .søk(
@@ -1876,7 +1876,7 @@ class PostgresOppgaveRepositoryTest {
                     tilstand = Oppgave.KlarTilBehandling,
                 )
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
 
             repo
                 .søk(
@@ -1917,7 +1917,7 @@ class PostgresOppgaveRepositoryTest {
                 opprettet = opprettetNå.minusDays(1),
             )
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             repo
                 .søk(
                     Søkefilter(
@@ -2025,7 +2025,7 @@ class PostgresOppgaveRepositoryTest {
             this.leggTilOppgave(tilstand = Oppgave.KlarTilBehandling, opprettet = iForgårsSåSeintPåDagenSomMulig)
             this.leggTilOppgave(tilstand = Oppgave.KlarTilBehandling, opprettet = iDagSåTidligPåDagenSomMulig)
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             val oppgaver =
                 repo.søk(
                     Søkefilter(
@@ -2049,7 +2049,7 @@ class PostgresOppgaveRepositoryTest {
             val oppgaveIGår = this.leggTilOppgave(tilstand = Oppgave.KlarTilBehandling, opprettet = iGår.atStartOfDay())
             val oppgave3 = this.leggTilOppgave(tilstand = Oppgave.KlarTilBehandling, opprettet = iDag.atStartOfDay())
 
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             val oppgaver =
                 repo.søk(
                     Søkefilter(
@@ -2068,7 +2068,7 @@ class PostgresOppgaveRepositoryTest {
     @Test
     fun `Skal hente en oppgave basert på behandlingId`() {
         DBTestHelper.withOppgave(oppgave = TestHelper.testOppgave) { ds ->
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             repo.hentOppgaveFor(TestHelper.testOppgave.behandling.behandlingId) shouldBe TestHelper.testOppgave
 
             shouldThrow<DataNotFoundException> {
@@ -2080,7 +2080,7 @@ class PostgresOppgaveRepositoryTest {
     @Test
     fun `Skal finne en oppgave basert på behandlingId hvis den finnes`() {
         DBTestHelper.withOppgave(TestHelper.testOppgave) { ds ->
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             repo.finnOppgaveFor(TestHelper.testOppgave.behandling.behandlingId) shouldBe TestHelper.testOppgave
             repo.finnOppgaveFor(behandlingId = UUIDv7.ny()) shouldBe null
         }
@@ -2096,7 +2096,7 @@ class PostgresOppgaveRepositoryTest {
                     ),
             )
         DBTestHelper.withOppgave(oppgave = oppgave) { ds ->
-            PostgresOppgaveRepository(testDatabaseSession(ds))
+            PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
                 .adresseGraderingForPerson(oppgave.oppgaveId) shouldBe STRENGT_FORTROLIG
         }
     }
@@ -2116,7 +2116,7 @@ class PostgresOppgaveRepositoryTest {
                 tilstandslogg = OppgaveTilstandslogg(tilstandsendring),
             )
         DBTestHelper.withBehandling(behandling = behandling) { ds ->
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             repo.lagre(testOppgave)
             val oppgaveFraDatabase = repo.hentOppgave(testOppgave.oppgaveId)
             oppgaveFraDatabase.tilstandslogg shouldBe testOppgave.tilstandslogg
@@ -2141,7 +2141,7 @@ class PostgresOppgaveRepositoryTest {
             )
 
         DBTestHelper.Companion.withBehandlinger(behandlinger = listOf(behandling1, behandling2)) { ds ->
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             val oppgave1 =
                 lagOppgave(
                     tilstand = Oppgave.KlarTilBehandling,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/person/PostgresPersonRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/person/PostgresPersonRepositoryTest.kt
@@ -8,13 +8,14 @@ import no.nav.dagpenger.saksbehandling.TestHelper.lagPerson
 import no.nav.dagpenger.saksbehandling.TestHelper.testPerson
 import no.nav.dagpenger.saksbehandling.db.Postgres.withMigratedDb
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import org.junit.jupiter.api.Test
 
 class PostgresPersonRepositoryTest {
     @Test
     fun `Skal kunne lagre og hente person`() {
         withMigratedDb { ds ->
-            val repo = PostgresPersonRepository(ds)
+            val repo = PostgresPersonRepository(testDatabaseSession(ds))
             repo.lagre(testPerson)
 
             val personFraDatabase = repo.finnPerson(testPerson.ident)
@@ -25,7 +26,7 @@ class PostgresPersonRepositoryTest {
     @Test
     fun `Skal kunne oppdatere egen ansatt skjerming på en person`() {
         withMigratedDb { ds ->
-            val repo = PostgresPersonRepository(ds)
+            val repo = PostgresPersonRepository(testDatabaseSession(ds))
             repo.lagre(testPerson)
             repo.finnPerson(testPerson.ident) shouldBe testPerson
 
@@ -38,7 +39,7 @@ class PostgresPersonRepositoryTest {
     @Test
     fun `Skal kunne oppdatere bare egen ansatt skjerming på en person`() {
         withMigratedDb { ds ->
-            val repo = PostgresPersonRepository(ds)
+            val repo = PostgresPersonRepository(testDatabaseSession(ds))
             repo.lagre(testPerson)
             repo.hentPerson(testPerson.ident).skjermesSomEgneAnsatte shouldBe false
 
@@ -50,7 +51,7 @@ class PostgresPersonRepositoryTest {
     @Test
     fun `Skal kunne oppdatere adresse beskyttet status på en person`() {
         withMigratedDb { ds ->
-            val personRepository = PostgresPersonRepository(ds)
+            val personRepository = PostgresPersonRepository(testDatabaseSession(ds))
             personRepository.lagre(testPerson)
             personRepository.hentPerson(testPerson.ident).adressebeskyttelseGradering shouldBe UGRADERT
 
@@ -62,7 +63,7 @@ class PostgresPersonRepositoryTest {
     @Test
     fun `Exception hvis vi ikke får hentet person basert på ident`() {
         withMigratedDb { ds ->
-            val personRepository = PostgresPersonRepository(ds)
+            val personRepository = PostgresPersonRepository(testDatabaseSession(ds))
 
             shouldThrow<DataNotFoundException> {
                 personRepository.hentPerson(testPerson.ident)
@@ -73,7 +74,7 @@ class PostgresPersonRepositoryTest {
     @Test
     fun `Sjekk om fødselsnumre eksisterer i vårt system`() {
         withMigratedDb { ds ->
-            val personRepository = PostgresPersonRepository(ds)
+            val personRepository = PostgresPersonRepository(testDatabaseSession(ds))
             val (fnr1, fnr2, fnr3) = Triple("12345678910", "10987654321", "12345678931")
 
             personRepository.lagre(lagPerson(fnr1))

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/person/PostgresPersonRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/person/PostgresPersonRepositoryTest.kt
@@ -6,16 +6,16 @@ import no.nav.dagpenger.saksbehandling.AdressebeskyttelseGradering.STRENGT_FORTR
 import no.nav.dagpenger.saksbehandling.AdressebeskyttelseGradering.UGRADERT
 import no.nav.dagpenger.saksbehandling.TestHelper.lagPerson
 import no.nav.dagpenger.saksbehandling.TestHelper.testPerson
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.Postgres.withMigratedDb
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import org.junit.jupiter.api.Test
 
 class PostgresPersonRepositoryTest {
     @Test
     fun `Skal kunne lagre og hente person`() {
         withMigratedDb { ds ->
-            val repo = PostgresPersonRepository(testDatabaseSession(ds))
+            val repo = PostgresPersonRepository(DatabaseSession(lazy { ds }))
             repo.lagre(testPerson)
 
             val personFraDatabase = repo.finnPerson(testPerson.ident)
@@ -26,7 +26,7 @@ class PostgresPersonRepositoryTest {
     @Test
     fun `Skal kunne oppdatere egen ansatt skjerming på en person`() {
         withMigratedDb { ds ->
-            val repo = PostgresPersonRepository(testDatabaseSession(ds))
+            val repo = PostgresPersonRepository(DatabaseSession(lazy { ds }))
             repo.lagre(testPerson)
             repo.finnPerson(testPerson.ident) shouldBe testPerson
 
@@ -39,7 +39,7 @@ class PostgresPersonRepositoryTest {
     @Test
     fun `Skal kunne oppdatere bare egen ansatt skjerming på en person`() {
         withMigratedDb { ds ->
-            val repo = PostgresPersonRepository(testDatabaseSession(ds))
+            val repo = PostgresPersonRepository(DatabaseSession(lazy { ds }))
             repo.lagre(testPerson)
             repo.hentPerson(testPerson.ident).skjermesSomEgneAnsatte shouldBe false
 
@@ -51,7 +51,7 @@ class PostgresPersonRepositoryTest {
     @Test
     fun `Skal kunne oppdatere adresse beskyttet status på en person`() {
         withMigratedDb { ds ->
-            val personRepository = PostgresPersonRepository(testDatabaseSession(ds))
+            val personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds }))
             personRepository.lagre(testPerson)
             personRepository.hentPerson(testPerson.ident).adressebeskyttelseGradering shouldBe UGRADERT
 
@@ -63,7 +63,7 @@ class PostgresPersonRepositoryTest {
     @Test
     fun `Exception hvis vi ikke får hentet person basert på ident`() {
         withMigratedDb { ds ->
-            val personRepository = PostgresPersonRepository(testDatabaseSession(ds))
+            val personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds }))
 
             shouldThrow<DataNotFoundException> {
                 personRepository.hentPerson(testPerson.ident)
@@ -74,7 +74,7 @@ class PostgresPersonRepositoryTest {
     @Test
     fun `Sjekk om fødselsnumre eksisterer i vårt system`() {
         withMigratedDb { ds ->
-            val personRepository = PostgresPersonRepository(testDatabaseSession(ds))
+            val personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds }))
             val (fnr1, fnr2, fnr3) = Triple("12345678910", "10987654321", "12345678931")
 
             personRepository.lagre(lagPerson(fnr1))

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/sak/PostgresSakRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/sak/PostgresSakRepositoryTest.kt
@@ -10,8 +10,8 @@ import no.nav.dagpenger.saksbehandling.Sak
 import no.nav.dagpenger.saksbehandling.SakHistorikk
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.DpBehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.SøknadsbehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.TomHendelse
@@ -109,7 +109,7 @@ class PostgresSakRepositoryTest {
     @Test
     fun `Skal kunne lagre sakHistorikk`() {
         DBTestHelper.withPerson(person) { dataSource ->
-            val sakRepository = PostgresSakRepository(testDatabaseSession(dataSource))
+            val sakRepository = PostgresSakRepository(DatabaseSession(lazy { dataSource }))
             sakRepository.lagre(sakHistorikk)
             this.leggTilOppgave(oppgaveId, behandling1iSak1.behandlingId)
             val sakHistorikkFraDB = sakRepository.hentSakHistorikk(person.ident)
@@ -159,7 +159,7 @@ class PostgresSakRepositoryTest {
                     it.leggTilSak(sak1)
                     it.leggTilSak(sakFerietillegg)
                 }
-            val sakRepository = PostgresSakRepository(testDatabaseSession(dataSource))
+            val sakRepository = PostgresSakRepository(DatabaseSession(lazy { dataSource }))
             sakRepository.lagre(sakHistorikkMedFerietillegg)
             val sakHistorikkFraDB = sakRepository.hentSakHistorikk(person.ident)
 
@@ -182,7 +182,7 @@ class PostgresSakRepositoryTest {
     @Test
     fun `Hent sakId basert på behandlingId`() {
         DBTestHelper.withSaker(saker = listOf(sak1)) { ds ->
-            val sakRepository = PostgresSakRepository(testDatabaseSession(ds))
+            val sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds }))
 
             sakRepository.merkSakenSomDpSak(sak1.sakId, true)
             sakRepository.hentSakIdForBehandlingId(behandling1iSak1.behandlingId) shouldBe sak1.sakId
@@ -199,7 +199,7 @@ class PostgresSakRepositoryTest {
     @Test
     fun `Henter sakId til nyeste dp-sak for en person`() {
         DBTestHelper.withSaker(saker = listOf(sak1, sak2)) { ds ->
-            val sakRepository = PostgresSakRepository(testDatabaseSession(ds))
+            val sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds }))
 
             ds.opprettOppgaveForBehandling(behandlingId = behandling1iSak1.behandlingId)
             ds.opprettOppgaveForBehandling(behandlingId = behandling2iSak1.behandlingId)
@@ -225,7 +225,7 @@ class PostgresSakRepositoryTest {
     @Test
     fun `Finner sakId for en søknad`() {
         DBTestHelper.withSaker(saker = listOf(sak1, sak2)) { ds ->
-            val sakRepository = PostgresSakRepository(testDatabaseSession(ds))
+            val sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds }))
 
             sakRepository.finnSakIdForSøknad(
                 søknadId = søknadIdSak1,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/sak/PostgresSakRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/sak/PostgresSakRepositoryTest.kt
@@ -11,6 +11,7 @@ import no.nav.dagpenger.saksbehandling.SakHistorikk
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.DpBehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.SøknadsbehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.TomHendelse
@@ -108,7 +109,7 @@ class PostgresSakRepositoryTest {
     @Test
     fun `Skal kunne lagre sakHistorikk`() {
         DBTestHelper.withPerson(person) { dataSource ->
-            val sakRepository = PostgresSakRepository(dataSource = dataSource)
+            val sakRepository = PostgresSakRepository(testDatabaseSession(dataSource))
             sakRepository.lagre(sakHistorikk)
             this.leggTilOppgave(oppgaveId, behandling1iSak1.behandlingId)
             val sakHistorikkFraDB = sakRepository.hentSakHistorikk(person.ident)
@@ -158,7 +159,7 @@ class PostgresSakRepositoryTest {
                     it.leggTilSak(sak1)
                     it.leggTilSak(sakFerietillegg)
                 }
-            val sakRepository = PostgresSakRepository(dataSource = dataSource)
+            val sakRepository = PostgresSakRepository(testDatabaseSession(dataSource))
             sakRepository.lagre(sakHistorikkMedFerietillegg)
             val sakHistorikkFraDB = sakRepository.hentSakHistorikk(person.ident)
 
@@ -181,7 +182,7 @@ class PostgresSakRepositoryTest {
     @Test
     fun `Hent sakId basert på behandlingId`() {
         DBTestHelper.withSaker(saker = listOf(sak1)) { ds ->
-            val sakRepository = PostgresSakRepository(ds)
+            val sakRepository = PostgresSakRepository(testDatabaseSession(ds))
 
             sakRepository.merkSakenSomDpSak(sak1.sakId, true)
             sakRepository.hentSakIdForBehandlingId(behandling1iSak1.behandlingId) shouldBe sak1.sakId
@@ -198,7 +199,7 @@ class PostgresSakRepositoryTest {
     @Test
     fun `Henter sakId til nyeste dp-sak for en person`() {
         DBTestHelper.withSaker(saker = listOf(sak1, sak2)) { ds ->
-            val sakRepository = PostgresSakRepository(ds)
+            val sakRepository = PostgresSakRepository(testDatabaseSession(ds))
 
             ds.opprettOppgaveForBehandling(behandlingId = behandling1iSak1.behandlingId)
             ds.opprettOppgaveForBehandling(behandlingId = behandling2iSak1.behandlingId)
@@ -224,7 +225,7 @@ class PostgresSakRepositoryTest {
     @Test
     fun `Finner sakId for en søknad`() {
         DBTestHelper.withSaker(saker = listOf(sak1, sak2)) { ds ->
-            val sakRepository = PostgresSakRepository(ds)
+            val sakRepository = PostgresSakRepository(testDatabaseSession(ds))
 
             sakRepository.finnSakIdForSøknad(
                 søknadId = søknadIdSak1,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/frist/OppgaveFristUtgåttJobTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/frist/OppgaveFristUtgåttJobTest.kt
@@ -19,6 +19,7 @@ import no.nav.dagpenger.saksbehandling.TestHelper.lagBehandling
 import no.nav.dagpenger.saksbehandling.TestHelper.lagOppgave
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -33,7 +34,7 @@ class OppgaveFristUtgåttJobTest {
             person = TestHelper.testPerson,
             behandlinger = listOf(behandling1, behandling2, behandling3, behandling4),
         ) { ds ->
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             val oppgaveMediator =
                 OppgaveMediator(
                     oppgaveRepository = repo,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/frist/OppgaveFristUtgåttJobTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/frist/OppgaveFristUtgåttJobTest.kt
@@ -18,8 +18,8 @@ import no.nav.dagpenger.saksbehandling.TestHelper
 import no.nav.dagpenger.saksbehandling.TestHelper.lagBehandling
 import no.nav.dagpenger.saksbehandling.TestHelper.lagOppgave
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -34,7 +34,7 @@ class OppgaveFristUtgåttJobTest {
             person = TestHelper.testPerson,
             behandlinger = listOf(behandling1, behandling2, behandling3, behandling4),
         ) { ds ->
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             val oppgaveMediator =
                 OppgaveMediator(
                     oppgaveRepository = repo,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediatorTest.kt
@@ -30,6 +30,7 @@ import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
 import no.nav.dagpenger.saksbehandling.db.oppgave.Søkefilter
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.db.sak.PostgresSakRepository
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingOpprettetForSøknadHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.FerdigstillInnsendingHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.InnsendingFerdigstiltHendelse
@@ -144,18 +145,18 @@ class InnsendingMediatorTest {
             val sakMediator =
                 SakMediator(
                     personMediator = personMediatorMock,
-                    sakRepository = PostgresSakRepository(it),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(it)),
                     rapidsConnection = mockk(relaxed = true),
                 )
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(it),
+                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(it)),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = sakMediator,
                     rapidsConnection = mockk(relaxed = true),
                 )
-            val innsendingRepository = PostgresInnsendingRepository(it)
+            val innsendingRepository = PostgresInnsendingRepository(testDatabaseSession(it))
             val innsendingMediator =
                 InnsendingMediator(
                     sakMediator = sakMediator,
@@ -300,18 +301,18 @@ class InnsendingMediatorTest {
             val sakMediator =
                 SakMediator(
                     personMediator = personMediatorMock,
-                    sakRepository = PostgresSakRepository(it),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(it)),
                     rapidsConnection = mockk(relaxed = true),
                 )
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(it),
+                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(it)),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = sakMediator,
                     rapidsConnection = mockk(relaxed = true),
                 )
-            val innsendingRepository = PostgresInnsendingRepository(it)
+            val innsendingRepository = PostgresInnsendingRepository(testDatabaseSession(it))
             val innsendingMediator =
                 InnsendingMediator(
                     sakMediator = sakMediator,
@@ -387,12 +388,12 @@ class InnsendingMediatorTest {
             val sakMediator =
                 SakMediator(
                     personMediator = personMediatorMock,
-                    sakRepository = PostgresSakRepository(it),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(it)),
                     rapidsConnection = mockk(relaxed = true),
                 )
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(it),
+                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(it)),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = sakMediator,
@@ -516,18 +517,18 @@ class InnsendingMediatorTest {
             val sakMediator =
                 SakMediator(
                     personMediator = personMediatorMock,
-                    sakRepository = PostgresSakRepository(it),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(it)),
                     rapidsConnection = mockk(relaxed = true),
                 )
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(it),
+                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(it)),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = sakMediator,
                     rapidsConnection = mockk(relaxed = true),
                 )
-            val innsendingRepository = PostgresInnsendingRepository(it)
+            val innsendingRepository = PostgresInnsendingRepository(testDatabaseSession(it))
             val innsendingMediator =
                 InnsendingMediator(
                     sakMediator = sakMediator,
@@ -628,7 +629,7 @@ class InnsendingMediatorTest {
             val sakMediator =
                 SakMediator(
                     personMediator = personMediatorMock,
-                    sakRepository = PostgresSakRepository(it),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(it)),
                     rapidsConnection = mockk(relaxed = true),
                 )
             val behandlingKlientMock =
@@ -638,13 +639,13 @@ class InnsendingMediatorTest {
                 }
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(it),
+                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(it)),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = sakMediator,
                     rapidsConnection = mockk(relaxed = true),
                 )
-            val innsendingRepository = PostgresInnsendingRepository(it)
+            val innsendingRepository = PostgresInnsendingRepository(testDatabaseSession(it))
             val innsendingMediator =
                 InnsendingMediator(
                     sakMediator = sakMediator,
@@ -773,7 +774,7 @@ class InnsendingMediatorTest {
             val sakMediator =
                 SakMediator(
                     personMediator = personMediatorMock,
-                    sakRepository = PostgresSakRepository(it),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(it)),
                     rapidsConnection = mockk(relaxed = true),
                 )
             val behandlingKlientMock =
@@ -783,13 +784,13 @@ class InnsendingMediatorTest {
                 }
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(it),
+                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(it)),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = sakMediator,
                     rapidsConnection = mockk(relaxed = true),
                 )
-            val innsendingRepository = PostgresInnsendingRepository(it)
+            val innsendingRepository = PostgresInnsendingRepository(testDatabaseSession(it))
             val innsendingMediator =
                 InnsendingMediator(
                     sakMediator = sakMediator,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediatorTest.kt
@@ -23,6 +23,7 @@ import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.UtsendingSak
 import no.nav.dagpenger.saksbehandling.behandling.BehandlingKlient
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.innsending.InnsendingRepository
 import no.nav.dagpenger.saksbehandling.db.innsending.PostgresInnsendingRepository
 import no.nav.dagpenger.saksbehandling.db.oppgave.Periode
@@ -30,7 +31,6 @@ import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
 import no.nav.dagpenger.saksbehandling.db.oppgave.Søkefilter
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.db.sak.PostgresSakRepository
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingOpprettetForSøknadHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.FerdigstillInnsendingHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.InnsendingFerdigstiltHendelse
@@ -145,18 +145,18 @@ class InnsendingMediatorTest {
             val sakMediator =
                 SakMediator(
                     personMediator = personMediatorMock,
-                    sakRepository = PostgresSakRepository(testDatabaseSession(it)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { it })),
                     rapidsConnection = mockk(relaxed = true),
                 )
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(it)),
+                    oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(lazy { it })),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = sakMediator,
                     rapidsConnection = mockk(relaxed = true),
                 )
-            val innsendingRepository = PostgresInnsendingRepository(testDatabaseSession(it))
+            val innsendingRepository = PostgresInnsendingRepository(DatabaseSession(lazy { it }))
             val innsendingMediator =
                 InnsendingMediator(
                     sakMediator = sakMediator,
@@ -301,18 +301,18 @@ class InnsendingMediatorTest {
             val sakMediator =
                 SakMediator(
                     personMediator = personMediatorMock,
-                    sakRepository = PostgresSakRepository(testDatabaseSession(it)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { it })),
                     rapidsConnection = mockk(relaxed = true),
                 )
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(it)),
+                    oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(lazy { it })),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = sakMediator,
                     rapidsConnection = mockk(relaxed = true),
                 )
-            val innsendingRepository = PostgresInnsendingRepository(testDatabaseSession(it))
+            val innsendingRepository = PostgresInnsendingRepository(DatabaseSession(lazy { it }))
             val innsendingMediator =
                 InnsendingMediator(
                     sakMediator = sakMediator,
@@ -388,12 +388,12 @@ class InnsendingMediatorTest {
             val sakMediator =
                 SakMediator(
                     personMediator = personMediatorMock,
-                    sakRepository = PostgresSakRepository(testDatabaseSession(it)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { it })),
                     rapidsConnection = mockk(relaxed = true),
                 )
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(it)),
+                    oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(lazy { it })),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = sakMediator,
@@ -517,18 +517,18 @@ class InnsendingMediatorTest {
             val sakMediator =
                 SakMediator(
                     personMediator = personMediatorMock,
-                    sakRepository = PostgresSakRepository(testDatabaseSession(it)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { it })),
                     rapidsConnection = mockk(relaxed = true),
                 )
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(it)),
+                    oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(lazy { it })),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = sakMediator,
                     rapidsConnection = mockk(relaxed = true),
                 )
-            val innsendingRepository = PostgresInnsendingRepository(testDatabaseSession(it))
+            val innsendingRepository = PostgresInnsendingRepository(DatabaseSession(lazy { it }))
             val innsendingMediator =
                 InnsendingMediator(
                     sakMediator = sakMediator,
@@ -629,7 +629,7 @@ class InnsendingMediatorTest {
             val sakMediator =
                 SakMediator(
                     personMediator = personMediatorMock,
-                    sakRepository = PostgresSakRepository(testDatabaseSession(it)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { it })),
                     rapidsConnection = mockk(relaxed = true),
                 )
             val behandlingKlientMock =
@@ -639,13 +639,13 @@ class InnsendingMediatorTest {
                 }
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(it)),
+                    oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(lazy { it })),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = sakMediator,
                     rapidsConnection = mockk(relaxed = true),
                 )
-            val innsendingRepository = PostgresInnsendingRepository(testDatabaseSession(it))
+            val innsendingRepository = PostgresInnsendingRepository(DatabaseSession(lazy { it }))
             val innsendingMediator =
                 InnsendingMediator(
                     sakMediator = sakMediator,
@@ -774,7 +774,7 @@ class InnsendingMediatorTest {
             val sakMediator =
                 SakMediator(
                     personMediator = personMediatorMock,
-                    sakRepository = PostgresSakRepository(testDatabaseSession(it)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { it })),
                     rapidsConnection = mockk(relaxed = true),
                 )
             val behandlingKlientMock =
@@ -784,13 +784,13 @@ class InnsendingMediatorTest {
                 }
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(it)),
+                    oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(lazy { it })),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = sakMediator,
                     rapidsConnection = mockk(relaxed = true),
                 )
-            val innsendingRepository = PostgresInnsendingRepository(testDatabaseSession(it))
+            val innsendingRepository = PostgresInnsendingRepository(DatabaseSession(lazy { it }))
             val innsendingMediator =
                 InnsendingMediator(
                     sakMediator = sakMediator,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/metrikker/MetrikkJobTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/metrikker/MetrikkJobTest.kt
@@ -18,8 +18,8 @@ import no.nav.dagpenger.saksbehandling.TestHelper.lagPerson
 import no.nav.dagpenger.saksbehandling.TestHelper.lagUtsending
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.utsending.Utsending
 import no.nav.dagpenger.saksbehandling.utsending.db.PostgresUtsendingRepository
 import org.junit.jupiter.api.Test
@@ -51,7 +51,7 @@ class MetrikkJobTest {
                     behandling8,
                 ),
         ) { ds ->
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             repo.lagre(lagOppgave(oppgaveId = UUIDv7.ny(), tilstand = PåVent, behandling = behandling1))
             repo.lagre(lagOppgave(oppgaveId = UUIDv7.ny(), tilstand = PåVent, behandling = behandling2))
             repo.lagre(lagOppgave(oppgaveId = UUIDv7.ny(), tilstand = KlarTilBehandling, behandling = behandling3))
@@ -113,8 +113,8 @@ class MetrikkJobTest {
                     behandling8,
                 ),
         ) { ds ->
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
-            val utsendingRepository = PostgresUtsendingRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
+            val utsendingRepository = PostgresUtsendingRepository(DatabaseSession(lazy { ds }))
             lagOppgave(tilstand = PåVent, behandling = behandling1).also {
                 repo.lagre(it)
                 utsendingRepository.lagre(

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/metrikker/MetrikkJobTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/metrikker/MetrikkJobTest.kt
@@ -19,6 +19,7 @@ import no.nav.dagpenger.saksbehandling.TestHelper.lagUtsending
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.utsending.Utsending
 import no.nav.dagpenger.saksbehandling.utsending.db.PostgresUtsendingRepository
 import org.junit.jupiter.api.Test
@@ -50,7 +51,7 @@ class MetrikkJobTest {
                     behandling8,
                 ),
         ) { ds ->
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             repo.lagre(lagOppgave(oppgaveId = UUIDv7.ny(), tilstand = PåVent, behandling = behandling1))
             repo.lagre(lagOppgave(oppgaveId = UUIDv7.ny(), tilstand = PåVent, behandling = behandling2))
             repo.lagre(lagOppgave(oppgaveId = UUIDv7.ny(), tilstand = KlarTilBehandling, behandling = behandling3))
@@ -112,8 +113,8 @@ class MetrikkJobTest {
                     behandling8,
                 ),
         ) { ds ->
-            val repo = PostgresOppgaveRepository(ds)
-            val utsendingRepository = PostgresUtsendingRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val utsendingRepository = PostgresUtsendingRepository(testDatabaseSession(ds))
             lagOppgave(tilstand = PåVent, behandling = behandling1).also {
                 repo.lagre(it)
                 utsendingRepository.lagre(

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediatorTest.kt
@@ -16,6 +16,7 @@ import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.db.person.PostgresPersonRepository
 import no.nav.dagpenger.saksbehandling.db.sak.PostgresSakRepository
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.FerdigstillOppfølgingHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.OppfølgingFerdigstiltHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.OpprettOppfølgingHendelse
@@ -31,17 +32,17 @@ class OppfølgingMediatorTest {
     @Test
     fun `E2E - opprette og ferdigstille oppfølging`() {
         DBTestHelper.withPerson { ds ->
-            val oppfølgingRepository = PostgresOppfølgingRepository(ds)
-            val personMediator = PersonMediator(PostgresPersonRepository(ds), mockk())
+            val oppfølgingRepository = PostgresOppfølgingRepository(testDatabaseSession(ds))
+            val personMediator = PersonMediator(PostgresPersonRepository(testDatabaseSession(ds)), mockk())
             val sakMediator =
                 SakMediator(
                     personMediator = personMediator,
-                    sakRepository = PostgresSakRepository(ds),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
                     rapidsConnection = mockk(relaxed = true),
                 )
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(ds),
+                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(ds)),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = sakMediator,
@@ -117,15 +118,15 @@ class OppfølgingMediatorTest {
     @Test
     fun `ferdigstill med OpprettOppfølging - frist og beholdOppgaven gir ny oppgave i PåVent`() {
         DBTestHelper.withPerson { ds ->
-            val oppfølgingRepository = PostgresOppfølgingRepository(ds)
-            val personMediator = PersonMediator(PostgresPersonRepository(ds), mockk())
+            val oppfølgingRepository = PostgresOppfølgingRepository(testDatabaseSession(ds))
+            val personMediator = PersonMediator(PostgresPersonRepository(testDatabaseSession(ds)), mockk())
             val sakMediator =
                 SakMediator(
                     personMediator = personMediator,
-                    sakRepository = PostgresSakRepository(ds),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
                     rapidsConnection = mockk(relaxed = true),
                 )
-            val oppgaveRepository = PostgresOppgaveRepository(ds)
+            val oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(ds))
             val oppgaveMediator =
                 OppgaveMediator(
                     oppgaveRepository = oppgaveRepository,
@@ -186,15 +187,15 @@ class OppfølgingMediatorTest {
     @Test
     fun `ferdigstill med OpprettOppfølging uten beholdOppgaven gir ny oppgave i KlarTilBehandling uten behandler`() {
         DBTestHelper.withPerson { ds ->
-            val oppfølgingRepository = PostgresOppfølgingRepository(ds)
-            val personMediator = PersonMediator(PostgresPersonRepository(ds), mockk())
+            val oppfølgingRepository = PostgresOppfølgingRepository(testDatabaseSession(ds))
+            val personMediator = PersonMediator(PostgresPersonRepository(testDatabaseSession(ds)), mockk())
             val sakMediator =
                 SakMediator(
                     personMediator = personMediator,
-                    sakRepository = PostgresSakRepository(ds),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
                     rapidsConnection = mockk(relaxed = true),
                 )
-            val oppgaveRepository = PostgresOppgaveRepository(ds)
+            val oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(ds))
             val oppgaveMediator =
                 OppgaveMediator(
                     oppgaveRepository = oppgaveRepository,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediatorTest.kt
@@ -11,12 +11,12 @@ import no.nav.dagpenger.saksbehandling.Saksbehandler
 import no.nav.dagpenger.saksbehandling.TilgangType
 import no.nav.dagpenger.saksbehandling.behandling.BehandlingKlient
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.oppfolging.PostgresOppfølgingRepository
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.db.person.PostgresPersonRepository
 import no.nav.dagpenger.saksbehandling.db.sak.PostgresSakRepository
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.FerdigstillOppfølgingHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.OppfølgingFerdigstiltHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.OpprettOppfølgingHendelse
@@ -32,17 +32,17 @@ class OppfølgingMediatorTest {
     @Test
     fun `E2E - opprette og ferdigstille oppfølging`() {
         DBTestHelper.withPerson { ds ->
-            val oppfølgingRepository = PostgresOppfølgingRepository(testDatabaseSession(ds))
-            val personMediator = PersonMediator(PostgresPersonRepository(testDatabaseSession(ds)), mockk())
+            val oppfølgingRepository = PostgresOppfølgingRepository(DatabaseSession(lazy { ds }))
+            val personMediator = PersonMediator(PostgresPersonRepository(DatabaseSession(lazy { ds })), mockk())
             val sakMediator =
                 SakMediator(
                     personMediator = personMediator,
-                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
                     rapidsConnection = mockk(relaxed = true),
                 )
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(ds)),
+                    oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(lazy { ds })),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = sakMediator,
@@ -118,15 +118,15 @@ class OppfølgingMediatorTest {
     @Test
     fun `ferdigstill med OpprettOppfølging - frist og beholdOppgaven gir ny oppgave i PåVent`() {
         DBTestHelper.withPerson { ds ->
-            val oppfølgingRepository = PostgresOppfølgingRepository(testDatabaseSession(ds))
-            val personMediator = PersonMediator(PostgresPersonRepository(testDatabaseSession(ds)), mockk())
+            val oppfølgingRepository = PostgresOppfølgingRepository(DatabaseSession(lazy { ds }))
+            val personMediator = PersonMediator(PostgresPersonRepository(DatabaseSession(lazy { ds })), mockk())
             val sakMediator =
                 SakMediator(
                     personMediator = personMediator,
-                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
                     rapidsConnection = mockk(relaxed = true),
                 )
-            val oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             val oppgaveMediator =
                 OppgaveMediator(
                     oppgaveRepository = oppgaveRepository,
@@ -187,15 +187,15 @@ class OppfølgingMediatorTest {
     @Test
     fun `ferdigstill med OpprettOppfølging uten beholdOppgaven gir ny oppgave i KlarTilBehandling uten behandler`() {
         DBTestHelper.withPerson { ds ->
-            val oppfølgingRepository = PostgresOppfølgingRepository(testDatabaseSession(ds))
-            val personMediator = PersonMediator(PostgresPersonRepository(testDatabaseSession(ds)), mockk())
+            val oppfølgingRepository = PostgresOppfølgingRepository(DatabaseSession(lazy { ds }))
+            val personMediator = PersonMediator(PostgresPersonRepository(DatabaseSession(lazy { ds })), mockk())
             val sakMediator =
                 SakMediator(
                     personMediator = personMediator,
-                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
                     rapidsConnection = mockk(relaxed = true),
                 )
-            val oppgaveRepository = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             val oppgaveMediator =
                 OppgaveMediator(
                     oppgaveRepository = oppgaveRepository,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/sak/SakMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/sak/SakMediatorTest.kt
@@ -19,12 +19,12 @@ import no.nav.dagpenger.saksbehandling.SakHistorikk
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.UtsendingSak
 import no.nav.dagpenger.saksbehandling.api.Oppslag
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.Postgres.withMigratedDb
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.db.person.PostgresPersonRepository
 import no.nav.dagpenger.saksbehandling.db.sak.PostgresSakRepository
 import no.nav.dagpenger.saksbehandling.db.sak.SakRepository
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.DpBehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.InnsendingMottattHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.Kategori
@@ -120,11 +120,11 @@ class SakMediatorTest {
 
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
+                            personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds })),
                             oppslag = oppslagMock,
                         ),
                 )
@@ -157,11 +157,11 @@ class SakMediatorTest {
 
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
+                            personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds })),
                             oppslag = oppslagMock,
                         ),
                 )
@@ -201,11 +201,11 @@ class SakMediatorTest {
         withMigratedDb { ds ->
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
+                            personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds })),
                             oppslag = oppslagMock,
                         ),
                 )
@@ -235,11 +235,11 @@ class SakMediatorTest {
         withMigratedDb { ds ->
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
+                            personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds })),
                             oppslag = oppslagMock,
                         ),
                 )
@@ -270,11 +270,11 @@ class SakMediatorTest {
         withMigratedDb { ds ->
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
+                            personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds })),
                             oppslag = oppslagMock,
                         ),
                 )
@@ -342,11 +342,11 @@ class SakMediatorTest {
         withMigratedDb { ds ->
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
+                            personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds })),
                             oppslag = oppslagMock,
                         ),
                 )
@@ -407,11 +407,11 @@ class SakMediatorTest {
         withMigratedDb { ds ->
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
+                            personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds })),
                             oppslag = oppslagMock,
                         ),
                 )
@@ -472,11 +472,11 @@ class SakMediatorTest {
         withMigratedDb { ds ->
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
+                            personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds })),
                             oppslag = oppslagMock,
                         ),
                 )
@@ -511,11 +511,11 @@ class SakMediatorTest {
 
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
+                            personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds })),
                             oppslag = oppslagMock,
                         ),
                 )
@@ -610,11 +610,11 @@ class SakMediatorTest {
 
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
+                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
+                            personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds })),
                             oppslag = oppslagMock,
                         ),
                 )

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/sak/SakMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/sak/SakMediatorTest.kt
@@ -24,6 +24,7 @@ import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.db.person.PostgresPersonRepository
 import no.nav.dagpenger.saksbehandling.db.sak.PostgresSakRepository
 import no.nav.dagpenger.saksbehandling.db.sak.SakRepository
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.DpBehandlingOpprettetHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.InnsendingMottattHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.Kategori
@@ -119,11 +120,11 @@ class SakMediatorTest {
 
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(ds),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(ds),
+                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
                             oppslag = oppslagMock,
                         ),
                 )
@@ -156,11 +157,11 @@ class SakMediatorTest {
 
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(ds),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(ds),
+                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
                             oppslag = oppslagMock,
                         ),
                 )
@@ -200,11 +201,11 @@ class SakMediatorTest {
         withMigratedDb { ds ->
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(ds),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(ds),
+                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
                             oppslag = oppslagMock,
                         ),
                 )
@@ -234,11 +235,11 @@ class SakMediatorTest {
         withMigratedDb { ds ->
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(ds),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(ds),
+                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
                             oppslag = oppslagMock,
                         ),
                 )
@@ -269,11 +270,11 @@ class SakMediatorTest {
         withMigratedDb { ds ->
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(ds),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(ds),
+                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
                             oppslag = oppslagMock,
                         ),
                 )
@@ -341,11 +342,11 @@ class SakMediatorTest {
         withMigratedDb { ds ->
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(ds),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(ds),
+                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
                             oppslag = oppslagMock,
                         ),
                 )
@@ -406,11 +407,11 @@ class SakMediatorTest {
         withMigratedDb { ds ->
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(ds),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(ds),
+                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
                             oppslag = oppslagMock,
                         ),
                 )
@@ -471,11 +472,11 @@ class SakMediatorTest {
         withMigratedDb { ds ->
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(ds),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(ds),
+                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
                             oppslag = oppslagMock,
                         ),
                 )
@@ -510,11 +511,11 @@ class SakMediatorTest {
 
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(ds),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(ds),
+                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
                             oppslag = oppslagMock,
                         ),
                 )
@@ -609,11 +610,11 @@ class SakMediatorTest {
 
             val sakMediator =
                 SakMediator(
-                    sakRepository = PostgresSakRepository(ds),
+                    sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
                     rapidsConnection = testRapid,
                     personMediator =
                         PersonMediator(
-                            personRepository = PostgresPersonRepository(ds),
+                            personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
                             oppslag = oppslagMock,
                         ),
                 )

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/statistikk/db/PostgresProduksjonsstatistikkRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/statistikk/db/PostgresProduksjonsstatistikkRepositoryTest.kt
@@ -17,9 +17,9 @@ import no.nav.dagpenger.saksbehandling.TestHelper.lagOppgave
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.api.models.GrupperEtterDTO
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.oppgave.Periode
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.statistikk.ProduksjonsstatistikkFilter
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -105,7 +105,7 @@ class PostgresProduksjonsstatistikkRepositoryTest {
             behandlinger = listOf(behandling1, behandling2, behandling3, behandling4, behandling5, behandling6, behandling7),
         ) { ds: DataSource ->
             // Insert test data
-            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
+            val repo = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
             repo.lagre(oppgave1FerdigBehandlet)
             repo.lagre(oppgave2FerdigBehandlet)
             repo.lagre(oppgave3FerdigBehandlet)
@@ -114,7 +114,7 @@ class PostgresProduksjonsstatistikkRepositoryTest {
             repo.lagre(oppgave6FerdigBehandletIForgårs)
             repo.lagre(oppgave7KlarTilBehandling)
 
-            val statistikkTjeneste = PostgresProduksjonsstatistikkRepository(testDatabaseSession(ds))
+            val statistikkTjeneste = PostgresProduksjonsstatistikkRepository(DatabaseSession(lazy { ds }))
 
             val tilstanderAlle =
                 statistikkTjeneste.hentTilstanderMedUtløstAvFilter(

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/statistikk/db/PostgresProduksjonsstatistikkRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/statistikk/db/PostgresProduksjonsstatistikkRepositoryTest.kt
@@ -19,6 +19,7 @@ import no.nav.dagpenger.saksbehandling.api.models.GrupperEtterDTO
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
 import no.nav.dagpenger.saksbehandling.db.oppgave.Periode
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.statistikk.ProduksjonsstatistikkFilter
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -104,7 +105,7 @@ class PostgresProduksjonsstatistikkRepositoryTest {
             behandlinger = listOf(behandling1, behandling2, behandling3, behandling4, behandling5, behandling6, behandling7),
         ) { ds: DataSource ->
             // Insert test data
-            val repo = PostgresOppgaveRepository(ds)
+            val repo = PostgresOppgaveRepository(testDatabaseSession(ds))
             repo.lagre(oppgave1FerdigBehandlet)
             repo.lagre(oppgave2FerdigBehandlet)
             repo.lagre(oppgave3FerdigBehandlet)
@@ -113,7 +114,7 @@ class PostgresProduksjonsstatistikkRepositoryTest {
             repo.lagre(oppgave6FerdigBehandletIForgårs)
             repo.lagre(oppgave7KlarTilBehandling)
 
-            val statistikkTjeneste = PostgresProduksjonsstatistikkRepository(ds)
+            val statistikkTjeneste = PostgresProduksjonsstatistikkRepository(testDatabaseSession(ds))
 
             val tilstanderAlle =
                 statistikkTjeneste.hentTilstanderMedUtløstAvFilter(

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/statistikk/db/PostgresSaksbehandlingsstatistikkRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/statistikk/db/PostgresSaksbehandlingsstatistikkRepositoryTest.kt
@@ -14,6 +14,7 @@ import no.nav.dagpenger.saksbehandling.TestHelper.beslutter
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper.Companion.testPerson
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.AvbrytOppgaveHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.GodkjentBehandlingHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.PåVentFristUtgåttHendelse
@@ -55,7 +56,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                 oppgave = oppgave,
                 merkSomEgenSak = true,
             )
-            val postgresStatistikkTjeneste = PostgresSaksbehandlingsstatistikkRepository(dataSource = ds)
+            val postgresStatistikkTjeneste = PostgresSaksbehandlingsstatistikkRepository(testDatabaseSession(ds))
             val førsteTilstandsendring =
                 postgresStatistikkTjeneste.oppgaveTilstandsendringer().let {
                     it.size shouldBe 1
@@ -98,7 +99,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                 ),
             )
 
-            PostgresOppgaveRepository(dataSource = ds).lagre(oppgave)
+            PostgresOppgaveRepository(testDatabaseSession(ds)).lagre(oppgave)
 
             postgresStatistikkTjeneste.oppgaveTilstandsendringer().let {
                 it.size shouldBe 1
@@ -144,7 +145,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                     utførtAv = beslutter,
                 ),
             )
-            PostgresOppgaveRepository(dataSource = ds).lagre(oppgave)
+            PostgresOppgaveRepository(testDatabaseSession(ds)).lagre(oppgave)
 
             postgresStatistikkTjeneste.oppgaveTilstandsendringer().let {
                 it.size shouldBe 4
@@ -201,7 +202,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                     utførtAv = TestHelper.saksbehandler,
                 ),
             )
-            PostgresOppgaveRepository(dataSource = ds).lagre(oppgave)
+            PostgresOppgaveRepository(testDatabaseSession(ds)).lagre(oppgave)
 
             postgresStatistikkTjeneste.oppgaveTilstandsendringer().let {
                 it.size shouldBe 2
@@ -250,7 +251,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                 oppgave = oppgave,
                 merkSomEgenSak = true,
             )
-            val postgresStatistikkTjeneste = PostgresSaksbehandlingsstatistikkRepository(dataSource = ds)
+            val postgresStatistikkTjeneste = PostgresSaksbehandlingsstatistikkRepository(testDatabaseSession(ds))
             val førsteTilstandsendring =
                 postgresStatistikkTjeneste.oppgaveTilstandsendringer().let {
                     it.size shouldBe 1
@@ -293,7 +294,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                 ),
             )
 
-            PostgresOppgaveRepository(dataSource = ds).lagre(oppgave)
+            PostgresOppgaveRepository(testDatabaseSession(ds)).lagre(oppgave)
             val andreTilstandsendring =
                 postgresStatistikkTjeneste.oppgaveTilstandsendringer().let {
                     it.size shouldBe 1
@@ -335,7 +336,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                 ),
             )
 
-            PostgresOppgaveRepository(dataSource = ds).lagre(oppgave)
+            PostgresOppgaveRepository(testDatabaseSession(ds)).lagre(oppgave)
             val tredjeTilstandsendring =
                 postgresStatistikkTjeneste.oppgaveTilstandsendringer().let {
                     it.size shouldBe 1
@@ -398,7 +399,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                 oppgave = innsendingOppgave,
                 merkSomEgenSak = true,
             )
-            val postgresStatistikkTjeneste = PostgresSaksbehandlingsstatistikkRepository(dataSource = ds)
+            val postgresStatistikkTjeneste = PostgresSaksbehandlingsstatistikkRepository(testDatabaseSession(ds))
             postgresStatistikkTjeneste.oppgaveTilstandsendringer().size shouldBe 1
 
             innsendingOppgave.tildel(
@@ -409,7 +410,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                 ),
             )
 
-            PostgresOppgaveRepository(dataSource = ds).lagre(innsendingOppgave)
+            PostgresOppgaveRepository(testDatabaseSession(ds)).lagre(innsendingOppgave)
 
             postgresStatistikkTjeneste.oppgaveTilstandsendringer().size shouldBe 2
         }
@@ -442,7 +443,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                 oppgave = klageOppgave,
                 merkSomEgenSak = true,
             )
-            val postgresStatistikkTjeneste = PostgresSaksbehandlingsstatistikkRepository(dataSource = ds)
+            val postgresStatistikkTjeneste = PostgresSaksbehandlingsstatistikkRepository(testDatabaseSession(ds))
             postgresStatistikkTjeneste.oppgaveTilstandsendringer().size shouldBe 0
 
             klageOppgave.tildel(
@@ -453,7 +454,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                 ),
             )
 
-            PostgresOppgaveRepository(dataSource = ds).lagre(klageOppgave)
+            PostgresOppgaveRepository(testDatabaseSession(ds)).lagre(klageOppgave)
 
             postgresStatistikkTjeneste.oppgaveTilstandsendringer().size shouldBe 0
         }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/statistikk/db/PostgresSaksbehandlingsstatistikkRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/statistikk/db/PostgresSaksbehandlingsstatistikkRepositoryTest.kt
@@ -13,8 +13,8 @@ import no.nav.dagpenger.saksbehandling.TestHelper
 import no.nav.dagpenger.saksbehandling.TestHelper.beslutter
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper.Companion.testPerson
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.AvbrytOppgaveHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.GodkjentBehandlingHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.PåVentFristUtgåttHendelse
@@ -56,7 +56,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                 oppgave = oppgave,
                 merkSomEgenSak = true,
             )
-            val postgresStatistikkTjeneste = PostgresSaksbehandlingsstatistikkRepository(testDatabaseSession(ds))
+            val postgresStatistikkTjeneste = PostgresSaksbehandlingsstatistikkRepository(DatabaseSession(lazy { ds }))
             val førsteTilstandsendring =
                 postgresStatistikkTjeneste.oppgaveTilstandsendringer().let {
                     it.size shouldBe 1
@@ -99,7 +99,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                 ),
             )
 
-            PostgresOppgaveRepository(testDatabaseSession(ds)).lagre(oppgave)
+            PostgresOppgaveRepository(DatabaseSession(lazy { ds })).lagre(oppgave)
 
             postgresStatistikkTjeneste.oppgaveTilstandsendringer().let {
                 it.size shouldBe 1
@@ -145,7 +145,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                     utførtAv = beslutter,
                 ),
             )
-            PostgresOppgaveRepository(testDatabaseSession(ds)).lagre(oppgave)
+            PostgresOppgaveRepository(DatabaseSession(lazy { ds })).lagre(oppgave)
 
             postgresStatistikkTjeneste.oppgaveTilstandsendringer().let {
                 it.size shouldBe 4
@@ -202,7 +202,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                     utførtAv = TestHelper.saksbehandler,
                 ),
             )
-            PostgresOppgaveRepository(testDatabaseSession(ds)).lagre(oppgave)
+            PostgresOppgaveRepository(DatabaseSession(lazy { ds })).lagre(oppgave)
 
             postgresStatistikkTjeneste.oppgaveTilstandsendringer().let {
                 it.size shouldBe 2
@@ -251,7 +251,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                 oppgave = oppgave,
                 merkSomEgenSak = true,
             )
-            val postgresStatistikkTjeneste = PostgresSaksbehandlingsstatistikkRepository(testDatabaseSession(ds))
+            val postgresStatistikkTjeneste = PostgresSaksbehandlingsstatistikkRepository(DatabaseSession(lazy { ds }))
             val førsteTilstandsendring =
                 postgresStatistikkTjeneste.oppgaveTilstandsendringer().let {
                     it.size shouldBe 1
@@ -294,7 +294,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                 ),
             )
 
-            PostgresOppgaveRepository(testDatabaseSession(ds)).lagre(oppgave)
+            PostgresOppgaveRepository(DatabaseSession(lazy { ds })).lagre(oppgave)
             val andreTilstandsendring =
                 postgresStatistikkTjeneste.oppgaveTilstandsendringer().let {
                     it.size shouldBe 1
@@ -336,7 +336,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                 ),
             )
 
-            PostgresOppgaveRepository(testDatabaseSession(ds)).lagre(oppgave)
+            PostgresOppgaveRepository(DatabaseSession(lazy { ds })).lagre(oppgave)
             val tredjeTilstandsendring =
                 postgresStatistikkTjeneste.oppgaveTilstandsendringer().let {
                     it.size shouldBe 1
@@ -399,7 +399,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                 oppgave = innsendingOppgave,
                 merkSomEgenSak = true,
             )
-            val postgresStatistikkTjeneste = PostgresSaksbehandlingsstatistikkRepository(testDatabaseSession(ds))
+            val postgresStatistikkTjeneste = PostgresSaksbehandlingsstatistikkRepository(DatabaseSession(lazy { ds }))
             postgresStatistikkTjeneste.oppgaveTilstandsendringer().size shouldBe 1
 
             innsendingOppgave.tildel(
@@ -410,7 +410,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                 ),
             )
 
-            PostgresOppgaveRepository(testDatabaseSession(ds)).lagre(innsendingOppgave)
+            PostgresOppgaveRepository(DatabaseSession(lazy { ds })).lagre(innsendingOppgave)
 
             postgresStatistikkTjeneste.oppgaveTilstandsendringer().size shouldBe 2
         }
@@ -443,7 +443,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                 oppgave = klageOppgave,
                 merkSomEgenSak = true,
             )
-            val postgresStatistikkTjeneste = PostgresSaksbehandlingsstatistikkRepository(testDatabaseSession(ds))
+            val postgresStatistikkTjeneste = PostgresSaksbehandlingsstatistikkRepository(DatabaseSession(lazy { ds }))
             postgresStatistikkTjeneste.oppgaveTilstandsendringer().size shouldBe 0
 
             klageOppgave.tildel(
@@ -454,7 +454,7 @@ class PostgresSaksbehandlingsstatistikkRepositoryTest {
                 ),
             )
 
-            PostgresOppgaveRepository(testDatabaseSession(ds)).lagre(klageOppgave)
+            PostgresOppgaveRepository(DatabaseSession(lazy { ds })).lagre(klageOppgave)
 
             postgresStatistikkTjeneste.oppgaveTilstandsendringer().size shouldBe 0
         }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/utsending/UtsendingMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/utsending/UtsendingMediatorTest.kt
@@ -19,6 +19,7 @@ import no.nav.dagpenger.saksbehandling.UtsendingSak
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
 import no.nav.dagpenger.saksbehandling.db.person.PostgresPersonRepository
 import no.nav.dagpenger.saksbehandling.db.sak.PostgresSakRepository
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.helper.arkiverbartDokumentBehovLøsning
 import no.nav.dagpenger.saksbehandling.helper.behandlingsresultatEvent
 import no.nav.dagpenger.saksbehandling.helper.distribuertDokumentBehovLøsning
@@ -63,7 +64,7 @@ class UtsendingMediatorTest {
             val sakId = DBTestHelper.sakId.toString()
             val utsendingSak = UtsendingSak(sakId, "Dagpenger")
             val htmlBrev = "<H1>Hei</H1><p>Her er et brev</p>"
-            val utsendingRepository = PostgresUtsendingRepository(ds)
+            val utsendingRepository = PostgresUtsendingRepository(testDatabaseSession(ds))
             val utsendingMediator =
                 UtsendingMediator(
                     utsendingRepository = utsendingRepository,
@@ -83,7 +84,7 @@ class UtsendingMediatorTest {
             BehandlingsresultatMottakForUtsending(
                 rapidsConnection = rapid,
                 utsendingMediator = utsendingMediator,
-                sakRepository = PostgresSakRepository(ds),
+                sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
             )
 
             UtsendingBehovLøsningMottak(
@@ -227,7 +228,7 @@ class UtsendingMediatorTest {
             val utsendingSak = UtsendingSak("123", "Arena")
             val htmlBrev = "<H1>Hei</H1><p>Her er et brev</p>"
 
-            val utsendingRepository = PostgresUtsendingRepository(ds)
+            val utsendingRepository = PostgresUtsendingRepository(testDatabaseSession(ds))
             val utsendingMediator =
                 UtsendingMediator(
                     utsendingRepository = utsendingRepository,
@@ -245,7 +246,7 @@ class UtsendingMediatorTest {
             ArenaSinkVedtakOpprettetMottak(
                 rapidsConnection = rapid,
                 utsendingMediator = utsendingMediator,
-                personRepository = PostgresPersonRepository(ds),
+                personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
                 sakMediator = mockSakMediator,
             )
 
@@ -395,7 +396,7 @@ class UtsendingMediatorTest {
             val sakId = DBTestHelper.sakId.toString()
             val utsendingSak = UtsendingSak(sakId, "Dagpenger")
             val htmlBrev = "<H1>Hei</H1><p>Her er et automatisk vedtaksbrev</p>"
-            val utsendingRepository = PostgresUtsendingRepository(ds)
+            val utsendingRepository = PostgresUtsendingRepository(testDatabaseSession(ds))
             val utsendingMediator =
                 UtsendingMediator(
                     utsendingRepository = utsendingRepository,
@@ -415,7 +416,7 @@ class UtsendingMediatorTest {
             BehandlingsresultatMottakForAutomatiskVedtakUtsending(
                 rapidsConnection = rapid,
                 utsendingMediator = utsendingMediator,
-                sakRepository = PostgresSakRepository(ds),
+                sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
             )
 
             UtsendingBehovLøsningMottak(
@@ -538,7 +539,7 @@ class UtsendingMediatorTest {
 
         DBTestHelper.withBehandling(behandling = behandling, person = person) { ds ->
             val behandlingId = behandling.behandlingId
-            val utsendingRepository = PostgresUtsendingRepository(ds)
+            val utsendingRepository = PostgresUtsendingRepository(testDatabaseSession(ds))
             val utsendingMediator =
                 UtsendingMediator(
                     utsendingRepository = utsendingRepository,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/utsending/UtsendingMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/utsending/UtsendingMediatorTest.kt
@@ -17,9 +17,9 @@ import no.nav.dagpenger.saksbehandling.TestHelper.lagPerson
 import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.UtsendingSak
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.person.PostgresPersonRepository
 import no.nav.dagpenger.saksbehandling.db.sak.PostgresSakRepository
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.helper.arkiverbartDokumentBehovLøsning
 import no.nav.dagpenger.saksbehandling.helper.behandlingsresultatEvent
 import no.nav.dagpenger.saksbehandling.helper.distribuertDokumentBehovLøsning
@@ -64,7 +64,7 @@ class UtsendingMediatorTest {
             val sakId = DBTestHelper.sakId.toString()
             val utsendingSak = UtsendingSak(sakId, "Dagpenger")
             val htmlBrev = "<H1>Hei</H1><p>Her er et brev</p>"
-            val utsendingRepository = PostgresUtsendingRepository(testDatabaseSession(ds))
+            val utsendingRepository = PostgresUtsendingRepository(DatabaseSession(lazy { ds }))
             val utsendingMediator =
                 UtsendingMediator(
                     utsendingRepository = utsendingRepository,
@@ -84,7 +84,7 @@ class UtsendingMediatorTest {
             BehandlingsresultatMottakForUtsending(
                 rapidsConnection = rapid,
                 utsendingMediator = utsendingMediator,
-                sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
+                sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
             )
 
             UtsendingBehovLøsningMottak(
@@ -228,7 +228,7 @@ class UtsendingMediatorTest {
             val utsendingSak = UtsendingSak("123", "Arena")
             val htmlBrev = "<H1>Hei</H1><p>Her er et brev</p>"
 
-            val utsendingRepository = PostgresUtsendingRepository(testDatabaseSession(ds))
+            val utsendingRepository = PostgresUtsendingRepository(DatabaseSession(lazy { ds }))
             val utsendingMediator =
                 UtsendingMediator(
                     utsendingRepository = utsendingRepository,
@@ -246,7 +246,7 @@ class UtsendingMediatorTest {
             ArenaSinkVedtakOpprettetMottak(
                 rapidsConnection = rapid,
                 utsendingMediator = utsendingMediator,
-                personRepository = PostgresPersonRepository(testDatabaseSession(ds)),
+                personRepository = PostgresPersonRepository(DatabaseSession(lazy { ds })),
                 sakMediator = mockSakMediator,
             )
 
@@ -396,7 +396,7 @@ class UtsendingMediatorTest {
             val sakId = DBTestHelper.sakId.toString()
             val utsendingSak = UtsendingSak(sakId, "Dagpenger")
             val htmlBrev = "<H1>Hei</H1><p>Her er et automatisk vedtaksbrev</p>"
-            val utsendingRepository = PostgresUtsendingRepository(testDatabaseSession(ds))
+            val utsendingRepository = PostgresUtsendingRepository(DatabaseSession(lazy { ds }))
             val utsendingMediator =
                 UtsendingMediator(
                     utsendingRepository = utsendingRepository,
@@ -416,7 +416,7 @@ class UtsendingMediatorTest {
             BehandlingsresultatMottakForAutomatiskVedtakUtsending(
                 rapidsConnection = rapid,
                 utsendingMediator = utsendingMediator,
-                sakRepository = PostgresSakRepository(testDatabaseSession(ds)),
+                sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
             )
 
             UtsendingBehovLøsningMottak(
@@ -539,7 +539,7 @@ class UtsendingMediatorTest {
 
         DBTestHelper.withBehandling(behandling = behandling, person = person) { ds ->
             val behandlingId = behandling.behandlingId
-            val utsendingRepository = PostgresUtsendingRepository(testDatabaseSession(ds))
+            val utsendingRepository = PostgresUtsendingRepository(DatabaseSession(lazy { ds }))
             val utsendingMediator =
                 UtsendingMediator(
                     utsendingRepository = utsendingRepository,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/utsending/db/PostgresUtsendingRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/utsending/db/PostgresUtsendingRepositoryTest.kt
@@ -11,6 +11,7 @@ import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.UtsendingSak
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper.Companion.withBehandling
+import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.TomHendelse
 import no.nav.dagpenger.saksbehandling.utsending.Utsending
 import no.nav.dagpenger.saksbehandling.utsending.UtsendingType
@@ -35,7 +36,7 @@ class PostgresUtsendingRepositoryTest {
             val brev = "vedtaksbrev.html"
             val utsendingSak = UtsendingSak("id", "fagsystem")
 
-            val repository = PostgresUtsendingRepository(ds)
+            val repository = PostgresUtsendingRepository(testDatabaseSession(ds))
             val distribusjonId = "distribusjonId"
             val utsending =
                 Utsending(
@@ -62,7 +63,7 @@ class PostgresUtsendingRepositoryTest {
         val testPerson = DBTestHelper.testPerson
 
         withBehandling(behandling = behandling, person = testPerson) { ds ->
-            val repository = PostgresUtsendingRepository(ds)
+            val repository = PostgresUtsendingRepository(testDatabaseSession(ds))
             val utsending =
                 Utsending(
                     behandlingId = behandling.behandlingId,
@@ -82,7 +83,7 @@ class PostgresUtsendingRepositoryTest {
     @Test
     fun `skal kunne finne ut om en utsending finnes eller ikke for oppgaveId og behandlingId`() {
         withBehandling(behandling = behandling, person = testPerson) { ds ->
-            val repository = PostgresUtsendingRepository(ds)
+            val repository = PostgresUtsendingRepository(testDatabaseSession(ds))
             val utsending =
                 Utsending(
                     behandlingId = behandling.behandlingId,
@@ -102,7 +103,7 @@ class PostgresUtsendingRepositoryTest {
     @Test
     fun `Skal ikke kunne lagre flere utsendinger for samme behandling`() {
         withBehandling(behandling = behandling) { ds ->
-            val repository = PostgresUtsendingRepository(ds)
+            val repository = PostgresUtsendingRepository(testDatabaseSession(ds))
             repository.lagre(lagUtsending(tilstand = Utsending.VenterPåVedtak, behandlingId = behandling.behandlingId))
             shouldThrow<PSQLException> {
                 repository.lagre(

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/utsending/db/PostgresUtsendingRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/utsending/db/PostgresUtsendingRepositoryTest.kt
@@ -11,7 +11,7 @@ import no.nav.dagpenger.saksbehandling.UUIDv7
 import no.nav.dagpenger.saksbehandling.UtsendingSak
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper.Companion.withBehandling
-import no.nav.dagpenger.saksbehandling.db.testDatabaseSession
+import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.hendelser.TomHendelse
 import no.nav.dagpenger.saksbehandling.utsending.Utsending
 import no.nav.dagpenger.saksbehandling.utsending.UtsendingType
@@ -36,7 +36,7 @@ class PostgresUtsendingRepositoryTest {
             val brev = "vedtaksbrev.html"
             val utsendingSak = UtsendingSak("id", "fagsystem")
 
-            val repository = PostgresUtsendingRepository(testDatabaseSession(ds))
+            val repository = PostgresUtsendingRepository(DatabaseSession(lazy { ds }))
             val distribusjonId = "distribusjonId"
             val utsending =
                 Utsending(
@@ -63,7 +63,7 @@ class PostgresUtsendingRepositoryTest {
         val testPerson = DBTestHelper.testPerson
 
         withBehandling(behandling = behandling, person = testPerson) { ds ->
-            val repository = PostgresUtsendingRepository(testDatabaseSession(ds))
+            val repository = PostgresUtsendingRepository(DatabaseSession(lazy { ds }))
             val utsending =
                 Utsending(
                     behandlingId = behandling.behandlingId,
@@ -83,7 +83,7 @@ class PostgresUtsendingRepositoryTest {
     @Test
     fun `skal kunne finne ut om en utsending finnes eller ikke for oppgaveId og behandlingId`() {
         withBehandling(behandling = behandling, person = testPerson) { ds ->
-            val repository = PostgresUtsendingRepository(testDatabaseSession(ds))
+            val repository = PostgresUtsendingRepository(DatabaseSession(lazy { ds }))
             val utsending =
                 Utsending(
                     behandlingId = behandling.behandlingId,
@@ -103,7 +103,7 @@ class PostgresUtsendingRepositoryTest {
     @Test
     fun `Skal ikke kunne lagre flere utsendinger for samme behandling`() {
         withBehandling(behandling = behandling) { ds ->
-            val repository = PostgresUtsendingRepository(testDatabaseSession(ds))
+            val repository = PostgresUtsendingRepository(DatabaseSession(lazy { ds }))
             repository.lagre(lagUtsending(tilstand = Utsending.VenterPåVedtak, behandlingId = behandling.behandlingId))
             shouldThrow<PSQLException> {
                 repository.lagre(


### PR DESCRIPTION
## Hva gjør denne PR-en?

Introduserer `DatabaseSession` som wrapper rundt `DataSource` og migrerer alle repositories til å bruke den.

### Motivasjon
Forbereder for `PostgresUnitOfWork` (cross-repository transaksjoner) ved å gi alle repos en felles inngang til databasen. Gir også automatisk Prometheus-metrics for alle transaksjoner (commit/rollback-tellere, varighet).

### Endringer
1. **`DatabaseSession`** — ny klasse som wrapper `DataSource` med `session {}` og `transaction {}` metoder
2. **`PostgresUnitOfWork`** — data class som holder en `Session` (brukes i neste PR)
3. **`DbMetrics`** — Prometheus-tellere for commit, rollback, transaksjonsvarighet
4. **Alle 9 repositories** migrert fra `DataSource` til `DatabaseSession`
5. **`TransactionalSession`-extensions** endret til `PostgresUnitOfWork`-extensions
6. **`databaseSession.transaction {}`** brukes nå i stedet for `session.transaction { tx -> }` — gir metrics automatisk
7. **Testinfrastruktur** oppdatert med `testDatabaseSession(ds)` hjelpefunksjon

### Ingen endring i oppførsel
Ren mekanisk refaktorering. Alle eksisterende tester passerer uten endring i assertions.

### Neste steg (separate PR-er)
- UoW-overloads i alle repo-interfaces (dual-signature)
- Migrere hotspots én for én (OppfølgingMediator.taImot, InnsendingMediator, etc.)