### PR TITLE
feat: wrap InnsendingMediator.taImot* i transaksjon

### DIFF
--- a/dokumentasjon/UnitOfWork-hotspots.md
+++ b/dokumentasjon/UnitOfWork-hotspots.md
@@ -68,7 +68,23 @@ Alle 🟡 gule er enten wrappet (der mulig), bevisst ikke wrappet (HTTP i midten
 | 14 | `OppgaveMediator.avbryt()` | DB+Kafka | **Medium** | `lagre(oppgave)` → Kafka `avbryt_behandling`. Ingen alarm-jobb dekker dette. dp-behandling vet ikke om avbruddet ved krasj |
 | 15 | `SakMediator.opprettSak()` | DB+DB | Lav | `finnEllerOpprettPerson` → `lagre(sakHistorikk)`. Idempotent ved retry |
 
-**Anbefaling for #14:** Lag `AvbrytBehandlingAlarmJob` som finner oppgaver i tilstand `Avbrutt` der behandlingen fortsatt er aktiv i dp-behandling, eller bruk outbox-pattern for `avbryt_behandling`-eventen.
+### Re-vurdering av nye funn (2026-06-01)
+
+Etter kritisk gjennomgang: **#13/#14/#15 er ikke reelle problemer** for cross-repo transaksjonshåndtering.
+
+| # | Flow | Type | Konklusjon |
+|---|------|------|------------|
+| 13 | `OppgaveMediator.endreMeldingOmVedtakKilde()` | DB+DB | **Ikke problem.** API-trigget (synkron). `slettUtsending` er separat, trygg. Feiler den, får saksbehandler HTTP-feil og prøver på nytt; `endreMeldingOmVedtakKilde` er idempotent. Selvhelende ved retry |
+| 14 | `OppgaveMediator.avbryt()` | DB+Kafka | **Ikke cross-repo-hotspot.** Dette er dual-write (DB+Kafka), annen problemklasse enn UoW. API-trigget. `rapidsConnection.publish` kaster sjelden; vinduet er app-krasj mellom to linjer. Akseptert R&R-tradeoff på tvers av hele kodebasen |
+| 15 | `SakMediator.opprettSak()` | DB+DB | **Ikke problem.** Kafka-trigget → River reprosesserer ved feil (onPacket kaster = ingen ack). `finnEllerOpprettPerson` idempotent. Selvhelende |
+
+### Funn som ble fikset
+
+| # | Flow | Fil | Beskrivelse | Status |
+|---|------|-----|-------------|--------|
+| 16 | `InnsendingMediator.automatiskFerdigstill()` | `innsending/InnsendingMediator.kt:133` | `innsendingRepo.lagre` → `oppgaveMediator.avbrytOppgave` (cross-repo, ingen HTTP imellom). Var ikke wrappet — strukturelt identisk med #2/#3 | ✅ Wrappet i tx (la til `ctx`-param på `avbrytOppgave`) + rollback-test |
+
+**Konklusjon:** Etter wrapping av #16 er alle ekte cross-repo DB-write-flows uten ekstern I/O dekket. Gjenstående uvwrappede flows har enten HTTP/Kafka imellom (bevisst, mitigert av alarm-jobber) eller er selvhelende via River-retry/idempotens.
 
 ## Notater
 

--- a/dokumentasjon/UnitOfWork-hotspots.md
+++ b/dokumentasjon/UnitOfWork-hotspots.md
@@ -50,12 +50,29 @@ felles `Session` gjennom alle repo-kall innenfor en transaksjon.
 
 ## Anbefalt rekkefølge
 
-1. **Innfør infrastruktur**: `DatabaseSession` + `PostgresUnitOfWork` (etter dp-behandling-mønster)
-2. **Migrer 🔴 hotspots**: Rene DB-writes, ingen ekstern I/O — trygt å samle i transaksjon
+1. ✅ **Innfør infrastruktur**: `DatabaseSession` + `PostgresUnitOfWork` (etter dp-behandling-mønster)
+2. ✅ **Migrer 🔴 hotspots**: Rene DB-writes, ingen ekstern I/O — trygt å samle i transaksjon
 3. **Vurder 🟡 hotspots**: For flows med HTTP/Kafka — vurder om DB-delen kan isoleres i transaksjon med I/O utenfor
 4. **Outbox-pattern**: For flows der DB+event-konsistens er kritisk
+
+## Status (2026-06-01)
+
+Alle 🔴 røde hotspots (#1–5) er wrappet i transaksjon via PR-stack #386→#387→#389.
+Alle 🟡 gule er enten wrappet (der mulig), bevisst ikke wrappet (HTTP i midten), eller mitigert med alarm-jobb.
+
+### Nye funn fra fullstendig mediator-gjennomgang
+
+| # | Flow | Type | Risiko | Beskrivelse |
+|---|------|------|--------|-------------|
+| 13 | `OppgaveMediator.endreMeldingOmVedtakKilde()` | DB+DB | Lav | `lagre(oppgave)` → `slettUtsending`. Reverser rekkefølge eller wrap i tx |
+| 14 | `OppgaveMediator.avbryt()` | DB+Kafka | **Medium** | `lagre(oppgave)` → Kafka `avbryt_behandling`. Ingen alarm-jobb dekker dette. dp-behandling vet ikke om avbruddet ved krasj |
+| 15 | `SakMediator.opprettSak()` | DB+DB | Lav | `finnEllerOpprettPerson` → `lagre(sakHistorikk)`. Idempotent ved retry |
+
+**Anbefaling for #14:** Lag `AvbrytBehandlingAlarmJob` som finner oppgaver i tilstand `Avbrutt` der behandlingen fortsatt er aktiv i dp-behandling, eller bruk outbox-pattern for `avbryt_behandling`-eventen.
 
 ## Notater
 
 - `OppfølgingMediator.ferdigstill()` har bevisst split-transaksjon (se Oppfølging.md) — mitigert av OppfølgingAlarmJob
+- `InnsendingMediator.ferdigstill()` har bevisst split-transaksjon — mitigert av InnsendingAlarmJob
 - `ferdigstillOppgaveMedUtsending()` har allerede compensating delete — fungerer, men er sårbar for app-krasj mellom steg 1 og 3
+- `OppgaveTilstandAlertJob` sjekker kun oppgaver stuck i `OPPRETTET` — dekker ikke #14

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/ApplicationBuilder.kt
@@ -212,6 +212,7 @@ internal class ApplicationBuilder(
                                 behandlingKlient = behandlingKlient,
                                 oppfølgingMediator = oppfølgingMediator,
                             ),
+                        transaksjoner = Transaksjoner(databaseSession),
                     )
 
                 server.application.installerApis(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
@@ -627,7 +627,10 @@ class OppgaveMediator(
         }.getOrThrow()
     }
 
-    fun avbrytOppgave(hendelse: BehandlingAvbruttHendelse) {
+    fun avbrytOppgave(
+        hendelse: BehandlingAvbruttHendelse,
+        ctx: Transaksjonskontekst = Transaksjonskontekst.IkkeAktiv,
+    ) {
         oppgaveRepository
             .søk(
                 Søkefilter(
@@ -643,7 +646,7 @@ class OppgaveMediator(
                 ) {
                     logger.info { "Mottatt BehandlingAvbruttHendelse for oppgave i tilstand ${oppgave.tilstand().type}" }
                     oppgave.avbryt(hendelse)
-                    oppgaveRepository.lagre(oppgave)
+                    oppgaveRepository.lagre(oppgave, ctx)
                     logger.info { "Tilstand etter BehandlingAvbruttHendelse: ${oppgave.tilstand().type}" }
                 }
             }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
@@ -62,6 +62,7 @@ class OppgaveMediator(
         innsendingMottattHendelse: InnsendingMottattHendelse,
         behandling: Behandling,
         person: Person,
+        ctx: Transaksjonskontekst = Transaksjonskontekst.IkkeAktiv,
     ) {
         val forventerBehandlingOpprettet =
             innsendingMottattHendelse.søknadId != null &&
@@ -84,7 +85,7 @@ class OppgaveMediator(
                 }
             }
 
-        oppgaveRepository.lagre(oppgave)
+        oppgaveRepository.lagre(oppgave, ctx)
     }
 
     fun lagOppgaveForOppfølging(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediator.kt
@@ -152,7 +152,10 @@ class OppgaveMediator(
         return oppgave
     }
 
-    fun taImotEttersending(hendelse: InnsendingMottattHendelse) {
+    fun taImotEttersending(
+        hendelse: InnsendingMottattHendelse,
+        ctx: Transaksjonskontekst = Transaksjonskontekst.IkkeAktiv,
+    ) {
         if (!hendelse.erEttersendingMedSøknadId()) {
             return
         }
@@ -169,7 +172,7 @@ class OppgaveMediator(
             .singleOrNull()
             ?.let { oppgave ->
                 oppgave.taImotEttersending(hendelse)
-                oppgaveRepository.lagre(oppgave)
+                oppgaveRepository.lagre(oppgave, ctx)
             } ?: logger.warn {
             "Fant ingen oppgave for søknad med id ${hendelse.søknadId}. Kunne ikke legge til ettersending."
         }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/innsending/InnsendingRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/innsending/InnsendingRepository.kt
@@ -1,10 +1,15 @@
 package no.nav.dagpenger.saksbehandling.db.innsending
 
+import no.nav.dagpenger.saksbehandling.db.Transaksjonskontekst
+import no.nav.dagpenger.saksbehandling.db.Transaksjonskontekst.IkkeAktiv
 import no.nav.dagpenger.saksbehandling.innsending.Innsending
 import java.util.UUID
 
 interface InnsendingRepository {
-    fun lagre(innsending: Innsending)
+    fun lagre(
+        innsending: Innsending,
+        ctx: Transaksjonskontekst = IkkeAktiv,
+    )
 
     fun hent(innsendingId: UUID): Innsending
 

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/innsending/PostgresInnsendingRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/innsending/PostgresInnsendingRepository.kt
@@ -6,6 +6,7 @@ import kotliquery.queryOf
 import no.nav.dagpenger.saksbehandling.AdressebeskyttelseGradering
 import no.nav.dagpenger.saksbehandling.Person
 import no.nav.dagpenger.saksbehandling.db.DatabaseSession
+import no.nav.dagpenger.saksbehandling.db.Transaksjonskontekst
 import no.nav.dagpenger.saksbehandling.db.oppgave.DataNotFoundException
 import no.nav.dagpenger.saksbehandling.hendelser.Kategori
 import no.nav.dagpenger.saksbehandling.innsending.Innsending
@@ -17,8 +18,11 @@ private val sikkerlogger = KotlinLogging.logger("tjenestekall")
 class PostgresInnsendingRepository(
     private val databaseSession: DatabaseSession,
 ) : InnsendingRepository {
-    override fun lagre(innsending: Innsending) {
-        databaseSession.transaction {
+    override fun lagre(
+        innsending: Innsending,
+        ctx: Transaksjonskontekst,
+    ) {
+        databaseSession.inContext(ctx) {
             val innsendingResultat = innsending.innsendingResultat()
             session.run(
                 queryOf(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediator.kt
@@ -36,8 +36,6 @@ class InnsendingMediator(
     private val transaksjoner: Transaksjoner,
 ) {
     fun taImotInnsending(hendelse: InnsendingMottattHendelse): HåndterInnsendingResultat {
-        oppgaveMediator.taImotEttersending(hendelse)
-
         val sisteSakId = sakMediator.finnSisteDagpengeSakId(hendelse.ident)
 
         if (sisteSakId != null) {
@@ -46,6 +44,8 @@ class InnsendingMediator(
             } else {
                 taImotInnsendingPåSisteSak(hendelse, sisteSakId)
             }
+        } else {
+            oppgaveMediator.taImotEttersending(hendelse)
         }
 
         return when (sisteSakId) {
@@ -72,6 +72,7 @@ class InnsendingMediator(
                     utløstAv = HendelseBehandler.Intern.Innsending,
                 )
             transaksjoner.transaksjon { ctx ->
+                oppgaveMediator.taImotEttersending(hendelse, ctx)
                 innsendingRepository.lagre(innsending, ctx)
                 sakMediator.knyttEttersendingTilSammeSakSomSøknad(
                     behandling = behandling,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediator.kt
@@ -137,17 +137,20 @@ class InnsendingMediator(
                 it.gjelderSøknadMedId(søknadId = hendelse.søknadId)
             }?.let { innsending ->
                 innsending.automatiskFerdigstill(hendelse)
-                innsendingRepository.lagre(innsending)
-                oppgaveMediator.avbrytOppgave(
-                    hendelse =
-                        BehandlingAvbruttHendelse(
-                            behandlingId = innsending.innsendingId,
-                            behandletHendelseId = hendelse.søknadId.toString(),
-                            behandletHendelseType = "Søknad",
-                            ident = hendelse.ident,
-                            utførtAv = hendelse.utførtAv,
-                        ),
-                )
+                transaksjoner.transaksjon { ctx ->
+                    innsendingRepository.lagre(innsending, ctx)
+                    oppgaveMediator.avbrytOppgave(
+                        hendelse =
+                            BehandlingAvbruttHendelse(
+                                behandlingId = innsending.innsendingId,
+                                behandletHendelseId = hendelse.søknadId.toString(),
+                                behandletHendelseType = "Søknad",
+                                ident = hendelse.ident,
+                                utførtAv = hendelse.utførtAv,
+                            ),
+                        ctx = ctx,
+                    )
+                }
             }
     }
 

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediator.kt
@@ -7,6 +7,7 @@ import no.nav.dagpenger.saksbehandling.Oppgave
 import no.nav.dagpenger.saksbehandling.OppgaveMediator
 import no.nav.dagpenger.saksbehandling.Sak
 import no.nav.dagpenger.saksbehandling.Saksbehandler
+import no.nav.dagpenger.saksbehandling.db.Transaksjoner
 import no.nav.dagpenger.saksbehandling.db.innsending.InnsendingRepository
 import no.nav.dagpenger.saksbehandling.db.person.PersonMediator
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingAvbruttHendelse
@@ -32,6 +33,7 @@ class InnsendingMediator(
     private val personMediator: PersonMediator,
     private val innsendingRepository: InnsendingRepository,
     private val innsendingBehandler: InnsendingBehandler,
+    private val transaksjoner: Transaksjoner,
 ) {
     fun taImotInnsending(hendelse: InnsendingMottattHendelse): HåndterInnsendingResultat {
         oppgaveMediator.taImotEttersending(hendelse)
@@ -62,7 +64,6 @@ class InnsendingMediator(
         if (søknadErFerdigBehandlet(hendelse)) {
             val person = personMediator.finnEllerOpprettPerson(hendelse.ident)
             val innsending = Innsending.opprett(hendelse = hendelse) { ident -> person }
-            innsendingRepository.lagre(innsending)
             val behandling =
                 Behandling(
                     behandlingId = innsending.innsendingId,
@@ -70,11 +71,15 @@ class InnsendingMediator(
                     hendelse = hendelse,
                     utløstAv = HendelseBehandler.Intern.Innsending,
                 )
-            sakMediator.knyttEttersendingTilSammeSakSomSøknad(
-                behandling = behandling,
-                hendelse = hendelse,
-            )
-            oppgaveMediator.lagOppgaveForInnsendingBehandling(hendelse, behandling, person)
+            transaksjoner.transaksjon { ctx ->
+                innsendingRepository.lagre(innsending, ctx)
+                sakMediator.knyttEttersendingTilSammeSakSomSøknad(
+                    behandling = behandling,
+                    hendelse = hendelse,
+                    ctx = ctx,
+                )
+                oppgaveMediator.lagOppgaveForInnsendingBehandling(hendelse, behandling, person, ctx)
+            }
         }
     }
 
@@ -82,13 +87,9 @@ class InnsendingMediator(
         hendelse: InnsendingMottattHendelse,
         sisteSakId: UUID,
     ) {
+        val person = personMediator.finnEllerOpprettPerson(hendelse.ident)
         val innsending =
-            Innsending.opprett(hendelse = hendelse) { ident ->
-                personMediator.finnEllerOpprettPerson(
-                    hendelse.ident,
-                )
-            }
-        innsendingRepository.lagre(innsending)
+            Innsending.opprett(hendelse = hendelse) { ident -> person }
         val behandling =
             Behandling(
                 behandlingId = innsending.innsendingId,
@@ -97,17 +98,21 @@ class InnsendingMediator(
                 utløstAv = HendelseBehandler.Intern.Innsending,
             )
 
-        sakMediator.knyttBehandlingTilSak(
-            behandling = behandling,
-            hendelse = hendelse,
-            sakId = sisteSakId,
-        )
-
-        oppgaveMediator.lagOppgaveForInnsendingBehandling(
-            innsendingMottattHendelse = hendelse,
-            behandling = behandling,
-            person = personMediator.finnEllerOpprettPerson(hendelse.ident),
-        )
+        transaksjoner.transaksjon { ctx ->
+            innsendingRepository.lagre(innsending, ctx)
+            sakMediator.knyttBehandlingTilSak(
+                behandling = behandling,
+                hendelse = hendelse,
+                sakId = sisteSakId,
+                ctx = ctx,
+            )
+            oppgaveMediator.lagOppgaveForInnsendingBehandling(
+                innsendingMottattHendelse = hendelse,
+                behandling = behandling,
+                person = person,
+                ctx = ctx,
+            )
+        }
     }
 
     fun ferdigstill(hendelse: FerdigstillInnsendingHendelse) {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/sak/SakMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/sak/SakMediator.kt
@@ -243,6 +243,7 @@ class SakMediator(
     fun knyttEttersendingTilSammeSakSomSøknad(
         behandling: Behandling,
         hendelse: InnsendingMottattHendelse,
+        ctx: Transaksjonskontekst = IkkeAktiv,
     ) {
         requireNotNull(hendelse.søknadId) { "Ettersending må ha søknadId for å knyttes til samme sak som søknaden" }
         val sakId =
@@ -251,7 +252,7 @@ class SakMediator(
         sakRepository.finnSakHistorikk(ident = hendelse.ident).let { sakHistorikk ->
             sakHistorikk?.dagpengeSaker()?.find { sak -> sak.sakId == sakId }?.let { sak ->
                 sak.leggTilBehandling(behandling)
-                sakRepository.lagre(sakHistorikk)
+                sakRepository.lagre(sakHistorikk, ctx)
             } ?: throw IllegalStateException("Fant ingen sak for søknadId: ${hendelse.søknadId}")
         }
     }
@@ -260,6 +261,7 @@ class SakMediator(
         behandling: Behandling,
         hendelse: InnsendingMottattHendelse,
         sakId: UUID,
+        ctx: Transaksjonskontekst = IkkeAktiv,
     ) {
         sakRepository.finnSakHistorikk(ident = hendelse.ident).let { sakHistorikk ->
             sakHistorikk
@@ -270,7 +272,7 @@ class SakMediator(
                     sak.leggTilBehandling(
                         behandling = behandling,
                     )
-                    sakRepository.lagre(sakHistorikk)
+                    sakRepository.lagre(sakHistorikk, ctx)
                 } ?: throw IllegalStateException("Fant ikke sak med id: $sakId")
         }
     }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
@@ -55,6 +55,7 @@ import no.nav.dagpenger.saksbehandling.db.DBTestHelper
 import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.Postgres.withMigratedDb
 import no.nav.dagpenger.saksbehandling.db.PostgresDataSourceBuilder.dataSource
+import no.nav.dagpenger.saksbehandling.db.Transaksjoner
 import no.nav.dagpenger.saksbehandling.db.innsending.PostgresInnsendingRepository
 import no.nav.dagpenger.saksbehandling.db.oppgave.OppgaveRepository
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
@@ -1652,6 +1653,7 @@ OppgaveMediatorTest {
                     personMediator = personMediatorMock,
                     innsendingRepository = innsendingRepository,
                     innsendingBehandler = mockk(),
+                    transaksjoner = Transaksjoner(DatabaseSession(it)),
                 )
             sakMediator.merkSakenSomDpSak(
                 vedtakFattetHendelse =

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediatorTest.kt
@@ -885,6 +885,166 @@ class InnsendingMediatorTest {
         }
     }
 
+    @Test
+    fun `taImotInnsendingPåSisteSak ruller tilbake alle DB-endringer hvis oppgave-lagring feiler`() {
+        val sak =
+            Sak(
+                sakId = sakId,
+                opprettet = DBTestHelper.opprettetNå,
+                behandlinger = mutableSetOf(),
+            )
+        DBTestHelper.withMigratedDb {
+            val behandling =
+                Behandling(
+                    behandlingId = behandlingIdSøknad,
+                    opprettet = DBTestHelper.opprettetNå,
+                    hendelse =
+                        SøknadsbehandlingOpprettetHendelse(
+                            søknadId = søknadId,
+                            behandlingId = behandlingIdSøknad,
+                            ident = testPerson.ident,
+                            opprettet = DBTestHelper.opprettetNå,
+                        ),
+                    utløstAv = HendelseBehandler.DpBehandling.Søknad,
+                )
+            opprettSakMedBehandlingOgOppgave(
+                person = testPerson,
+                sak = sak,
+                behandling = behandling,
+                oppgave =
+                    TestHelper.lagOppgave(
+                        person = testPerson,
+                        behandling = behandling,
+                        tilstand = Oppgave.FerdigBehandlet,
+                    ),
+                merkSomEgenSak = true,
+            )
+            val databaseSession = DatabaseSession(it)
+            val sakMediator =
+                SakMediator(
+                    personMediator = personMediatorMock,
+                    sakRepository = PostgresSakRepository(databaseSession),
+                    rapidsConnection = mockk(relaxed = true),
+                )
+            val oppgaveMediator =
+                mockk<OppgaveMediator>().also { mock ->
+                    every { mock.lagOppgaveForInnsendingBehandling(any(), any(), any(), any()) } throws
+                        RuntimeException("DB-feil ved lagring av oppgave")
+                }
+            val innsendingRepository = PostgresInnsendingRepository(databaseSession)
+            val innsendingMediator =
+                InnsendingMediator(
+                    sakMediator = sakMediator,
+                    oppgaveMediator = oppgaveMediator,
+                    personMediator = personMediatorMock,
+                    innsendingRepository = innsendingRepository,
+                    innsendingBehandler = mockk(),
+                    transaksjoner = Transaksjoner(databaseSession),
+                )
+
+            runCatching {
+                innsendingMediator.taImotInnsending(
+                    InnsendingMottattHendelse(
+                        ident = testPerson.ident,
+                        journalpostId = journalpostId,
+                        registrertTidspunkt = registrertTidspunkt,
+                        søknadId = null,
+                        skjemaKode = skjemaKode,
+                        kategori = Kategori.KLAGE,
+                    ),
+                )
+            }.isFailure shouldBe true
+
+            // Verifiser at innsending IKKE ble lagret (rollback)
+            innsendingRepository.finnInnsendingerForPerson(ident = testPerson.ident) shouldBe emptyList()
+
+            // Verifiser at saken fortsatt bare har 1 behandling (rollback)
+            val sakHistorikk = sakMediator.hentSakHistorikk(ident = testPerson.ident)
+            sakHistorikk.finnSak { it.sakId == sak.sakId }!!.behandlinger().size shouldBe 1
+        }
+    }
+
+    @Test
+    fun `taImotEttersendingTilSøknad ruller tilbake alle DB-endringer hvis oppgave-lagring feiler`() {
+        val sak =
+            Sak(
+                sakId = sakId,
+                opprettet = DBTestHelper.opprettetNå,
+                behandlinger = mutableSetOf(),
+            )
+        DBTestHelper.withMigratedDb {
+            val behandling =
+                Behandling(
+                    behandlingId = behandlingIdSøknad,
+                    opprettet = DBTestHelper.opprettetNå,
+                    hendelse =
+                        SøknadsbehandlingOpprettetHendelse(
+                            søknadId = søknadId,
+                            behandlingId = behandlingIdSøknad,
+                            ident = testPerson.ident,
+                            opprettet = DBTestHelper.opprettetNå,
+                        ),
+                    utløstAv = HendelseBehandler.DpBehandling.Søknad,
+                )
+            opprettSakMedBehandlingOgOppgave(
+                person = testPerson,
+                sak = sak,
+                behandling = behandling,
+                oppgave =
+                    TestHelper.lagOppgave(
+                        person = testPerson,
+                        behandling = behandling,
+                        tilstand = Oppgave.FerdigBehandlet,
+                    ),
+                merkSomEgenSak = true,
+            )
+            val databaseSession = DatabaseSession(it)
+            val sakMediator =
+                SakMediator(
+                    personMediator = personMediatorMock,
+                    sakRepository = PostgresSakRepository(databaseSession),
+                    rapidsConnection = mockk(relaxed = true),
+                )
+            val oppgaveMediator =
+                mockk<OppgaveMediator>().also { mock ->
+                    every { mock.oppgaveTilstandForSøknad(søknadId, any()) } returns FERDIG_BEHANDLET
+                    every { mock.taImotEttersending(any(), any()) } just Runs
+                    every { mock.lagOppgaveForInnsendingBehandling(any(), any(), any(), any()) } throws
+                        RuntimeException("DB-feil ved lagring av oppgave")
+                }
+            val innsendingRepository = PostgresInnsendingRepository(databaseSession)
+            val innsendingMediator =
+                InnsendingMediator(
+                    sakMediator = sakMediator,
+                    oppgaveMediator = oppgaveMediator,
+                    personMediator = personMediatorMock,
+                    innsendingRepository = innsendingRepository,
+                    innsendingBehandler = mockk(),
+                    transaksjoner = Transaksjoner(databaseSession),
+                )
+
+            runCatching {
+                innsendingMediator.taImotInnsending(
+                    InnsendingMottattHendelse(
+                        ident = testPerson.ident,
+                        journalpostId = journalpostId,
+                        registrertTidspunkt = registrertTidspunkt,
+                        søknadId = søknadId,
+                        skjemaKode = skjemaKode,
+                        kategori = Kategori.ETTERSENDING,
+                    ),
+                )
+            }.isFailure shouldBe true
+
+            // Verifiser at innsending IKKE ble lagret (rollback)
+            innsendingRepository.finnInnsendingerForPerson(ident = testPerson.ident) shouldBe emptyList()
+
+            // Verifiser at saken fortsatt bare har 1 behandling (rollback)
+            val sakHistorikk = sakMediator.hentSakHistorikk(ident = testPerson.ident)
+            sakHistorikk.finnSak { it.sakId == sak.sakId }!!.behandlinger().size shouldBe 1
+        }
+    }
+
     private fun OppgaveMediator.finnAlleOppgaverFor(ident: String): List<Oppgave> =
         this
             .søk(

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediatorTest.kt
@@ -24,6 +24,7 @@ import no.nav.dagpenger.saksbehandling.UtsendingSak
 import no.nav.dagpenger.saksbehandling.behandling.BehandlingKlient
 import no.nav.dagpenger.saksbehandling.db.DBTestHelper
 import no.nav.dagpenger.saksbehandling.db.DatabaseSession
+import no.nav.dagpenger.saksbehandling.db.Transaksjoner
 import no.nav.dagpenger.saksbehandling.db.innsending.InnsendingRepository
 import no.nav.dagpenger.saksbehandling.db.innsending.PostgresInnsendingRepository
 import no.nav.dagpenger.saksbehandling.db.oppgave.Periode
@@ -175,6 +176,7 @@ class InnsendingMediatorTest {
                                     utførtAv = saksbehandler,
                                 )
                         },
+                    transaksjoner = Transaksjoner(DatabaseSession(it)),
                 )
 
             sakMediator.merkSakenSomDpSak(
@@ -243,6 +245,7 @@ class InnsendingMediatorTest {
                                 utførtAv = saksbehandler,
                             )
                     },
+                transaksjoner = Transaksjoner(DatabaseSession(it)),
             ).ferdigstill(
                 hendelse =
                     FerdigstillInnsendingHendelse(
@@ -320,6 +323,7 @@ class InnsendingMediatorTest {
                     personMediator = personMediatorMock,
                     innsendingRepository = innsendingRepository,
                     innsendingBehandler = mockk(),
+                    transaksjoner = Transaksjoner(DatabaseSession(it)),
                 )
 
             val innsendingMottattHendelse =
@@ -407,6 +411,7 @@ class InnsendingMediatorTest {
                     personMediator = personMediatorMock,
                     innsendingRepository = innsendingRepository,
                     innsendingBehandler = mockk(),
+                    transaksjoner = mockk(relaxed = true),
                 )
 
             val innsendingMottattHendelse =
@@ -423,13 +428,13 @@ class InnsendingMediatorTest {
                 innsendingMottattHendelse,
             )
             verify(exactly = 0) {
-                innsendingRepository.lagre(any())
+                innsendingRepository.lagre(any(), any())
             }
             verify(exactly = 0) {
-                sakMediatorMock.knyttBehandlingTilSak(any(), any(), any())
+                sakMediatorMock.knyttBehandlingTilSak(any(), any(), any(), any())
             }
             verify(exactly = 0) {
-                oppgaveMediatorMock.lagOppgaveForInnsendingBehandling(any(), any(), any())
+                oppgaveMediatorMock.lagOppgaveForInnsendingBehandling(any(), any(), any(), any())
             }
         }
     }
@@ -445,6 +450,7 @@ class InnsendingMediatorTest {
                 personMediator = personMediatorMock,
                 innsendingRepository = innsendingRepository,
                 innsendingBehandler = innsendingBehandler,
+                transaksjoner = mockk(relaxed = true),
             )
 
         val innsendingMottattHendelse =
@@ -466,16 +472,16 @@ class InnsendingMediatorTest {
         }
 
         verify(exactly = 0) {
-            innsendingRepository.lagre(any())
+            innsendingRepository.lagre(any(), any())
         }
         verify(exactly = 0) {
             innsendingBehandler.utførAksjon(any(), any())
         }
         verify(exactly = 0) {
-            sakMediatorMock.knyttBehandlingTilSak(any(), any(), any())
+            sakMediatorMock.knyttBehandlingTilSak(any(), any(), any(), any())
         }
         verify(exactly = 0) {
-            oppgaveMediatorMock.lagOppgaveForInnsendingBehandling(any(), any(), any())
+            oppgaveMediatorMock.lagOppgaveForInnsendingBehandling(any(), any(), any(), any())
         }
     }
 
@@ -536,6 +542,7 @@ class InnsendingMediatorTest {
                     personMediator = personMediatorMock,
                     innsendingRepository = innsendingRepository,
                     innsendingBehandler = mockk(),
+                    transaksjoner = Transaksjoner(DatabaseSession(it)),
                 )
             val innsendingMottattHendelse =
                 InnsendingMottattHendelse(
@@ -658,6 +665,7 @@ class InnsendingMediatorTest {
                             behandlingKlient = behandlingKlientMock,
                             oppfølgingMediator = mockk(),
                         ),
+                    transaksjoner = Transaksjoner(DatabaseSession(it)),
                 )
             val innsendingMottattHendelse =
                 InnsendingMottattHendelse(
@@ -803,6 +811,7 @@ class InnsendingMediatorTest {
                             behandlingKlient = behandlingKlientMock,
                             oppfølgingMediator = mockk(),
                         ),
+                    transaksjoner = Transaksjoner(DatabaseSession(it)),
                 )
             val innsendingMottattHendelse =
                 InnsendingMottattHendelse(

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/innsending/InnsendingMediatorTest.kt
@@ -2,6 +2,7 @@ package no.nav.dagpenger.saksbehandling.innsending
 
 import io.kotest.assertions.fail
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.every
@@ -1042,6 +1043,114 @@ class InnsendingMediatorTest {
             // Verifiser at saken fortsatt bare har 1 behandling (rollback)
             val sakHistorikk = sakMediator.hentSakHistorikk(ident = testPerson.ident)
             sakHistorikk.finnSak { it.sakId == sak.sakId }!!.behandlinger().size shouldBe 1
+        }
+    }
+
+    @Test
+    fun `automatiskFerdigstill ruller tilbake innsending hvis avbryt av oppgave feiler`() {
+        val søknadIdGjenopptak = UUIDv7.ny()
+        val sak =
+            Sak(
+                sakId = UUIDv7.ny(),
+                opprettet = DBTestHelper.opprettetNå,
+                behandlinger = mutableSetOf(),
+            )
+        DBTestHelper.withMigratedDb {
+            val behandling =
+                Behandling(
+                    behandlingId = behandlingIdSøknad,
+                    opprettet = DBTestHelper.opprettetNå,
+                    hendelse =
+                        SøknadsbehandlingOpprettetHendelse(
+                            søknadId = søknadId,
+                            behandlingId = behandlingIdSøknad,
+                            ident = testPerson.ident,
+                            opprettet = DBTestHelper.opprettetNå,
+                        ),
+                    utløstAv = HendelseBehandler.DpBehandling.Søknad,
+                )
+            opprettSakMedBehandlingOgOppgave(
+                person = testPerson,
+                sak = sak,
+                behandling = behandling,
+                oppgave =
+                    TestHelper.lagOppgave(
+                        person = testPerson,
+                        behandling = behandling,
+                        tilstand = Oppgave.FerdigBehandlet,
+                    ),
+                merkSomEgenSak = true,
+            )
+            val databaseSession = DatabaseSession(it)
+            val sakMediator =
+                SakMediator(
+                    personMediator = personMediatorMock,
+                    sakRepository = PostgresSakRepository(databaseSession),
+                    rapidsConnection = mockk(relaxed = true),
+                )
+            val innsendingRepository = PostgresInnsendingRepository(databaseSession)
+
+            // Oppretter innsending med ekte oppgaveMediator
+            val ekteOppgaveMediator =
+                OppgaveMediator(
+                    oppgaveRepository = PostgresOppgaveRepository(databaseSession),
+                    behandlingKlient = mockk(),
+                    utsendingMediator = mockk(),
+                    sakMediator = sakMediator,
+                    rapidsConnection = mockk(relaxed = true),
+                )
+            InnsendingMediator(
+                sakMediator = sakMediator,
+                oppgaveMediator = ekteOppgaveMediator,
+                personMediator = personMediatorMock,
+                innsendingRepository = innsendingRepository,
+                innsendingBehandler = mockk(),
+                transaksjoner = Transaksjoner(databaseSession),
+            ).taImotInnsending(
+                InnsendingMottattHendelse(
+                    ident = testPerson.ident,
+                    journalpostId = journalpostId,
+                    registrertTidspunkt = registrertTidspunkt,
+                    søknadId = søknadIdGjenopptak,
+                    skjemaKode = skjemaKode,
+                    kategori = Kategori.GJENOPPTAK,
+                ),
+            )
+            val tilstandFør =
+                innsendingRepository.finnInnsendingerForPerson(ident = testPerson.ident).single().tilstand()
+
+            // Ferdigstill automatisk med oppgaveMediator som feiler på avbryt
+            val feilendeOppgaveMediator =
+                mockk<OppgaveMediator>().also { mock ->
+                    every { mock.avbrytOppgave(any(), any()) } throws
+                        RuntimeException("DB-feil ved avbryt av oppgave")
+                }
+            val innsendingMediator =
+                InnsendingMediator(
+                    sakMediator = sakMediator,
+                    oppgaveMediator = feilendeOppgaveMediator,
+                    personMediator = personMediatorMock,
+                    innsendingRepository = innsendingRepository,
+                    innsendingBehandler = mockk(),
+                    transaksjoner = Transaksjoner(databaseSession),
+                )
+
+            runCatching {
+                innsendingMediator.automatiskFerdigstill(
+                    hendelse =
+                        BehandlingOpprettetForSøknadHendelse(
+                            ident = testPerson.ident,
+                            søknadId = søknadIdGjenopptak,
+                            behandlingId = behandlingIdSøknad,
+                        ),
+                )
+            }.isFailure shouldBe true
+
+            // Verifiser at innsending IKKE ble ferdigstilt (rollback)
+            val innsendingEtter =
+                innsendingRepository.finnInnsendingerForPerson(ident = testPerson.ident).single()
+            innsendingEtter.tilstand() shouldBe tilstandFør
+            innsendingEtter.tilstand() shouldNotBe "FERDIGSTILT"
         }
     }
 


### PR DESCRIPTION
## Endringer

Wrapper DB-operasjonene i `taImotEttersendingTilSøknad` og `taImotInnsendingPåSisteSak` i en felles transaksjon slik at innsending, sak-kobling og oppgave enten alle lagres eller alle rulles tilbake.

### Detaljer

- Legger til `ctx: Transaksjonskontekst`-param på:
  - `SakMediator.knyttEttersendingTilSammeSakSomSøknad`
  - `SakMediator.knyttBehandlingTilSak`
  - `OppgaveMediator.lagOppgaveForInnsendingBehandling`
  - `InnsendingRepository.lagre`
- Injiserer `Transaksjoner` i `InnsendingMediator`
- Flytter person-lookup (HTTP) utenfor transaksjon
- Fikser duplikat `finnEllerOpprettPerson`-kall i `taImotInnsendingPåSisteSak`

### Mønster

Samme mønster som PR #387 (OppfølgingMediator):
- HTTP-kall utenfor tx
- Alle DB-skrivinger innenfor én atomisk transaksjon
- `ctx`-param med default `IkkeAktiv` for bakoverkompatibilitet

### Stacked på
- #387 (uow-oppfolging-mediator)
- #386 (uow-klage-mediator)