### PR TITLE
feat: Wrap OppfølgingMediator i transaksjoner

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/ApplicationBuilder.kt
@@ -189,6 +189,7 @@ internal class ApplicationBuilder(
                     )
                 val oppfølgingMediator =
                     OppfølgingMediator(
+                        transaksjoner = Transaksjoner(databaseSession),
                         oppfølgingRepository = PostgresOppfølgingRepository(databaseSession),
                         oppfølgingBehandler =
                             OppfølgingBehandler(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/KlageMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/KlageMediator.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import no.nav.dagpenger.saksbehandling.api.Oppslag
 import no.nav.dagpenger.saksbehandling.db.Transaksjoner
+import no.nav.dagpenger.saksbehandling.db.Transaksjonskontekst
 import no.nav.dagpenger.saksbehandling.db.klage.KlageRepository
 import no.nav.dagpenger.saksbehandling.hendelser.AvbruttHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingOpprettetHendelse
@@ -54,7 +55,10 @@ class KlageMediator(
         return klageRepository.hentKlageBehandling(behandlingId)
     }
 
-    fun opprettKlage(klageMottattHendelse: KlageMottattHendelse): Oppgave {
+    fun opprettKlage(
+        klageMottattHendelse: KlageMottattHendelse,
+        ctx: Transaksjonskontekst = Transaksjonskontekst.IkkeAktiv,
+    ): Oppgave {
         val klageBehandling =
             KlageBehandling(
                 journalpostId = klageMottattHendelse.journalpostId,
@@ -79,13 +83,13 @@ class KlageMediator(
             )
 
         val oppgave =
-            transaksjoner.transaksjon { ctx ->
-                klageRepository.lagre(klageBehandling, ctx)
-                val sakHistorikk = sakMediator.knyttTilSak(behandlingOpprettetHendelse, ctx)
+            transaksjoner.transaksjon(ctx) { aktiv ->
+                klageRepository.lagre(klageBehandling, aktiv)
+                val sakHistorikk = sakMediator.knyttTilSak(behandlingOpprettetHendelse, aktiv)
                 oppgaveMediator.lagOppgaveForKlage(
                     hendelse = behandlingOpprettetHendelse,
                     sakHistorikk = sakHistorikk,
-                    ctx = ctx,
+                    ctx = aktiv,
                 )
             }
 

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
@@ -91,6 +91,7 @@ class OppgaveMediator(
         hendelse: OpprettOppfølgingHendelse,
         behandling: Behandling,
         person: Person,
+        ctx: Transaksjonskontekst = Transaksjonskontekst.IkkeAktiv,
     ): Oppgave {
         val oppgave =
             Oppgave(
@@ -107,7 +108,7 @@ class OppgaveMediator(
             )
 
         oppgave.klargjørForBehandling(hendelse)
-        oppgaveRepository.lagre(oppgave)
+        oppgaveRepository.lagre(oppgave, ctx)
         return oppgave
     }
 

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
@@ -491,7 +491,10 @@ class OppgaveMediator(
         }
     }
 
-    fun ferdigstillOppgave(oppfølgingFerdigstiltHendelse: OppfølgingFerdigstiltHendelse) {
+    fun ferdigstillOppgave(
+        oppfølgingFerdigstiltHendelse: OppfølgingFerdigstiltHendelse,
+        ctx: Transaksjonskontekst = Transaksjonskontekst.IkkeAktiv,
+    ) {
         oppgaveRepository.hentOppgaveFor(oppfølgingFerdigstiltHendelse.oppfølgingId).let { oppgave ->
             withLoggingContext(
                 "oppgaveId" to oppgave.oppgaveId.toString(),
@@ -501,7 +504,7 @@ class OppgaveMediator(
                     "Mottatt OppfølgingFerdigstiltHendelse for oppgave i tilstand ${oppgave.tilstand().type}"
                 }
                 oppgave.ferdigstill(oppfølgingFerdigstiltHendelse)
-                oppgaveRepository.lagre(oppgave)
+                oppgaveRepository.lagre(oppgave, ctx)
                 logger.info {
                     "Behandlet OppfølgingFerdigstiltHendelse. Tilstand etter behandling: ${oppgave.tilstand().type}"
                 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/Transaksjonskontekst.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/Transaksjonskontekst.kt
@@ -31,4 +31,17 @@ class Transaksjoner(
         databaseSession.transaction {
             block(Transaksjonskontekst.Aktiv(this.session))
         }
+
+    /**
+     * Starter ny transaksjon hvis [ctx] er [Transaksjonskontekst.IkkeAktiv],
+     * eller gjenbruker eksisterende hvis [ctx] allerede er [Transaksjonskontekst.Aktiv].
+     */
+    fun <R> transaksjon(
+        ctx: Transaksjonskontekst,
+        block: (Transaksjonskontekst.Aktiv) -> R,
+    ): R =
+        when (ctx) {
+            is Transaksjonskontekst.Aktiv -> block(ctx)
+            is Transaksjonskontekst.IkkeAktiv -> transaksjon(block)
+        }
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingBehandler.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingBehandler.kt
@@ -3,6 +3,7 @@ package no.nav.dagpenger.saksbehandling.oppfolging
 import no.nav.dagpenger.saksbehandling.KlageMediator
 import no.nav.dagpenger.saksbehandling.behandling.BehandlingKlient
 import no.nav.dagpenger.saksbehandling.behandling.BehandlingstypeDTO
+import no.nav.dagpenger.saksbehandling.db.Transaksjonskontekst
 import no.nav.dagpenger.saksbehandling.hendelser.FerdigstillOppfølgingHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.KlageMottattHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.OppfølgingFerdigstiltHendelse
@@ -12,47 +13,35 @@ class OppfølgingBehandler(
     private val klageMediator: KlageMediator,
     private val behandlingKlient: BehandlingKlient,
 ) {
-    fun utførAksjon(
+    fun opprettKlage(
         oppfølging: Oppfølging,
         hendelse: FerdigstillOppfølgingHendelse,
-        oppfølgingMediator: OppfølgingMediator,
-    ): OppfølgingFerdigstiltHendelse =
-        when (hendelse.aksjon) {
-            is OppfølgingAksjon.Avslutt ->
-                OppfølgingFerdigstiltHendelse(
-                    oppfølgingId = oppfølging.id,
-                    aksjonType = hendelse.aksjon.type,
-                    opprettetBehandlingId = null,
-                    utførtAv = hendelse.utførtAv,
-                )
+        ctx: Transaksjonskontekst.Aktiv,
+    ): OppfølgingFerdigstiltHendelse {
+        val aksjon = hendelse.aksjon as OppfølgingAksjon.OpprettKlage
 
-            is OppfølgingAksjon.OpprettKlage ->
-                opprettKlage(
-                    oppfølging = oppfølging,
-                    hendelse = hendelse,
-                )
+        val klageOppgave =
+            klageMediator.opprettKlage(
+                klageMottattHendelse =
+                    KlageMottattHendelse(
+                        ident = oppfølging.person.ident,
+                        opprettet = oppfølging.opprettet,
+                        journalpostId = null,
+                        sakId = aksjon.valgtSakId,
+                        utførtAv = hendelse.utførtAv,
+                    ),
+                ctx = ctx,
+            )
 
-            is OppfølgingAksjon.OpprettManuellBehandling ->
-                opprettBehandling(
-                    oppfølging = oppfølging,
-                    hendelse = hendelse,
-                )
+        return OppfølgingFerdigstiltHendelse(
+            oppfølgingId = oppfølging.id,
+            aksjonType = hendelse.aksjon.type,
+            opprettetBehandlingId = klageOppgave.behandling.behandlingId,
+            utførtAv = hendelse.utførtAv,
+        )
+    }
 
-            is OppfølgingAksjon.OpprettRevurderingBehandling ->
-                opprettBehandling(
-                    oppfølging = oppfølging,
-                    hendelse = hendelse,
-                )
-
-            is OppfølgingAksjon.OpprettOppfølging ->
-                opprettNyOppfølging(
-                    oppfølging = oppfølging,
-                    hendelse = hendelse,
-                    oppfølgingMediator = oppfølgingMediator,
-                )
-        }
-
-    private fun opprettBehandling(
+    fun opprettBehandling(
         oppfølging: Oppfølging,
         hendelse: FerdigstillOppfølgingHendelse,
     ): OppfølgingFerdigstiltHendelse {
@@ -83,36 +72,11 @@ class OppfølgingBehandler(
             }
     }
 
-    private fun opprettKlage(
-        oppfølging: Oppfølging,
-        hendelse: FerdigstillOppfølgingHendelse,
-    ): OppfølgingFerdigstiltHendelse {
-        val aksjon = hendelse.aksjon as OppfølgingAksjon.OpprettKlage
-
-        val klageOppgave =
-            klageMediator.opprettKlage(
-                klageMottattHendelse =
-                    KlageMottattHendelse(
-                        ident = oppfølging.person.ident,
-                        opprettet = oppfølging.opprettet,
-                        journalpostId = null,
-                        sakId = aksjon.valgtSakId,
-                        utførtAv = hendelse.utførtAv,
-                    ),
-            )
-
-        return OppfølgingFerdigstiltHendelse(
-            oppfølgingId = oppfølging.id,
-            aksjonType = hendelse.aksjon.type,
-            opprettetBehandlingId = klageOppgave.behandling.behandlingId,
-            utførtAv = hendelse.utførtAv,
-        )
-    }
-
-    private fun opprettNyOppfølging(
+    fun opprettNyOppfølging(
         oppfølging: Oppfølging,
         hendelse: FerdigstillOppfølgingHendelse,
         oppfølgingMediator: OppfølgingMediator,
+        ctx: Transaksjonskontekst.Aktiv,
     ): OppfølgingFerdigstiltHendelse {
         val aksjon = hendelse.aksjon as OppfølgingAksjon.OpprettOppfølging
 
@@ -127,9 +91,8 @@ class OppfølgingBehandler(
                 utførtAv = hendelse.utførtAv,
             )
 
-        val opprettet = oppfølgingMediator.taImot(nyOppgaveHendelse)
+        val opprettet = oppfølgingMediator.taImot(nyOppgaveHendelse, ctx)
 
-        // Når frist er satt håndterer klargjørForBehandling beholdOppgaven — tildelOppgave skal ikke kalles
         return OppfølgingFerdigstiltHendelse(
             oppfølgingId = oppfølging.id,
             aksjonType = aksjon.type,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingBehandler.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingBehandler.kt
@@ -18,6 +18,7 @@ class OppfølgingBehandler(
         hendelse: FerdigstillOppfølgingHendelse,
         ctx: Transaksjonskontekst.Aktiv,
     ): OppfølgingFerdigstiltHendelse {
+        require(hendelse.aksjon is OppfølgingAksjon.OpprettKlage) { "Ugyldig aksjon for opprettKlage: ${hendelse.aksjon}" }
         val aksjon = hendelse.aksjon as OppfølgingAksjon.OpprettKlage
 
         val klageOppgave =
@@ -49,8 +50,10 @@ class OppfølgingBehandler(
             when (val aksjon = hendelse.aksjon) {
                 is OppfølgingAksjon.OpprettManuellBehandling ->
                     aksjon.saksbehandlerToken to BehandlingstypeDTO.MANUELL
+
                 is OppfølgingAksjon.OpprettRevurderingBehandling ->
                     aksjon.saksbehandlerToken to BehandlingstypeDTO.REVURDERING
+
                 else -> throw IllegalArgumentException("Ugyldig aksjon for opprettBehandling: $aksjon")
             }
 
@@ -78,6 +81,7 @@ class OppfølgingBehandler(
         oppfølgingMediator: OppfølgingMediator,
         ctx: Transaksjonskontekst.Aktiv,
     ): OppfølgingFerdigstiltHendelse {
+        require(hendelse.aksjon is OppfølgingAksjon.OpprettOppfølging) { "Ugyldig aksjon for opprettNyOppfølging: ${hendelse.aksjon}" }
         val aksjon = hendelse.aksjon as OppfølgingAksjon.OpprettOppfølging
 
         val nyOppgaveHendelse =

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediator.kt
@@ -12,6 +12,7 @@ import no.nav.dagpenger.saksbehandling.db.Transaksjonskontekst
 import no.nav.dagpenger.saksbehandling.db.oppfolging.OppfølgingRepository
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.hendelser.FerdigstillOppfølgingHendelse
+import no.nav.dagpenger.saksbehandling.hendelser.OppfølgingFerdigstiltHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.OpprettOppfølgingHendelse
 import no.nav.dagpenger.saksbehandling.sak.SakMediator
 import java.util.UUID
@@ -99,7 +100,32 @@ class OppfølgingMediator(
         )
         oppfølgingRepository.lagre(oppfølging)
 
-        val ferdigstiltHendelse = oppfølgingBehandler.utførAksjon(oppfølging, hendelse, this)
+        val ferdigstiltHendelse =
+            when (hendelse.aksjon) {
+                is OppfølgingAksjon.Avslutt ->
+                    OppfølgingFerdigstiltHendelse(
+                        oppfølgingId = oppfølging.id,
+                        aksjonType = hendelse.aksjon.type,
+                        opprettetBehandlingId = null,
+                        utførtAv = hendelse.utførtAv,
+                    )
+
+                is OppfølgingAksjon.OpprettKlage ->
+                    transaksjoner.transaksjon { ctx ->
+                        oppfølgingBehandler.opprettKlage(oppfølging, hendelse, ctx)
+                    }
+
+                is OppfølgingAksjon.OpprettManuellBehandling,
+                is OppfølgingAksjon.OpprettRevurderingBehandling,
+                ->
+                    oppfølgingBehandler.opprettBehandling(oppfølging, hendelse)
+
+                is OppfølgingAksjon.OpprettOppfølging ->
+                    transaksjoner.transaksjon { ctx ->
+                        oppfølgingBehandler.opprettNyOppfølging(oppfølging, hendelse, this, ctx)
+                    }
+            }
+
         logger.info { "Ferdigstiller oppfølging ${oppfølging.id} med aksjon ${hendelse.aksjon.type}" }
 
         oppfølging.ferdigstill(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediator.kt
@@ -7,6 +7,8 @@ import no.nav.dagpenger.saksbehandling.OppgaveMediator
 import no.nav.dagpenger.saksbehandling.Sak
 import no.nav.dagpenger.saksbehandling.Saksbehandler
 import no.nav.dagpenger.saksbehandling.UUIDv7
+import no.nav.dagpenger.saksbehandling.db.Transaksjoner
+import no.nav.dagpenger.saksbehandling.db.Transaksjonskontekst
 import no.nav.dagpenger.saksbehandling.db.oppfolging.OppfølgingRepository
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.hendelser.FerdigstillOppfølgingHendelse
@@ -22,13 +24,17 @@ data class OpprettetOppfølging(
 )
 
 class OppfølgingMediator(
+    private val transaksjoner: Transaksjoner,
     private val oppfølgingRepository: OppfølgingRepository,
     private val oppfølgingBehandler: OppfølgingBehandler,
     private val personMediator: PersonMediator,
     private val sakMediator: SakMediator,
     private val oppgaveMediator: OppgaveMediator,
 ) {
-    fun taImot(hendelse: OpprettOppfølgingHendelse): OpprettetOppfølging {
+    fun taImot(
+        hendelse: OpprettOppfølgingHendelse,
+        ctx: Transaksjonskontekst = Transaksjonskontekst.IkkeAktiv,
+    ): OpprettetOppfølging {
         val oppfølgingId = UUIDv7.ny()
         val person = personMediator.finnEllerOpprettPerson(hendelse.ident)
 
@@ -46,11 +52,6 @@ class OppfølgingMediator(
                 utløstAv = HendelseBehandler.Intern.Oppfølging,
             )
 
-        sakMediator.lagreBehandling(
-            personId = person.id,
-            behandling = behandling,
-        )
-
         val oppfølging =
             Oppfølging.opprett(
                 id = oppfølgingId,
@@ -62,14 +63,21 @@ class OppfølgingMediator(
                 opprettet = hendelse.registrertTidspunkt,
             )
 
-        oppfølgingRepository.lagre(oppfølging)
-
         val oppgave =
-            oppgaveMediator.lagOppgaveForOppfølging(
-                hendelse = hendelse,
-                behandling = behandling,
-                person = person,
-            )
+            transaksjoner.transaksjon(ctx) { aktiv ->
+                sakMediator.lagreBehandling(
+                    personId = person.id,
+                    behandling = behandling,
+                    ctx = aktiv,
+                )
+                oppfølgingRepository.lagre(oppfølging, aktiv)
+                oppgaveMediator.lagOppgaveForOppfølging(
+                    hendelse = hendelse,
+                    behandling = behandling,
+                    person = person,
+                    ctx = aktiv,
+                )
+            }
 
         logger.info {
             "Opprettet oppfølging ${oppfølging.id} med årsak ${hendelse.aarsak} i tilstand ${oppgave.tilstand()}" +

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediator.kt
@@ -94,11 +94,6 @@ class OppfølgingMediator(
     fun ferdigstill(hendelse: FerdigstillOppfølgingHendelse) {
         val oppfølging = hent(id = hendelse.oppfølgingId, saksbehandler = hendelse.utførtAv)
 
-        oppfølging.startFerdigstilling(
-            vurdering = hendelse.vurdering,
-            valgtSakId = hendelse.aksjon.valgtSakId,
-        )
-
         when (hendelse.aksjon) {
             is OppfølgingAksjon.Avslutt ->
                 ferdigstillInternt(oppfølging, hendelse) { _ ->
@@ -134,6 +129,10 @@ class OppfølgingMediator(
         aksjon: (Transaksjonskontekst.Aktiv) -> OppfølgingFerdigstiltHendelse,
     ) {
         transaksjoner.transaksjon { ctx ->
+            oppfølging.startFerdigstilling(
+                vurdering = hendelse.vurdering,
+                valgtSakId = hendelse.aksjon.valgtSakId,
+            )
             oppfølgingRepository.lagre(oppfølging, ctx)
             val ferdigstiltHendelse = aksjon(ctx)
             oppfølging.ferdigstill(
@@ -149,6 +148,10 @@ class OppfølgingMediator(
         oppfølging: Oppfølging,
         hendelse: FerdigstillOppfølgingHendelse,
     ) {
+        oppfølging.startFerdigstilling(
+            vurdering = hendelse.vurdering,
+            valgtSakId = hendelse.aksjon.valgtSakId,
+        )
         // Checkpoint: persist FERDIGSTILL_STARTET before external HTTP call
         oppfølgingRepository.lagre(oppfølging)
 

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediator.kt
@@ -98,42 +98,71 @@ class OppfølgingMediator(
             vurdering = hendelse.vurdering,
             valgtSakId = hendelse.aksjon.valgtSakId,
         )
-        oppfølgingRepository.lagre(oppfølging)
 
-        val ferdigstiltHendelse =
-            when (hendelse.aksjon) {
-                is OppfølgingAksjon.Avslutt ->
+        when (hendelse.aksjon) {
+            is OppfølgingAksjon.Avslutt ->
+                ferdigstillInternt(oppfølging, hendelse) { _ ->
                     OppfølgingFerdigstiltHendelse(
                         oppfølgingId = oppfølging.id,
                         aksjonType = hendelse.aksjon.type,
                         opprettetBehandlingId = null,
                         utførtAv = hendelse.utførtAv,
                     )
+                }
 
-                is OppfølgingAksjon.OpprettKlage ->
-                    transaksjoner.transaksjon { ctx ->
-                        oppfølgingBehandler.opprettKlage(oppfølging, hendelse, ctx)
-                    }
+            is OppfølgingAksjon.OpprettKlage ->
+                ferdigstillInternt(oppfølging, hendelse) { ctx ->
+                    oppfølgingBehandler.opprettKlage(oppfølging, hendelse, ctx)
+                }
 
-                is OppfølgingAksjon.OpprettManuellBehandling,
-                is OppfølgingAksjon.OpprettRevurderingBehandling,
-                ->
-                    oppfølgingBehandler.opprettBehandling(oppfølging, hendelse)
+            is OppfølgingAksjon.OpprettOppfølging ->
+                ferdigstillInternt(oppfølging, hendelse) { ctx ->
+                    oppfølgingBehandler.opprettNyOppfølging(oppfølging, hendelse, this, ctx)
+                }
 
-                is OppfølgingAksjon.OpprettOppfølging ->
-                    transaksjoner.transaksjon { ctx ->
-                        oppfølgingBehandler.opprettNyOppfølging(oppfølging, hendelse, this, ctx)
-                    }
-            }
+            is OppfølgingAksjon.OpprettManuellBehandling,
+            is OppfølgingAksjon.OpprettRevurderingBehandling,
+            -> ferdigstillEksternt(oppfølging, hendelse)
+        }
 
-        logger.info { "Ferdigstiller oppfølging ${oppfølging.id} med aksjon ${hendelse.aksjon.type}" }
+        logger.info { "Ferdigstilt oppfølging ${oppfølging.id} med aksjon ${hendelse.aksjon.type}" }
+    }
 
-        oppfølging.ferdigstill(
-            aksjonType = ferdigstiltHendelse.aksjonType,
-            opprettetBehandlingId = ferdigstiltHendelse.opprettetBehandlingId,
-        )
-        oppgaveMediator.ferdigstillOppgave(ferdigstiltHendelse)
+    private fun ferdigstillInternt(
+        oppfølging: Oppfølging,
+        hendelse: FerdigstillOppfølgingHendelse,
+        aksjon: (Transaksjonskontekst.Aktiv) -> OppfølgingFerdigstiltHendelse,
+    ) {
+        transaksjoner.transaksjon { ctx ->
+            oppfølgingRepository.lagre(oppfølging, ctx)
+            val ferdigstiltHendelse = aksjon(ctx)
+            oppfølging.ferdigstill(
+                aksjonType = ferdigstiltHendelse.aksjonType,
+                opprettetBehandlingId = ferdigstiltHendelse.opprettetBehandlingId,
+            )
+            oppgaveMediator.ferdigstillOppgave(ferdigstiltHendelse, ctx)
+            oppfølgingRepository.lagre(oppfølging, ctx)
+        }
+    }
+
+    private fun ferdigstillEksternt(
+        oppfølging: Oppfølging,
+        hendelse: FerdigstillOppfølgingHendelse,
+    ) {
+        // Checkpoint: persist FERDIGSTILL_STARTET before external HTTP call
         oppfølgingRepository.lagre(oppfølging)
+
+        val ferdigstiltHendelse = oppfølgingBehandler.opprettBehandling(oppfølging, hendelse)
+
+        // Final writes in one transaction after successful HTTP
+        transaksjoner.transaksjon { ctx ->
+            oppfølging.ferdigstill(
+                aksjonType = ferdigstiltHendelse.aksjonType,
+                opprettetBehandlingId = ferdigstiltHendelse.opprettetBehandlingId,
+            )
+            oppgaveMediator.ferdigstillOppgave(ferdigstiltHendelse, ctx)
+            oppfølgingRepository.lagre(oppfølging, ctx)
+        }
     }
 
     fun hent(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/sak/SakMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/sak/SakMediator.kt
@@ -278,11 +278,13 @@ class SakMediator(
     fun lagreBehandling(
         personId: UUID,
         behandling: Behandling,
+        ctx: Transaksjonskontekst = IkkeAktiv,
     ) {
         sakRepository.lagreBehandling(
             personId = personId,
             sakId = null,
             behandling = behandling,
+            ctx = ctx,
         )
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediatorTest.kt
@@ -12,6 +12,7 @@ import no.nav.dagpenger.saksbehandling.TilgangType
 import no.nav.dagpenger.saksbehandling.behandling.BehandlingKlient
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
 import no.nav.dagpenger.saksbehandling.db.DatabaseSession
+import no.nav.dagpenger.saksbehandling.db.Transaksjoner
 import no.nav.dagpenger.saksbehandling.db.oppfolging.PostgresOppfølgingRepository
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
@@ -64,6 +65,7 @@ class OppfølgingMediatorTest {
 
             val mediator =
                 OppfølgingMediator(
+                    transaksjoner = Transaksjoner(DatabaseSession(lazy { ds })),
                     oppfølgingRepository = oppfølgingRepository,
                     oppfølgingBehandler = oppfølgingBehandler,
                     personMediator = personMediator,
@@ -138,6 +140,7 @@ class OppfølgingMediatorTest {
             val saksbehandler = Saksbehandler("Z999999", emptySet(), setOf(TilgangType.SAKSBEHANDLER))
             val mediator =
                 OppfølgingMediator(
+                    transaksjoner = Transaksjoner(DatabaseSession(lazy { ds })),
                     oppfølgingRepository = oppfølgingRepository,
                     oppfølgingBehandler = OppfølgingBehandler(mockk<KlageMediator>(), mockk<BehandlingKlient>()),
                     personMediator = personMediator,
@@ -207,6 +210,7 @@ class OppfølgingMediatorTest {
             val saksbehandler = Saksbehandler("Z999999", emptySet(), setOf(TilgangType.SAKSBEHANDLER))
             val mediator =
                 OppfølgingMediator(
+                    transaksjoner = Transaksjoner(DatabaseSession(lazy { ds })),
                     oppfølgingRepository = oppfølgingRepository,
                     oppfølgingBehandler = OppfølgingBehandler(mockk<KlageMediator>(), mockk<BehandlingKlient>()),
                     personMediator = personMediator,
@@ -247,6 +251,49 @@ class OppfølgingMediatorTest {
             val nyOppgave = oppgaver.first { it.tilstand() == Oppgave.KlarTilBehandling }
             nyOppgave.tilstand() shouldBe Oppgave.KlarTilBehandling
             nyOppgave.behandlerIdent shouldBe null
+        }
+    }
+
+    @Test
+    fun `taImot ruller tilbake alle DB-endringer hvis oppgave-lagring feiler`() {
+        DBTestHelper.withPerson { ds ->
+            val databaseSession = DatabaseSession(lazy { ds })
+            val oppfølgingRepository = PostgresOppfølgingRepository(databaseSession)
+            val personMediator = PersonMediator(PostgresPersonRepository(databaseSession), mockk())
+            val sakMediator =
+                SakMediator(
+                    personMediator = personMediator,
+                    sakRepository = PostgresSakRepository(databaseSession),
+                    rapidsConnection = mockk(relaxed = true),
+                )
+            val oppgaveMediator =
+                mockk<OppgaveMediator>().also {
+                    every { it.lagOppgaveForOppfølging(any(), any(), any(), any()) } throws
+                        RuntimeException("DB-feil ved lagring av oppgave")
+                }
+
+            val mediator =
+                OppfølgingMediator(
+                    transaksjoner = Transaksjoner(databaseSession),
+                    oppfølgingRepository = oppfølgingRepository,
+                    oppfølgingBehandler = mockk(),
+                    personMediator = personMediator,
+                    sakMediator = sakMediator,
+                    oppgaveMediator = oppgaveMediator,
+                )
+
+            val hendelse =
+                OpprettOppfølgingHendelse(
+                    ident = testPerson.ident,
+                    aarsak = "Test",
+                    tittel = "Skal rulle tilbake",
+                )
+
+            runCatching { mediator.taImot(hendelse) }
+                .isFailure shouldBe true
+
+            // Verifiser at oppfølging IKKE ble lagret (rollback)
+            oppfølgingRepository.finnForPerson(testPerson.ident) shouldBe emptyList()
         }
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediatorTest.kt
@@ -19,7 +19,6 @@ import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.db.person.PostgresPersonRepository
 import no.nav.dagpenger.saksbehandling.db.sak.PostgresSakRepository
 import no.nav.dagpenger.saksbehandling.hendelser.FerdigstillOppfølgingHendelse
-import no.nav.dagpenger.saksbehandling.hendelser.OppfølgingFerdigstiltHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.OpprettOppfølgingHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.SettOppgaveAnsvarHendelse
 import no.nav.dagpenger.saksbehandling.sak.SakMediator
@@ -50,18 +49,7 @@ class OppfølgingMediatorTest {
                     rapidsConnection = mockk(relaxed = true),
                 )
 
-            val oppfølgingBehandler =
-                mockk<OppfølgingBehandler>().also {
-                    every { it.utførAksjon(any(), any(), any()) } answers {
-                        val oppgave = firstArg<Oppfølging>()
-                        OppfølgingFerdigstiltHendelse(
-                            oppfølgingId = oppgave.id,
-                            aksjonType = OppfølgingAksjon.Type.AVSLUTT,
-                            opprettetBehandlingId = null,
-                            utførtAv = saksbehandler,
-                        )
-                    }
-                }
+            val oppfølgingBehandler = mockk<OppfølgingBehandler>()
 
             val mediator =
                 OppfølgingMediator(

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediatorTest.kt
@@ -34,17 +34,18 @@ class OppfølgingMediatorTest {
     @Test
     fun `E2E - opprette og ferdigstille oppfølging`() {
         DBTestHelper.withPerson { ds ->
-            val oppfølgingRepository = PostgresOppfølgingRepository(DatabaseSession(lazy { ds }))
-            val personMediator = PersonMediator(PostgresPersonRepository(DatabaseSession(lazy { ds })), mockk())
+            val databaseSession = DatabaseSession(ds)
+            val oppfølgingRepository = PostgresOppfølgingRepository(databaseSession)
+            val personMediator = PersonMediator(PostgresPersonRepository(databaseSession), mockk())
             val sakMediator =
                 SakMediator(
                     personMediator = personMediator,
-                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
+                    sakRepository = PostgresSakRepository(databaseSession),
                     rapidsConnection = mockk(relaxed = true),
                 )
             val oppgaveMediator =
                 OppgaveMediator(
-                    oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(lazy { ds })),
+                    oppgaveRepository = PostgresOppgaveRepository(databaseSession),
                     behandlingKlient = mockk(),
                     utsendingMediator = mockk(),
                     sakMediator = sakMediator,
@@ -55,7 +56,7 @@ class OppfølgingMediatorTest {
 
             val mediator =
                 OppfølgingMediator(
-                    transaksjoner = Transaksjoner(DatabaseSession(lazy { ds })),
+                    transaksjoner = Transaksjoner(databaseSession),
                     oppfølgingRepository = oppfølgingRepository,
                     oppfølgingBehandler = oppfølgingBehandler,
                     personMediator = personMediator,
@@ -110,15 +111,15 @@ class OppfølgingMediatorTest {
     @Test
     fun `ferdigstill med OpprettOppfølging - frist og beholdOppgaven gir ny oppgave i PåVent`() {
         DBTestHelper.withPerson { ds ->
-            val oppfølgingRepository = PostgresOppfølgingRepository(DatabaseSession(lazy { ds }))
-            val personMediator = PersonMediator(PostgresPersonRepository(DatabaseSession(lazy { ds })), mockk())
+            val oppfølgingRepository = PostgresOppfølgingRepository(DatabaseSession(ds))
+            val personMediator = PersonMediator(PostgresPersonRepository(DatabaseSession(ds)), mockk())
             val sakMediator =
                 SakMediator(
                     personMediator = personMediator,
-                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
+                    sakRepository = PostgresSakRepository(DatabaseSession(ds)),
                     rapidsConnection = mockk(relaxed = true),
                 )
-            val oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
+            val oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(ds))
             val oppgaveMediator =
                 OppgaveMediator(
                     oppgaveRepository = oppgaveRepository,
@@ -130,7 +131,7 @@ class OppfølgingMediatorTest {
             val saksbehandler = Saksbehandler("Z999999", emptySet(), setOf(TilgangType.SAKSBEHANDLER))
             val mediator =
                 OppfølgingMediator(
-                    transaksjoner = Transaksjoner(DatabaseSession(lazy { ds })),
+                    transaksjoner = Transaksjoner(DatabaseSession(ds)),
                     oppfølgingRepository = oppfølgingRepository,
                     oppfølgingBehandler = OppfølgingBehandler(mockk<KlageMediator>(), mockk<BehandlingKlient>()),
                     personMediator = personMediator,
@@ -180,15 +181,15 @@ class OppfølgingMediatorTest {
     @Test
     fun `ferdigstill med OpprettOppfølging uten beholdOppgaven gir ny oppgave i KlarTilBehandling uten behandler`() {
         DBTestHelper.withPerson { ds ->
-            val oppfølgingRepository = PostgresOppfølgingRepository(DatabaseSession(lazy { ds }))
-            val personMediator = PersonMediator(PostgresPersonRepository(DatabaseSession(lazy { ds })), mockk())
+            val oppfølgingRepository = PostgresOppfølgingRepository(DatabaseSession(ds))
+            val personMediator = PersonMediator(PostgresPersonRepository(DatabaseSession(ds)), mockk())
             val sakMediator =
                 SakMediator(
                     personMediator = personMediator,
-                    sakRepository = PostgresSakRepository(DatabaseSession(lazy { ds })),
+                    sakRepository = PostgresSakRepository(DatabaseSession(ds)),
                     rapidsConnection = mockk(relaxed = true),
                 )
-            val oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(lazy { ds }))
+            val oppgaveRepository = PostgresOppgaveRepository(DatabaseSession(ds))
             val oppgaveMediator =
                 OppgaveMediator(
                     oppgaveRepository = oppgaveRepository,
@@ -200,7 +201,7 @@ class OppfølgingMediatorTest {
             val saksbehandler = Saksbehandler("Z999999", emptySet(), setOf(TilgangType.SAKSBEHANDLER))
             val mediator =
                 OppfølgingMediator(
-                    transaksjoner = Transaksjoner(DatabaseSession(lazy { ds })),
+                    transaksjoner = Transaksjoner(DatabaseSession(ds)),
                     oppfølgingRepository = oppfølgingRepository,
                     oppfølgingBehandler = OppfølgingBehandler(mockk<KlageMediator>(), mockk<BehandlingKlient>()),
                     personMediator = personMediator,
@@ -247,7 +248,7 @@ class OppfølgingMediatorTest {
     @Test
     fun `taImot ruller tilbake alle DB-endringer hvis oppgave-lagring feiler`() {
         DBTestHelper.withPerson { ds ->
-            val databaseSession = DatabaseSession(lazy { ds })
+            val databaseSession = DatabaseSession(ds)
             val oppfølgingRepository = PostgresOppfølgingRepository(databaseSession)
             val personMediator = PersonMediator(PostgresPersonRepository(databaseSession), mockk())
             val sakMediator =
@@ -290,7 +291,7 @@ class OppfølgingMediatorTest {
     @Test
     fun `ferdigstillInternt ruller tilbake alle DB-endringer hvis ferdigstillOppgave feiler`() {
         DBTestHelper.withPerson { ds ->
-            val databaseSession = DatabaseSession(lazy { ds })
+            val databaseSession = DatabaseSession(ds)
             val oppfølgingRepository = PostgresOppfølgingRepository(databaseSession)
             val personMediator = PersonMediator(PostgresPersonRepository(databaseSession), mockk())
             val sakMediator =
@@ -382,7 +383,7 @@ class OppfølgingMediatorTest {
     @Test
     fun `ferdigstillEksternt - HTTP-feil lar oppfølging stå i FERDIGSTILL_STARTET`() {
         DBTestHelper.withPerson { ds ->
-            val databaseSession = DatabaseSession(lazy { ds })
+            val databaseSession = DatabaseSession(ds)
             val oppfølgingRepository = PostgresOppfølgingRepository(databaseSession)
             val personMediator = PersonMediator(PostgresPersonRepository(databaseSession), mockk())
             val sakMediator =
@@ -458,7 +459,7 @@ class OppfølgingMediatorTest {
     @Test
     fun `ferdigstillEksternt - tx-feil etter HTTP lar oppfølging stå i FERDIGSTILL_STARTET`() {
         DBTestHelper.withPerson { ds ->
-            val databaseSession = DatabaseSession(lazy { ds })
+            val databaseSession = DatabaseSession(ds)
             val oppfølgingRepository = PostgresOppfølgingRepository(databaseSession)
             val personMediator = PersonMediator(PostgresPersonRepository(databaseSession), mockk())
             val sakMediator =

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediatorTest.kt
@@ -19,11 +19,13 @@ import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.db.person.PostgresPersonRepository
 import no.nav.dagpenger.saksbehandling.db.sak.PostgresSakRepository
 import no.nav.dagpenger.saksbehandling.hendelser.FerdigstillOppfølgingHendelse
+import no.nav.dagpenger.saksbehandling.hendelser.OppfølgingFerdigstiltHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.OpprettOppfølgingHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.SettOppgaveAnsvarHendelse
 import no.nav.dagpenger.saksbehandling.sak.SakMediator
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
+import java.util.UUID
 
 class OppfølgingMediatorTest {
     private val testPerson = DBTestHelper.testPerson
@@ -374,6 +376,182 @@ class OppfølgingMediatorTest {
             val oppfølging = oppfølgingRepository.hent(resultat.oppfølgingId)
             oppfølging.tilstand() shouldBe "BEHANDLES"
             oppfølging.vurdering() shouldBe null
+        }
+    }
+
+    @Test
+    fun `ferdigstillEksternt - HTTP-feil lar oppfølging stå i FERDIGSTILL_STARTET`() {
+        DBTestHelper.withPerson { ds ->
+            val databaseSession = DatabaseSession(lazy { ds })
+            val oppfølgingRepository = PostgresOppfølgingRepository(databaseSession)
+            val personMediator = PersonMediator(PostgresPersonRepository(databaseSession), mockk())
+            val sakMediator =
+                SakMediator(
+                    personMediator = personMediator,
+                    sakRepository = PostgresSakRepository(databaseSession),
+                    rapidsConnection = mockk(relaxed = true),
+                )
+            val oppgaveMediator =
+                OppgaveMediator(
+                    oppgaveRepository = PostgresOppgaveRepository(databaseSession),
+                    behandlingKlient = mockk(),
+                    utsendingMediator = mockk(),
+                    sakMediator = sakMediator,
+                    rapidsConnection = mockk(relaxed = true),
+                )
+
+            val oppfølgingBehandler =
+                mockk<OppfølgingBehandler>().also {
+                    every { it.opprettBehandling(any(), any()) } throws
+                        RuntimeException("HTTP-feil mot dp-behandling")
+                }
+
+            val mediator =
+                OppfølgingMediator(
+                    transaksjoner = Transaksjoner(databaseSession),
+                    oppfølgingRepository = oppfølgingRepository,
+                    oppfølgingBehandler = oppfølgingBehandler,
+                    personMediator = personMediator,
+                    sakMediator = sakMediator,
+                    oppgaveMediator = oppgaveMediator,
+                )
+
+            val resultat =
+                mediator.taImot(
+                    OpprettOppfølgingHendelse(
+                        ident = testPerson.ident,
+                        aarsak = "Test",
+                        tittel = "Test oppfølging",
+                    ),
+                )
+
+            oppgaveMediator.tildelOppgave(
+                SettOppgaveAnsvarHendelse(
+                    oppgaveId = resultat.oppgaveId,
+                    ansvarligIdent = saksbehandler.navIdent,
+                    utførtAv = saksbehandler,
+                ),
+            )
+
+            runCatching {
+                mediator.ferdigstill(
+                    FerdigstillOppfølgingHendelse(
+                        oppfølgingId = resultat.oppfølgingId,
+                        aksjon =
+                            OppfølgingAksjon.OpprettManuellBehandling(
+                                saksbehandlerToken = "token",
+                                valgtSakId = UUID.randomUUID(),
+                            ),
+                        vurdering = "Trenger manuell behandling",
+                        utførtAv = saksbehandler,
+                    ),
+                )
+            }.isFailure shouldBe true
+
+            // Oppfølging ble checkpointet til FERDIGSTILL_STARTET før HTTP-kallet
+            val oppfølging = oppfølgingRepository.hent(resultat.oppfølgingId)
+            oppfølging.tilstand() shouldBe "FERDIGSTILL_STARTET"
+            oppfølging.vurdering() shouldBe "Trenger manuell behandling"
+        }
+    }
+
+    @Test
+    fun `ferdigstillEksternt - tx-feil etter HTTP lar oppfølging stå i FERDIGSTILL_STARTET`() {
+        DBTestHelper.withPerson { ds ->
+            val databaseSession = DatabaseSession(lazy { ds })
+            val oppfølgingRepository = PostgresOppfølgingRepository(databaseSession)
+            val personMediator = PersonMediator(PostgresPersonRepository(databaseSession), mockk())
+            val sakMediator =
+                SakMediator(
+                    personMediator = personMediator,
+                    sakRepository = PostgresSakRepository(databaseSession),
+                    rapidsConnection = mockk(relaxed = true),
+                )
+            val oppgaveMediator =
+                OppgaveMediator(
+                    oppgaveRepository = PostgresOppgaveRepository(databaseSession),
+                    behandlingKlient = mockk(),
+                    utsendingMediator = mockk(),
+                    sakMediator = sakMediator,
+                    rapidsConnection = mockk(relaxed = true),
+                )
+
+            // OppfølgingBehandler som lykkes med HTTP men ferdigstillOppgave feiler etterpå
+            val oppfølgingBehandler =
+                mockk<OppfølgingBehandler>().also {
+                    every { it.opprettBehandling(any(), any()) } answers {
+                        val oppfølging = firstArg<Oppfølging>()
+                        OppfølgingFerdigstiltHendelse(
+                            oppfølgingId = oppfølging.id,
+                            aksjonType = OppfølgingAksjon.Type.OPPRETT_MANUELL_BEHANDLING,
+                            opprettetBehandlingId = UUID.randomUUID(),
+                            utførtAv = saksbehandler,
+                        )
+                    }
+                }
+
+            val mediator =
+                OppfølgingMediator(
+                    transaksjoner = Transaksjoner(databaseSession),
+                    oppfølgingRepository = oppfølgingRepository,
+                    oppfølgingBehandler = oppfølgingBehandler,
+                    personMediator = personMediator,
+                    sakMediator = sakMediator,
+                    oppgaveMediator = oppgaveMediator,
+                )
+
+            val resultat =
+                mediator.taImot(
+                    OpprettOppfølgingHendelse(
+                        ident = testPerson.ident,
+                        aarsak = "Test",
+                        tittel = "Test oppfølging",
+                    ),
+                )
+
+            oppgaveMediator.tildelOppgave(
+                SettOppgaveAnsvarHendelse(
+                    oppgaveId = resultat.oppgaveId,
+                    ansvarligIdent = saksbehandler.navIdent,
+                    utførtAv = saksbehandler,
+                ),
+            )
+
+            // Bytt til mediator med feilende oppgaveMediator for post-HTTP tx
+            val feilendeOppgaveMediator =
+                mockk<OppgaveMediator>().also {
+                    every { it.ferdigstillOppgave(any<OppfølgingFerdigstiltHendelse>(), any()) } throws
+                        RuntimeException("DB-feil i post-HTTP transaksjon")
+                }
+
+            val mediatorMedFeil =
+                OppfølgingMediator(
+                    transaksjoner = Transaksjoner(databaseSession),
+                    oppfølgingRepository = oppfølgingRepository,
+                    oppfølgingBehandler = oppfølgingBehandler,
+                    personMediator = personMediator,
+                    sakMediator = sakMediator,
+                    oppgaveMediator = feilendeOppgaveMediator,
+                )
+
+            runCatching {
+                mediatorMedFeil.ferdigstill(
+                    FerdigstillOppfølgingHendelse(
+                        oppfølgingId = resultat.oppfølgingId,
+                        aksjon =
+                            OppfølgingAksjon.OpprettManuellBehandling(
+                                saksbehandlerToken = "token",
+                                valgtSakId = UUID.randomUUID(),
+                            ),
+                        vurdering = "Trenger manuell behandling",
+                        utførtAv = saksbehandler,
+                    ),
+                )
+            }.isFailure shouldBe true
+
+            // Oppfølging forblir i FERDIGSTILL_STARTET — OppfølgingAlarmJob vil fange dette
+            val oppfølging = oppfølgingRepository.hent(resultat.oppfølgingId)
+            oppfølging.tilstand() shouldBe "FERDIGSTILL_STARTET"
         }
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediatorTest.kt
@@ -284,4 +284,96 @@ class OppfølgingMediatorTest {
             oppfølgingRepository.finnForPerson(testPerson.ident) shouldBe emptyList()
         }
     }
+
+    @Test
+    fun `ferdigstillInternt ruller tilbake alle DB-endringer hvis ferdigstillOppgave feiler`() {
+        DBTestHelper.withPerson { ds ->
+            val databaseSession = DatabaseSession(lazy { ds })
+            val oppfølgingRepository = PostgresOppfølgingRepository(databaseSession)
+            val personMediator = PersonMediator(PostgresPersonRepository(databaseSession), mockk())
+            val sakMediator =
+                SakMediator(
+                    personMediator = personMediator,
+                    sakRepository = PostgresSakRepository(databaseSession),
+                    rapidsConnection = mockk(relaxed = true),
+                )
+            val oppgaveMediator =
+                OppgaveMediator(
+                    oppgaveRepository = PostgresOppgaveRepository(databaseSession),
+                    behandlingKlient = mockk(),
+                    utsendingMediator = mockk(),
+                    sakMediator = sakMediator,
+                    rapidsConnection = mockk(relaxed = true),
+                )
+
+            val oppfølgingBehandler = mockk<OppfølgingBehandler>()
+
+            val mediator =
+                OppfølgingMediator(
+                    transaksjoner = Transaksjoner(databaseSession),
+                    oppfølgingRepository = oppfølgingRepository,
+                    oppfølgingBehandler = oppfølgingBehandler,
+                    personMediator = personMediator,
+                    sakMediator = sakMediator,
+                    oppgaveMediator = oppgaveMediator,
+                )
+
+            // Opprett en oppfølging først
+            val resultat =
+                mediator.taImot(
+                    OpprettOppfølgingHendelse(
+                        ident = testPerson.ident,
+                        aarsak = "Test",
+                        tittel = "Test oppfølging",
+                    ),
+                )
+
+            // Tildel oppgaven (kreves for ferdigstill)
+            oppgaveMediator.tildelOppgave(
+                SettOppgaveAnsvarHendelse(
+                    oppgaveId = resultat.oppgaveId,
+                    ansvarligIdent = saksbehandler.navIdent,
+                    utførtAv = saksbehandler,
+                ),
+            )
+
+            // Mock oppgaveMediator.ferdigstillOppgave til å kaste feil
+            val feilendeOppgaveMediator =
+                mockk<OppgaveMediator>().also {
+                    every {
+                        it.ferdigstillOppgave(
+                            any<no.nav.dagpenger.saksbehandling.hendelser.OppfølgingFerdigstiltHendelse>(),
+                            any(),
+                        )
+                    } throws
+                        RuntimeException("Feil ved ferdigstilling av oppgave")
+                }
+
+            val mediatorMedFeil =
+                OppfølgingMediator(
+                    transaksjoner = Transaksjoner(databaseSession),
+                    oppfølgingRepository = oppfølgingRepository,
+                    oppfølgingBehandler = oppfølgingBehandler,
+                    personMediator = personMediator,
+                    sakMediator = sakMediator,
+                    oppgaveMediator = feilendeOppgaveMediator,
+                )
+
+            runCatching {
+                mediatorMedFeil.ferdigstill(
+                    FerdigstillOppfølgingHendelse(
+                        oppfølgingId = resultat.oppfølgingId,
+                        aksjon = OppfølgingAksjon.Avslutt(null),
+                        vurdering = "Skal rulle tilbake",
+                        utførtAv = saksbehandler,
+                    ),
+                )
+            }.isFailure shouldBe true
+
+            // Verifiser at oppfølging IKKE ble ferdigstilt (rollback)
+            val oppfølging = oppfølgingRepository.hent(resultat.oppfølgingId)
+            oppfølging.tilstand() shouldBe "BEHANDLES"
+            oppfølging.vurdering() shouldBe null
+        }
+    }
 }


### PR DESCRIPTION
## Hva
Wrapper `OppfølgingMediator.taImot` og `ferdigstill` i eksplisitte transaksjoner med rollback-garanti.

## Endringer

### Commit 1: taImot i transaksjon
- `taImot` wrapper alle 3 DB-operasjoner (oppfølging, sak, oppgave) i én tx
- `Transaksjoner.transaksjon(ctx)` overload for nested/reuse

### Commit 2: Splitt OppfølgingBehandler
- Fjerner `utførAksjon` when-blokk
- Eksponerer: `opprettKlage(ctx)`, `opprettBehandling()`, `opprettNyOppfølging(ctx)`
- When-routing flyttes til OppfølgingMediator
- `KlageMediator.opprettKlage` får ctx-parameter

### Commit 3: ferdigstill med aksjon-routing
- Interne aksjoner (Avslutt, OpprettKlage, OpprettOppfølging): hele flyten i 1 tx
- Eksterne aksjoner (OpprettManuell, OpprettRevurdering): checkpoint → HTTP → tx
- `OppgaveMediator.ferdigstillOppgave(OppfølgingFerdigstiltHendelse)` får ctx-parameter
- Rollback-test for ferdigstillInternt

## Stacker på
PR #386 (uow-klage-mediator)
