### PR TITLE
refactor/oppfolging paa vent

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -45,7 +45,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     needs: [ build ]
-#    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: dev-gcp
     permissions:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -45,7 +45,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     needs: [ build ]
-    if: github.ref == 'refs/heads/main'
+#    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: dev-gcp
     permissions:

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -146,5 +146,5 @@ spec:
             value: "write,ddl,role"
           - name: pgaudit.log_parameter
             value: "on"
-strategy:
-  type: Recreate
+  strategy:
+    type: Recreate

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -146,3 +146,5 @@ spec:
             value: "write,ddl,role"
           - name: pgaudit.log_parameter
             value: "on"
+strategy:
+  type: Recreate

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/MeldingOmVedtakMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/MeldingOmVedtakMediator.kt
@@ -22,7 +22,7 @@ class MeldingOmVedtakMediator(
     ): String {
         val oppgave = oppgaveMediator.hentOppgave(oppgaveId, saksbehandler)
         val sisteSaksbehandler =
-            oppgave.sisteSaksbehandler()
+            oppgave.sisteSaksbehandlerIdent
                 ?: throw RuntimeException("Oppgave ${oppgave.oppgaveId} har ingen saksbehandler")
 
         return coroutineScope {
@@ -30,7 +30,7 @@ class MeldingOmVedtakMediator(
             val sisteSaksbehandler = async(Dispatchers.IO) { oppslag.hentBehandler(sisteSaksbehandler) }
             val beslutterDeferred =
                 async(Dispatchers.IO) {
-                    oppgave.sisteBeslutter()?.let { oppslag.hentBehandler(it) }
+                    oppgave.sisteBeslutterIdent?.let { oppslag.hentBehandler(it) }
                 }
             val sakIdDeferred =
                 async(Dispatchers.IO) {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveDTOMapper.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveDTOMapper.kt
@@ -109,11 +109,11 @@ internal class OppgaveDTOMapper(
             val person = async { oppslag.hentPerson(oppgave.personIdent()) }
             val journalpostIder = async { oppslag.hentJournalpostIder(oppgave) }
             val sisteSaksbehandlerDTO =
-                oppgave.sisteSaksbehandler()?.let { saksbehandlerIdent ->
+                oppgave.sisteSaksbehandlerIdent?.let { saksbehandlerIdent ->
                     async { oppslag.hentBehandler(saksbehandlerIdent) }
                 }
             val sisteBeslutterDTO =
-                oppgave.sisteBeslutter()?.let { beslutterIdent ->
+                oppgave.sisteBeslutterIdent?.let { beslutterIdent ->
                     async { oppslag.hentBehandler(beslutterIdent) }
                 }
 

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
@@ -301,7 +301,7 @@ class PostgresOppgaveRepository(
                 Søkefilter(
                     tilstander = setOf(tilstand),
                     periode = UBEGRENSET_PERIODE,
-                    saksbehandlerIdent = null,
+                    behandlerIdent = null,
                 ),
         ).oppgaver
 
@@ -469,7 +469,7 @@ class PostgresOppgaveRepository(
                 Søkefilter(
                     periode = UBEGRENSET_PERIODE,
                     tilstander = Type.søkbareTilstander,
-                    saksbehandlerIdent = null,
+                    behandlerIdent = null,
                     personIdent = ident,
                     paginering = antall?.let { Søkefilter.Paginering(antallOppgaver = it, side = 0) },
                     sortering = Søkefilter.Sortering.DESC,
@@ -498,8 +498,8 @@ class PostgresOppgaveRepository(
 
             val saksbehandlerClause =
                 when {
-                    søkeFilter.utenSaksbehandler -> " AND oppg.behandler_ident IS NULL "
-                    søkeFilter.saksbehandlerIdent != null ->
+                    søkeFilter.utenBehandler -> " AND oppg.behandler_ident IS NULL "
+                    søkeFilter.behandlerIdent != null ->
                         "AND ( oppg.siste_saksbehandler_ident = :behandler_ident " +
                             "OR oppg.siste_beslutter_ident = :behandler_ident ) "
                     else -> ""
@@ -653,7 +653,7 @@ class PostgresOppgaveRepository(
                 mapOf(
                     "fom" to søkeFilter.periode.fom,
                     "tom_pluss_1_dag" to søkeFilter.periode.tom.plusDays(1),
-                    "behandler_ident" to søkeFilter.saksbehandlerIdent,
+                    "behandler_ident" to søkeFilter.behandlerIdent,
                     "person_ident" to søkeFilter.personIdent,
                     "oppgave_id" to søkeFilter.oppgaveId,
                     "behandling_id" to søkeFilter.behandlingId,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
@@ -143,7 +143,7 @@ class PostgresOppgaveRepository(
                     ""
                 }
 
-            // Oppdaterer saksbehandler_ident og tilstand avhengig av om oppgaven som hentes som neste er klar til
+            // Oppdaterer behandler_ident og tilstand avhengig av om oppgaven som hentes som neste er klar til
             // behandling eller klar til kontroll. Pålogget saksbehandler må ha rettighet til aktuell oppgave.
             // Det sjekkes derfor mot tilganger i utplukket.
 
@@ -161,7 +161,7 @@ class PostgresOppgaveRepository(
                     JOIN     behandling_v1 beha ON beha.id = oppg.behandling_id
                     JOIN     person_v1     pers ON pers.id = beha.person_id
                     WHERE    oppg.tilstand = 'KLAR_TIL_BEHANDLING'
-                    AND      oppg.saksbehandler_ident IS NULL
+                    AND      oppg.behandler_ident IS NULL
                     AND      oppg.opprettet >= :fom
                     AND      oppg.opprettet <  :tom_pluss_1_dag
                     AND    ( NOT pers.skjermes_som_egne_ansatte
@@ -200,7 +200,7 @@ class PostgresOppgaveRepository(
                         )
                     WHERE   :har_beslutter_rolle
                     AND     oppg.tilstand = 'KLAR_TIL_KONTROLL'
-                    AND     oppg.saksbehandler_ident IS NULL
+                    AND     oppg.behandler_ident IS NULL
                     AND     oppg.opprettet >= :fom
                     AND     oppg.opprettet <  :tom_pluss_1_dag
                     AND   ( NOT pers.skjermes_som_egne_ansatte
@@ -231,11 +231,17 @@ class PostgresOppgaveRepository(
             val updateNesteOppgave =
                 """
                 UPDATE oppgave_v1 oppu
-                SET    saksbehandler_ident = :saksbehandler_ident
-                     , tilstand            = CASE oppu.tilstand
-                                                     WHEN 'KLAR_TIL_BEHANDLING' THEN 'UNDER_BEHANDLING'
-                                                     WHEN 'KLAR_TIL_KONTROLL' THEN 'UNDER_KONTROLL'
-                                                  END
+                SET    behandler_ident           = :behandler_ident
+                     , siste_saksbehandler_ident = CASE oppu.tilstand
+                                                       WHEN 'KLAR_TIL_BEHANDLING' THEN :behandler_ident
+                                                   END
+                     , siste_beslutter_ident     = CASE oppu.tilstand
+                                                       WHEN 'KLAR_TIL_KONTROLL' THEN :behandler_ident
+                                                   END
+                     , tilstand                  = CASE oppu.tilstand
+                                                       WHEN 'KLAR_TIL_BEHANDLING' THEN 'UNDER_BEHANDLING'
+                                                       WHEN 'KLAR_TIL_KONTROLL' THEN 'UNDER_KONTROLL'
+                                                   END
                 FROM  neste_oppgave next
                 WHERE next.id = oppu.id
                 RETURNING *
@@ -256,7 +262,7 @@ class PostgresOppgaveRepository(
                         statement = statement,
                         paramMap =
                             mapOf(
-                                "saksbehandler_ident" to nesteOppgaveHendelse.ansvarligIdent,
+                                "behandler_ident" to nesteOppgaveHendelse.ansvarligIdent,
                                 "fom" to filter.periode.fom,
                                 "tom_pluss_1_dag" to filter.periode.tom.plusDays(1),
                                 "har_tilgang_til_egne_ansatte" to filter.egneAnsatteTilgang,
@@ -492,8 +498,8 @@ class PostgresOppgaveRepository(
 
             val saksbehandlerClause =
                 when {
-                    søkeFilter.utenSaksbehandler -> " AND oppg.saksbehandler_ident IS NULL "
-                    søkeFilter.saksbehandlerIdent != null -> "AND oppg.saksbehandler_ident = :saksbehandler_ident "
+                    søkeFilter.utenSaksbehandler -> " AND oppg.behandler_ident IS NULL "
+                    søkeFilter.saksbehandlerIdent != null -> "AND oppg.behandler_ident = :behandler_ident "
                     else -> ""
                 }
 
@@ -587,7 +593,9 @@ class PostgresOppgaveRepository(
                         oppg.tilstand, 
                         oppg.opprettet AS oppgave_opprettet, 
                         oppg.behandling_id, 
-                        oppg.saksbehandler_ident,
+                        oppg.behandler_ident,
+                        oppg.siste_saksbehandler_ident,
+                        oppg.siste_beslutter_ident,
                         oppg.utsatt_til,
                         oppg.melding_om_vedtak_kilde,
                         oppg.kontrollert_brev,
@@ -643,7 +651,7 @@ class PostgresOppgaveRepository(
                 mapOf(
                     "fom" to søkeFilter.periode.fom,
                     "tom_pluss_1_dag" to søkeFilter.periode.tom.plusDays(1),
-                    "saksbehandler_ident" to søkeFilter.saksbehandlerIdent,
+                    "behandler_ident" to søkeFilter.saksbehandlerIdent,
                     "person_ident" to søkeFilter.personIdent,
                     "oppgave_id" to søkeFilter.oppgaveId,
                     "behandling_id" to søkeFilter.behandlingId,
@@ -711,7 +719,9 @@ class PostgresOppgaveRepository(
 
         return Oppgave.rehydrer(
             oppgaveId = oppgaveId,
-            behandlerIdent = this.stringOrNull("saksbehandler_ident"),
+            behandlerIdent = this.stringOrNull("behandler_ident"),
+            sisteSaksbehandlerIdent = this.stringOrNull("siste_saksbehandler_ident"),
+            sisteBeslutterIdent = this.stringOrNull("siste_beslutter_ident"),
             opprettet = this.localDateTime("oppgave_opprettet"),
             emneknagger = hentEmneknaggerForOppgave(oppgaveId, databaseSession),
             tilstand = tilstand,
@@ -830,7 +840,9 @@ private fun PostgresUnitOfWork.lagre(oppgave: Oppgave) {
                         behandling_id,
                         tilstand,
                         opprettet,
-                        saksbehandler_ident,
+                        behandler_ident,
+                        siste_saksbehandler_ident,
+                        siste_beslutter_ident,
                         utsatt_til,
                         melding_om_vedtak_kilde,
                         kontrollert_brev
@@ -841,14 +853,18 @@ private fun PostgresUnitOfWork.lagre(oppgave: Oppgave) {
                         :behandling_id,
                         :tilstand,
                         :opprettet,
-                        :saksbehandler_ident,
+                        :behandler_ident,
+                        :siste_saksbehandler_ident,
+                        :siste_beslutter_ident,
                         :utsatt_til,
                         :melding_om_vedtak_kilde,
                         :kontrollert_brev
                     ) 
                 ON CONFLICT(id) DO UPDATE SET
                  tilstand = :tilstand,
-                 saksbehandler_ident = :saksbehandler_ident,
+                 behandler_ident = :behandler_ident,
+                 siste_saksbehandler_ident = :siste_saksbehandler_ident,
+                 siste_beslutter_ident = :siste_beslutter_ident,
                  utsatt_til = :utsatt_til,
                  melding_om_vedtak_kilde = :melding_om_vedtak_kilde,
                  kontrollert_brev = :kontrollert_brev
@@ -859,7 +875,9 @@ private fun PostgresUnitOfWork.lagre(oppgave: Oppgave) {
                     "behandling_id" to oppgave.behandling.behandlingId,
                     "tilstand" to oppgave.tilstand().type.name,
                     "opprettet" to oppgave.opprettet,
-                    "saksbehandler_ident" to oppgave.behandlerIdent,
+                    "behandler_ident" to oppgave.behandlerIdent,
+                    "siste_saksbehandler_ident" to oppgave.sisteSaksbehandlerIdent,
+                    "siste_beslutter_ident" to oppgave.sisteBeslutterIdent,
                     "utsatt_til" to oppgave.utsattTil(),
                     "melding_om_vedtak_kilde" to oppgave.meldingOmVedtakKilde().name,
                     "kontrollert_brev" to oppgave.kontrollertBrev().name,
@@ -1014,7 +1032,7 @@ private fun Søkefilter.Sorteringsfelt.orderByClause(sortering: Søkefilter.Sort
             """ ORDER BY oppg.tilstand ${sortering.name}, oppg.id ${sortering.name} """
 
         Søkefilter.Sorteringsfelt.SAKSBEHANDLER ->
-            """ ORDER BY oppg.saksbehandler_ident ${sortering.name} NULLS LAST, oppg.id ${sortering.name} """
+            """ ORDER BY oppg.behandler_ident ${sortering.name} NULLS LAST, oppg.id ${sortering.name} """
 
         Søkefilter.Sorteringsfelt.UTSATT_TIL ->
             """ ORDER BY oppg.utsatt_til ${sortering.name} NULLS LAST, oppg.id ${sortering.name} """

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepository.kt
@@ -499,7 +499,9 @@ class PostgresOppgaveRepository(
             val saksbehandlerClause =
                 when {
                     søkeFilter.utenSaksbehandler -> " AND oppg.behandler_ident IS NULL "
-                    søkeFilter.saksbehandlerIdent != null -> "AND oppg.behandler_ident = :behandler_ident "
+                    søkeFilter.saksbehandlerIdent != null ->
+                        "AND ( oppg.siste_saksbehandler_ident = :behandler_ident " +
+                            "OR oppg.siste_beslutter_ident = :behandler_ident ) "
                     else -> ""
                 }
 

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/Søkefilter.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/Søkefilter.kt
@@ -19,8 +19,8 @@ import java.util.UUID
 data class Søkefilter(
     val periode: Periode,
     val tilstander: Set<Tilstand.Type>,
-    val saksbehandlerIdent: String? = null,
-    val utenSaksbehandler: Boolean = false,
+    val behandlerIdent: String? = null,
+    val utenBehandler: Boolean = false,
     val harDpSak: Boolean = false,
     val personIdent: String? = null,
     val oppgaveId: UUID? = null,
@@ -90,8 +90,8 @@ data class Søkefilter(
 
             val tilstander = builder.tilstander() ?: søkbareTilstander
             val mineOppgaver = builder.mineOppgaver() ?: false
-            val eksplisittSaksbehandlerIdent = builder.saksbehandlerIdent()
-            val utenSaksbehandler = builder.utenSaksbehandler()
+            val eksplisittSaksbehandlerIdent = builder.behandlerIdent()
+            val utenBehandler = builder.utenBehandler()
             val utløstAvTyper = builder.utløstAvTyper() ?: emptySet()
             val paginering = builder.paginering()
             val sorteringsfelt = builder.sorteringsfelt()
@@ -100,14 +100,14 @@ data class Søkefilter(
             return Søkefilter(
                 periode = Periode.fra(queryParameters),
                 tilstander = tilstander,
-                saksbehandlerIdent =
+                behandlerIdent =
                     when {
-                        utenSaksbehandler -> null
+                        utenBehandler -> null
                         eksplisittSaksbehandlerIdent != null -> eksplisittSaksbehandlerIdent
                         mineOppgaver -> saksbehandlerIdent
                         else -> null
                     },
-                utenSaksbehandler = utenSaksbehandler,
+                utenBehandler = utenBehandler,
                 harDpSak = builder.harDpSak(),
                 emneknaggGruppertPerKategori = builder.emneknaggGruppertPerKategori(),
                 ekskluderEmneknagger = builder.ekskluderEmneknagger(),
@@ -232,9 +232,9 @@ class FilterBuilder {
 
     fun mineOppgaver(): Boolean? = stringValues["mineOppgaver"]?.toBoolean()
 
-    fun saksbehandlerIdent(): String? = stringValues["saksbehandlerIdent"]?.trim()?.takeIf { it.isNotBlank() }
+    fun behandlerIdent(): String? = stringValues["saksbehandlerIdent"]?.trim()?.takeIf { it.isNotBlank() }
 
-    fun utenSaksbehandler(): Boolean = stringValues["utenSaksbehandler"]?.toBoolean() ?: false
+    fun utenBehandler(): Boolean = stringValues["utenSaksbehandler"]?.toBoolean() ?: false
 
     fun harDpSak(): Boolean = stringValues["harDpSak"]?.toBoolean() ?: false
 

--- a/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/utsending/UtsendingMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/saksbehandling/utsending/UtsendingMediator.kt
@@ -243,13 +243,13 @@ class UtsendingMediator(
                 val person = async(Dispatchers.IO) { oppslag.hentPerson(ident) }
                 val saksbehandler =
                     async(Dispatchers.IO) {
-                        oppgave.sisteSaksbehandler()?.let { saksbehandlerIdent ->
+                        oppgave.sisteSaksbehandlerIdent?.let { saksbehandlerIdent ->
                             oppslag.hentBehandler(saksbehandlerIdent)
                         } ?: throw RuntimeException("Fant ikke saksbehandler for oppgave ${oppgave.oppgaveId}")
                     }
                 val beslutter =
                     async(Dispatchers.IO) {
-                        oppgave.sisteBeslutter()?.let { beslutterIdent ->
+                        oppgave.sisteBeslutterIdent?.let { beslutterIdent ->
                             oppslag.hentBehandler(beslutterIdent)
                         }
                     }

--- a/mediator/src/main/resources/db/migration/common/V130__ALTER_TABLE_OPPGAVE_ADD_SISTE_SAKSBEHANDLER_OG_BESLUTTER.sql
+++ b/mediator/src/main/resources/db/migration/common/V130__ALTER_TABLE_OPPGAVE_ADD_SISTE_SAKSBEHANDLER_OG_BESLUTTER.sql
@@ -1,16 +1,30 @@
 ALTER TABLE oppgave_v1 DISABLE TRIGGER oppdater_endret_tidspunkt
 ;
 ALTER TABLE oppgave_v1
-ADD COLUMN siste_saksbehandler_ident TEXT,
-ADD COLUMN siste_beslutter_ident TEXT
+ADD COLUMN IF NOT EXISTS siste_saksbehandler_ident TEXT,
+ADD COLUMN IF NOT EXISTS siste_beslutter_ident TEXT
 ;
-ALTER TABLE oppgave_v1
-RENAME COLUMN saksbehandler_ident TO behandler_ident
+CREATE INDEX IF NOT EXISTS oppgave_siste_saksbehandler_ident_index ON oppgave_v1 (siste_saksbehandler_ident)
 ;
+CREATE INDEX IF NOT EXISTS oppgave_siste_beslutter_ident_index ON oppgave_v1 (siste_beslutter_ident)
+;
+DO $$
+    BEGIN
+        IF EXISTS (
+            SELECT  1
+            FROM    information_schema.columns
+            WHERE   table_schema = 'public'
+            AND     table_name   = 'oppgave_v1'
+            AND     column_name  = 'saksbehandler_ident'
+        ) THEN
+            ALTER TABLE oppgave_v1 RENAME COLUMN saksbehandler_ident TO behandler_ident;
+        END IF;
+    END $$;
+
 WITH oppgave AS
 (
-    SELECT    oppg.id
-            , logg.hendelse -> 'utførtAv' ->> 'navIdent'::TEXT AS siste_saksbehandler_ident
+    SELECT  oppg.id
+          , logg.hendelse -> 'utførtAv' ->> 'navIdent'::TEXT AS siste_saksbehandler_ident
     FROM    oppgave_v1 oppg
     JOIN    oppgave_tilstand_logg_v1 logg
         ON  logg.oppgave_id = oppg.id
@@ -27,7 +41,9 @@ WITH oppgave AS
                                                     AND     logg3.hendelse -> 'utførtAv' ->> 'navIdent'::TEXT IS NOT NULL
                                                   )
                       )
-)
+    WHERE   oppg.tilstand != 'KLAR_TIL_BEHANDLING'
+    AND     oppg.siste_saksbehandler_ident IS NULL
+    )
 UPDATE  oppgave_v1 uopp
 SET     siste_saksbehandler_ident = oppgave.siste_saksbehandler_ident
 FROM    oppgave
@@ -53,6 +69,8 @@ WITH oppgave AS
                                                     AND     logg3.hendelse -> 'utførtAv' ->> 'navIdent'::TEXT IS NOT NULL
                                                   )
                       )
+    WHERE   oppg.tilstand != 'KLAR_TIL_KONTROLL'
+    AND     oppg.siste_beslutter_ident IS NULL
 )
 UPDATE  oppgave_v1 uopp
 SET     siste_beslutter_ident = oppgave.siste_beslutter_ident

--- a/mediator/src/main/resources/db/migration/common/V130__ALTER_TABLE_OPPGAVE_ADD_SISTE_SAKSBEHANDLER_OG_BESLUTTER.sql
+++ b/mediator/src/main/resources/db/migration/common/V130__ALTER_TABLE_OPPGAVE_ADD_SISTE_SAKSBEHANDLER_OG_BESLUTTER.sql
@@ -1,7 +1,63 @@
+ALTER TABLE oppgave_v1 DISABLE TRIGGER oppdater_endret_tidspunkt
+;
 ALTER TABLE oppgave_v1
 ADD COLUMN siste_saksbehandler_ident TEXT,
 ADD COLUMN siste_beslutter_ident TEXT
 ;
 ALTER TABLE oppgave_v1
 RENAME COLUMN saksbehandler_ident TO behandler_ident
+;
+WITH oppgave AS
+(
+    SELECT    oppg.id
+            , logg.hendelse -> 'utførtAv' ->> 'navIdent'::TEXT AS siste_saksbehandler_ident
+    FROM    oppgave_v1 oppg
+    JOIN    oppgave_tilstand_logg_v1 logg
+        ON  logg.oppgave_id = oppg.id
+        AND logg.id = ( SELECT  logg2.id
+                        FROM    oppgave_tilstand_logg_v1 logg2
+                        WHERE   logg2.oppgave_id = oppg.id
+                        AND     logg2.tilstand IN('UNDER_BEHANDLING','PAA_VENT')
+                        AND     logg2.hendelse_type IN ('NesteOppgaveHendelse', 'SettOppgaveAnsvarHendelse','OpprettOppfølgingHendelse')
+                        AND     logg2.tidspunkt = ( SELECT  MAX(logg3.tidspunkt)
+                                                    FROM    oppgave_tilstand_logg_v1 logg3
+                                                    WHERE   logg3.oppgave_id = oppg.id
+                                                    AND     logg3.tilstand IN('UNDER_BEHANDLING','PAA_VENT')
+                                                    AND     logg3.hendelse_type IN ('SettOppgaveAnsvarHendelse', 'NesteOppgaveHendelse','OpprettOppfølgingHendelse')
+                                                    AND     logg3.hendelse -> 'utførtAv' ->> 'navIdent'::TEXT IS NOT NULL
+                                                  )
+                      )
+)
+UPDATE  oppgave_v1 uopp
+SET     siste_saksbehandler_ident = oppgave.siste_saksbehandler_ident
+FROM    oppgave
+WHERE   oppgave.id = uopp.id
+;
+WITH oppgave AS
+(
+    SELECT  oppg.id
+          , logg.hendelse -> 'utførtAv' ->> 'navIdent'::TEXT AS siste_beslutter_ident
+    FROM    oppgave_v1 oppg
+    JOIN    oppgave_tilstand_logg_v1 logg
+    ON      logg.oppgave_id = oppg.id
+    AND     logg.id = ( SELECT  logg2.id
+                        FROM    oppgave_tilstand_logg_v1 logg2
+                        WHERE   logg2.oppgave_id = oppg.id
+                        AND     logg2.tilstand = 'UNDER_KONTROLL'
+                        AND     logg2.hendelse_type IN ('NesteOppgaveHendelse', 'SettOppgaveAnsvarHendelse')
+                        AND     logg2.tidspunkt = ( SELECT  MAX(logg3.tidspunkt)
+                                                    FROM    oppgave_tilstand_logg_v1 logg3
+                                                    WHERE   logg3.oppgave_id = oppg.id
+                                                    AND     logg3.tilstand = 'UNDER_KONTROLL'
+                                                    AND     logg3.hendelse_type IN ('SettOppgaveAnsvarHendelse', 'NesteOppgaveHendelse')
+                                                    AND     logg3.hendelse -> 'utførtAv' ->> 'navIdent'::TEXT IS NOT NULL
+                                                  )
+                      )
+)
+UPDATE  oppgave_v1 uopp
+SET     siste_beslutter_ident = oppgave.siste_beslutter_ident
+FROM    oppgave
+WHERE   oppgave.id = uopp.id
+;
+ALTER TABLE oppgave_v1 ENABLE TRIGGER oppdater_endret_tidspunkt
 ;

--- a/mediator/src/main/resources/db/migration/common/V130__ALTER_TABLE_OPPGAVE_ADD_SISTE_SAKSBEHANDLER_OG_BESLUTTER.sql
+++ b/mediator/src/main/resources/db/migration/common/V130__ALTER_TABLE_OPPGAVE_ADD_SISTE_SAKSBEHANDLER_OG_BESLUTTER.sql
@@ -1,0 +1,7 @@
+ALTER TABLE oppgave_v1
+ADD COLUMN siste_saksbehandler_ident TEXT,
+ADD COLUMN siste_beslutter_ident TEXT
+;
+ALTER TABLE oppgave_v1
+RENAME COLUMN saksbehandler_ident TO behandler_ident
+;

--- a/mediator/src/main/resources/db/migration/common/V131__CREATE_INDEX_OPPGAVE_SAKSBEHANDLER_OG_BESLUTTER.sql
+++ b/mediator/src/main/resources/db/migration/common/V131__CREATE_INDEX_OPPGAVE_SAKSBEHANDLER_OG_BESLUTTER.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS oppgave_siste_saksbehandler_ident_index ON oppgave_v1 (siste_saksbehandler_ident);
+CREATE INDEX IF NOT EXISTS oppgave_siste_beslutter_ident_index ON oppgave_v1 (siste_beslutter_ident);

--- a/mediator/src/main/resources/db/migration/common/V131__CREATE_INDEX_OPPGAVE_SAKSBEHANDLER_OG_BESLUTTER.sql
+++ b/mediator/src/main/resources/db/migration/common/V131__CREATE_INDEX_OPPGAVE_SAKSBEHANDLER_OG_BESLUTTER.sql
@@ -1,2 +1,0 @@
-CREATE INDEX IF NOT EXISTS oppgave_siste_saksbehandler_ident_index ON oppgave_v1 (siste_saksbehandler_ident);
-CREATE INDEX IF NOT EXISTS oppgave_siste_beslutter_ident_index ON oppgave_v1 (siste_beslutter_ident);

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/KlageMediatorTest.kt
@@ -362,7 +362,7 @@ class KlageMediatorTest {
             oppgave.tilstand().type shouldBe UNDER_BEHANDLING
             oppgave.behandlerIdent shouldBe saksbehandler.navIdent
             oppgave.tilstandslogg.size shouldBe 3
-            oppgave.sisteSaksbehandler() shouldBe saksbehandler.navIdent
+            oppgave.sisteSaksbehandlerIdent shouldBe saksbehandler.navIdent
 
             klageMediator.registrerKlageBehandlingOpplysninger(behandlingId, saksbehandler)
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/MeldingOmVedtakMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/MeldingOmVedtakMediatorTest.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.runBlocking
 import no.nav.dagpenger.saksbehandling.api.Oppslag
 import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTO
 import no.nav.dagpenger.saksbehandling.api.models.BehandlerDTOEnhetDTO
-import no.nav.dagpenger.saksbehandling.hendelser.SettOppgaveAnsvarHendelse
 import no.nav.dagpenger.saksbehandling.sak.SakMediator
 import no.nav.dagpenger.saksbehandling.vedtaksmelding.MeldingOmVedtakKlient
 import no.nav.dagpenger.saksbehandling.vedtaksmelding.MeldingOmVedtakKlient.KanIkkeLageMeldingOmVedtak
@@ -42,18 +41,7 @@ class MeldingOmVedtakMediatorTest {
         TestHelper.lagOppgave(
             oppgaveId = oppgaveId,
             behandling = TestHelper.lagBehandling(behandlingId = behandlingId),
-            tilstandslogg =
-                OppgaveTilstandslogg().also {
-                    it.leggTil(
-                        Oppgave.Tilstand.Type.UNDER_BEHANDLING,
-                        hendelse =
-                            SettOppgaveAnsvarHendelse(
-                                oppgaveId = oppgaveId,
-                                ansvarligIdent = oppgavensSaksbehandler.navIdent,
-                                utførtAv = oppgavensSaksbehandler,
-                            ),
-                    )
-                },
+            saksbehandlerIdent = oppgavensSaksbehandler.navIdent,
         )
 
     private val oppgavensSaksbehandlerDTO =
@@ -124,7 +112,8 @@ class MeldingOmVedtakMediatorTest {
             TestHelper.lagOppgave(
                 oppgaveId = oppgaveId,
                 behandling = TestHelper.lagBehandling(behandlingId = behandlingId),
-                tilstandslogg = TestHelper.lagOppgaveTilstandslogg(),
+                saksbehandlerIdent = oppgavensSaksbehandler.navIdent,
+                beslutterIdent = beslutterIdent,
             )
 
         every { oppgaveMediator.hentOppgave(oppgaveId, beslutter) } returns oppgaveMedBeslutter

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveMediatorTest.kt
@@ -296,7 +296,7 @@ OppgaveMediatorTest {
             val oppgaveTilKontroll = oppgaveMediator.hentOppgave(oppgave.oppgaveId, testInspektør)
             oppgaveTilKontroll.tilstand().type shouldBe KLAR_TIL_KONTROLL
             oppgaveTilKontroll.behandlerIdent shouldBe null
-            oppgaveTilKontroll.sisteSaksbehandler() shouldBe saksbehandler.navIdent
+            oppgaveTilKontroll.sisteSaksbehandlerIdent shouldBe saksbehandler.navIdent
         }
     }
 
@@ -327,7 +327,7 @@ OppgaveMediatorTest {
             oppgaveMediator.hentOppgave(oppgave.oppgaveId, testInspektør).let {
                 it.tilstand().type shouldBe KLAR_TIL_KONTROLL
                 it.behandlerIdent shouldBe null
-                it.sisteSaksbehandler() shouldBe saksbehandler.navIdent
+                it.sisteSaksbehandlerIdent shouldBe saksbehandler.navIdent
             }
 
             oppgaveMediator.tildelOppgave(
@@ -340,8 +340,8 @@ OppgaveMediatorTest {
             oppgaveMediator.hentOppgave(oppgave.oppgaveId, testInspektør).let {
                 it.tilstand().type shouldBe UNDER_KONTROLL
                 it.behandlerIdent shouldBe beslutter.navIdent
-                it.sisteSaksbehandler() shouldBe saksbehandler.navIdent
-                it.sisteBeslutter() shouldBe beslutter.navIdent
+                it.sisteSaksbehandlerIdent shouldBe saksbehandler.navIdent
+                it.sisteBeslutterIdent shouldBe beslutter.navIdent
             }
 
             oppgaveMediator.returnerTilSaksbehandling(
@@ -356,8 +356,8 @@ OppgaveMediatorTest {
             oppgaveMediator.hentOppgave(oppgave.oppgaveId, testInspektør).let {
                 it.tilstand().type shouldBe UNDER_BEHANDLING
                 it.behandlerIdent shouldBe saksbehandler.navIdent
-                it.sisteSaksbehandler() shouldBe saksbehandler.navIdent
-                it.sisteBeslutter() shouldBe beslutter.navIdent
+                it.sisteSaksbehandlerIdent shouldBe saksbehandler.navIdent
+                it.sisteBeslutterIdent shouldBe beslutter.navIdent
             }
             oppgaveMediator.sendTilKontroll(
                 SendTilKontrollHendelse(
@@ -392,8 +392,8 @@ OppgaveMediatorTest {
             val oppgaveUnderKontroll = oppgaveMediator.hentOppgave(oppgave.oppgaveId, testInspektør)
             oppgaveUnderKontroll.tilstand().type shouldBe UNDER_KONTROLL
             oppgaveUnderKontroll.behandlerIdent shouldBe beslutter.navIdent
-            oppgaveUnderKontroll.sisteSaksbehandler() shouldBe saksbehandler.navIdent
-            oppgaveUnderKontroll.sisteBeslutter() shouldBe beslutter.navIdent
+            oppgaveUnderKontroll.sisteSaksbehandlerIdent shouldBe saksbehandler.navIdent
+            oppgaveUnderKontroll.sisteBeslutterIdent shouldBe beslutter.navIdent
         }
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/TestHelper.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/TestHelper.kt
@@ -224,6 +224,7 @@ internal object TestHelper {
         tilstand: Oppgave.Tilstand = KlarTilBehandling,
         opprettet: LocalDateTime = opprettetNå,
         saksbehandlerIdent: String? = null,
+        beslutterIdent: String? = null,
         person: Person = testPerson,
         behandling: Behandling = lagBehandling(opprettet = opprettet),
         emneknagger: Set<String> = emptySet(),
@@ -234,7 +235,13 @@ internal object TestHelper {
     ): Oppgave =
         Oppgave.rehydrer(
             oppgaveId = oppgaveId,
-            behandlerIdent = saksbehandlerIdent,
+            behandlerIdent =
+                when (tilstand) {
+                    is Oppgave.UnderKontroll -> beslutterIdent
+                    else -> saksbehandlerIdent
+                },
+            sisteSaksbehandlerIdent = saksbehandlerIdent,
+            sisteBeslutterIdent = beslutterIdent,
             opprettet = opprettet,
             emneknagger = emneknagger,
             tilstand = tilstand,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveApiTest.kt
@@ -180,7 +180,7 @@ class OppgaveApiTest {
                         Søkefilter(
                             periode = Periode.UBEGRENSET_PERIODE,
                             tilstander = søkbareTilstander,
-                            saksbehandlerIdent = null,
+                            behandlerIdent = null,
                             personIdent = null,
                             oppgaveId = null,
                             behandlingId = null,
@@ -423,7 +423,7 @@ class OppgaveApiTest {
                                     tom = LocalDate.parse("2023-01-01"),
                                 ),
                             tilstander = setOf(UNDER_BEHANDLING),
-                            saksbehandlerIdent = TestHelper.saksbehandler.navIdent,
+                            behandlerIdent = TestHelper.saksbehandler.navIdent,
                         ),
                     )
                 } returns søkResultat

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveDTOMapperTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/api/OppgaveDTOMapperTest.kt
@@ -74,6 +74,8 @@ class OppgaveDTOMapperTest {
             val oppgave =
                 TestHelper.lagOppgave(
                     tilstand = Oppgave.UnderKontroll(),
+                    saksbehandlerIdent = TestHelper.saksbehandler.navIdent,
+                    beslutterIdent = TestHelper.beslutter.navIdent,
                     opprettet = etTidspunkt,
                     person = TestHelper.testPerson,
                     tilstandslogg = TestHelper.lagOppgaveTilstandslogg(),
@@ -238,6 +240,8 @@ class OppgaveDTOMapperTest {
             val oppgave =
                 TestHelper.lagOppgave(
                     tilstand = UnderBehandling,
+                    saksbehandlerIdent = TestHelper.saksbehandler.navIdent,
+                    beslutterIdent = TestHelper.beslutter.navIdent,
                     opprettet = etTidspunkt,
                     tilstandslogg = TestHelper.lagOppgaveTilstandslogg(),
                 )
@@ -418,6 +422,8 @@ class OppgaveDTOMapperTest {
             val oppgave =
                 TestHelper.lagOppgave(
                     tilstand = Oppgave.UnderKontroll(),
+                    saksbehandlerIdent = TestHelper.saksbehandler.navIdent,
+                    beslutterIdent = TestHelper.beslutter.navIdent,
                     opprettet = etTidspunkt,
                     person = nødbremsetPerson,
                     tilstandslogg = TestHelper.lagOppgaveTilstandslogg(),
@@ -581,6 +587,8 @@ class OppgaveDTOMapperTest {
                     tilstand = UnderBehandling,
                     opprettet = etTidspunkt,
                     behandling = TestHelper.lagBehandling(utløstAvType = HendelseBehandler.DpBehandling.Manuell),
+                    saksbehandlerIdent = TestHelper.saksbehandler.navIdent,
+                    beslutterIdent = TestHelper.beslutter.navIdent,
                     tilstandslogg = TestHelper.lagOppgaveTilstandslogg(),
                 )
             OppgaveDTOMapper(
@@ -752,6 +760,8 @@ class OppgaveDTOMapperTest {
             val oppgave =
                 TestHelper.lagOppgave(
                     tilstand = UnderBehandling,
+                    saksbehandlerIdent = TestHelper.saksbehandler.navIdent,
+                    beslutterIdent = TestHelper.beslutter.navIdent,
                     opprettet = etTidspunkt,
                     behandling = TestHelper.lagBehandling(utløstAvType = HendelseBehandler.DpBehandling.Meldekort),
                     tilstandslogg = TestHelper.lagOppgaveTilstandslogg(),

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/DBTestHelper.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/DBTestHelper.kt
@@ -184,6 +184,7 @@ class DBTestHelper private constructor(
         type: HendelseBehandler = HendelseBehandler.DpBehandling.Søknad,
         tilstandslogg: OppgaveTilstandslogg = OppgaveTilstandslogg(),
         saksbehandlerIdent: String? = null,
+        beslutterIdent: String? = null,
     ): Oppgave {
         this.lagre(person)
 
@@ -214,7 +215,13 @@ class DBTestHelper private constructor(
                 tilstand = tilstand,
                 emneknagger = emneknagger,
                 tilstandslogg = tilstandslogg,
-                behandlerIdent = saksbehandlerIdent,
+                behandlerIdent =
+                    when (tilstand) {
+                        is Oppgave.UnderKontroll -> beslutterIdent
+                        else -> saksbehandlerIdent
+                    },
+                sisteSaksbehandlerIdent = saksbehandlerIdent,
+                sisteBeslutterIdent = beslutterIdent,
                 utsattTil = null,
                 behandling = behandling,
                 person = person,
@@ -249,6 +256,8 @@ class DBTestHelper private constructor(
                 person = person,
                 utsattTil = null,
                 behandlerIdent = null,
+                sisteSaksbehandlerIdent = null,
+                sisteBeslutterIdent = null,
                 meldingOmVedtak =
                     Oppgave.MeldingOmVedtak(
                         kilde = DP_SAK,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepositoryTest.kt
@@ -929,7 +929,7 @@ class PostgresOppgaveRepositoryTest {
                         require(it != null) { "Skal finne en oppgave" }
                         it.oppgaveId shouldBe eldsteKontrollOppgaveUtenSkjermingOgAdressegradering.oppgaveId
                         it.tilstand().type shouldBe Oppgave.Tilstand.Type.UNDER_KONTROLL
-                        it.sisteBeslutter() shouldBe vanligBeslutter.navIdent
+                        it.sisteBeslutterIdent shouldBe vanligBeslutter.navIdent
                     }
                 }
 
@@ -954,7 +954,7 @@ class PostgresOppgaveRepositoryTest {
                         require(it != null) { "Skal finne en oppgave" }
                         it.oppgaveId shouldBe eldsteKontrollOppgaveEgneAnsatteSkjerming.oppgaveId
                         it.tilstand().type shouldBe Oppgave.Tilstand.Type.UNDER_KONTROLL
-                        it.sisteBeslutter() shouldBe beslutterEgneAnsatte.navIdent
+                        it.sisteBeslutterIdent shouldBe beslutterEgneAnsatte.navIdent
                     }
                 }
 
@@ -979,7 +979,7 @@ class PostgresOppgaveRepositoryTest {
                         require(it != null) { "Skal finne en oppgave" }
                         it.oppgaveId shouldBe eldsteKontrollOppgaveFortroligAdresse.oppgaveId
                         it.tilstand().type shouldBe Oppgave.Tilstand.Type.UNDER_KONTROLL
-                        it.sisteBeslutter() shouldBe beslutterFortroligAdresse.navIdent
+                        it.sisteBeslutterIdent shouldBe beslutterFortroligAdresse.navIdent
                     }
                 }
 
@@ -1004,7 +1004,7 @@ class PostgresOppgaveRepositoryTest {
                         require(it != null) { "Skal finne en oppgave" }
                         it.oppgaveId shouldBe eldsteKontrollOppgaveStrengtFortroligAdresse.oppgaveId
                         it.tilstand().type shouldBe Oppgave.Tilstand.Type.UNDER_KONTROLL
-                        it.sisteBeslutter() shouldBe beslutterStrengtFortroligAdresse.navIdent
+                        it.sisteBeslutterIdent shouldBe beslutterStrengtFortroligAdresse.navIdent
                         it.opprettet shouldBe eldsteKontrollOppgaveStrengtFortroligAdresse.opprettet
                     }
                 }
@@ -1030,7 +1030,7 @@ class PostgresOppgaveRepositoryTest {
                         require(it != null) { "Skal finne en oppgave" }
                         it.oppgaveId shouldBe eldsteKontrollOppgaveStrengtFortroligAdresseUtland.oppgaveId
                         it.tilstand().type shouldBe Oppgave.Tilstand.Type.UNDER_KONTROLL
-                        it.sisteBeslutter() shouldBe beslutterStrengtFortroligAdresseUtland.navIdent
+                        it.sisteBeslutterIdent shouldBe beslutterStrengtFortroligAdresseUtland.navIdent
                     }
                 }
 
@@ -1061,7 +1061,7 @@ class PostgresOppgaveRepositoryTest {
                         require(it != null) { "Skal finne en oppgave" }
                         it.oppgaveId shouldBe eldsteKontrollOppgaveStrengtFortroligAdresseOgEgneAnsatteSkjerming.oppgaveId
                         it.tilstand().type shouldBe Oppgave.Tilstand.Type.UNDER_KONTROLL
-                        it.sisteBeslutter() shouldBe beslutterStrengtFortroligOgEgneAnsatte.navIdent
+                        it.sisteBeslutterIdent shouldBe beslutterStrengtFortroligOgEgneAnsatte.navIdent
                     }
                 }
         }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepositoryTest.kt
@@ -1796,7 +1796,7 @@ class PostgresOppgaveRepositoryTest {
     }
 
     @Test
-    fun `Skal kunne søke etter oppgaver tildelt en gitt saksbehandler`() {
+    fun `Skal kunne søke etter oppgaver hvor en gitt saksbehandler er siste saksbehandler eller siste beslutter`() {
         val enUkeSiden = opprettetNå.minusDays(7)
         val saksbehandler1 = "saksbehandler1"
         val saksbehandler2 = "saksbehandler2"
@@ -1816,6 +1816,7 @@ class PostgresOppgaveRepositoryTest {
             this.leggTilOppgave(
                 tilstand = Oppgave.FerdigBehandlet,
                 saksbehandlerIdent = saksbehandler2,
+                beslutterIdent = saksbehandler1,
                 emneknagger = setOf(Emneknagg.Regelknagg.INNVILGELSE.visningsnavn),
             )
             this.leggTilOppgave(
@@ -1834,7 +1835,7 @@ class PostgresOppgaveRepositoryTest {
                         periode = Periode.UBEGRENSET_PERIODE,
                         saksbehandlerIdent = saksbehandler1,
                     ),
-                ).oppgaver.size shouldBe 1
+                ).oppgaver.size shouldBe 2
 
             repo
                 .søk(

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/PostgresOppgaveRepositoryTest.kt
@@ -1833,7 +1833,7 @@ class PostgresOppgaveRepositoryTest {
                             Oppgave.Tilstand.Type.entries
                                 .toSet(),
                         periode = Periode.UBEGRENSET_PERIODE,
-                        saksbehandlerIdent = saksbehandler1,
+                        behandlerIdent = saksbehandler1,
                     ),
                 ).oppgaver.size shouldBe 2
 
@@ -1844,7 +1844,7 @@ class PostgresOppgaveRepositoryTest {
                             Oppgave.Tilstand.Type.entries
                                 .toSet(),
                         periode = Periode.UBEGRENSET_PERIODE,
-                        saksbehandlerIdent = saksbehandler2,
+                        behandlerIdent = saksbehandler2,
                     ),
                 ).oppgaver.size shouldBe 2
 
@@ -1855,7 +1855,7 @@ class PostgresOppgaveRepositoryTest {
                             Oppgave.Tilstand.Type.entries
                                 .toSet(),
                         periode = Periode.UBEGRENSET_PERIODE,
-                        saksbehandlerIdent = null,
+                        behandlerIdent = null,
                     ),
                 ).oppgaver.size shouldBe 4
 
@@ -1866,7 +1866,7 @@ class PostgresOppgaveRepositoryTest {
                             Oppgave.Tilstand.Type.entries
                                 .toSet(),
                         periode = Periode.UBEGRENSET_PERIODE,
-                        saksbehandlerIdent = saksbehandler2,
+                        behandlerIdent = saksbehandler2,
                         emneknaggGruppertPerKategori =
                             mapOf(
                                 Emneknagg.Regelknagg.INNVILGELSE.kategori to setOf(Emneknagg.Regelknagg.INNVILGELSE.visningsnavn),
@@ -1881,7 +1881,7 @@ class PostgresOppgaveRepositoryTest {
                             Oppgave.Tilstand.Type.entries
                                 .toSet(),
                         periode = Periode.UBEGRENSET_PERIODE,
-                        utenSaksbehandler = true,
+                        utenBehandler = true,
                     ),
                 ).oppgaver.size shouldBe 1
         }
@@ -2297,7 +2297,7 @@ class PostgresOppgaveRepositoryTest {
                     Søkefilter(
                         periode = Periode.UBEGRENSET_PERIODE,
                         tilstander = Oppgave.Tilstand.Type.søkbareTilstander,
-                        saksbehandlerIdent = null,
+                        behandlerIdent = null,
                         personIdent = null,
                         oppgaveId = null,
                         behandlingId = null,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/SøkefilterTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/db/oppgave/SøkefilterTest.kt
@@ -53,7 +53,7 @@ class SøkefilterTest {
                                 "Permittert fisk",
                             ),
                     )
-                søkefilter.saksbehandlerIdent shouldBe "testIdent"
+                søkefilter.behandlerIdent shouldBe "testIdent"
                 søkefilter.harDpSak shouldBe true
                 søkefilter.paginering shouldBe Søkefilter.Paginering(10, 0)
                 søkefilter.sorteringsfelt shouldBe Søkefilter.Sorteringsfelt.STATUS
@@ -73,7 +73,7 @@ class SøkefilterTest {
         søkefilter.tilstander shouldBe Oppgave.Tilstand.Type.søkbareTilstander
         søkefilter.ekskluderEmneknagger shouldBe emptySet()
         søkefilter.harDpSak shouldBe false
-        søkefilter.saksbehandlerIdent shouldBe null
+        søkefilter.behandlerIdent shouldBe null
         søkefilter.personIdent shouldBe null
         søkefilter.oppgaveId shouldBe null
         søkefilter.behandlingId shouldBe null
@@ -194,8 +194,8 @@ class SøkefilterTest {
                 this["saksbehandlerIdent"] = "annenIdent"
             }.let {
                 val søkefilter = Søkefilter.fra(it, "testIdent")
-                søkefilter.saksbehandlerIdent shouldBe "annenIdent"
-                søkefilter.utenSaksbehandler shouldBe false
+                søkefilter.behandlerIdent shouldBe "annenIdent"
+                søkefilter.utenBehandler shouldBe false
             }
     }
 
@@ -207,7 +207,7 @@ class SøkefilterTest {
                 this["mineOppgaver"] = "true"
             }.let {
                 val søkefilter = Søkefilter.fra(it, "testIdent")
-                søkefilter.saksbehandlerIdent shouldBe "annenIdent"
+                søkefilter.behandlerIdent shouldBe "annenIdent"
             }
     }
 
@@ -218,8 +218,8 @@ class SøkefilterTest {
                 this["utenSaksbehandler"] = "true"
             }.let {
                 val søkefilter = Søkefilter.fra(it, "testIdent")
-                søkefilter.utenSaksbehandler shouldBe true
-                søkefilter.saksbehandlerIdent shouldBe null
+                søkefilter.utenBehandler shouldBe true
+                søkefilter.behandlerIdent shouldBe null
             }
     }
 
@@ -232,7 +232,7 @@ class SøkefilterTest {
                 this["saksbehandlerIdent"] = "annenIdent"
             }.let {
                 val søkefilter = Søkefilter.fra(it, "testIdent")
-                søkefilter.saksbehandlerIdent shouldBe null
+                søkefilter.behandlerIdent shouldBe null
             }
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/frist/OppgaveFristUtgåttJobTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/frist/OppgaveFristUtgåttJobTest.kt
@@ -12,6 +12,7 @@ import no.nav.dagpenger.saksbehandling.Oppgave
 import no.nav.dagpenger.saksbehandling.Oppgave.KlarTilBehandling
 import no.nav.dagpenger.saksbehandling.Oppgave.PåVent
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.Type.KLAR_TIL_BEHANDLING
+import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.Type.OPPRETTET
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.Type.UNDER_BEHANDLING
 import no.nav.dagpenger.saksbehandling.Oppgave.UnderBehandling
 import no.nav.dagpenger.saksbehandling.OppgaveMediator
@@ -25,6 +26,7 @@ import no.nav.dagpenger.saksbehandling.db.DatabaseSession
 import no.nav.dagpenger.saksbehandling.db.Transaksjoner
 import no.nav.dagpenger.saksbehandling.db.oppgave.PostgresOppgaveRepository
 import no.nav.dagpenger.saksbehandling.hendelser.OpprettOppfølgingHendelse
+import no.nav.dagpenger.saksbehandling.hendelser.SettOppgaveAnsvarHendelse
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -87,7 +89,16 @@ class OppgaveFristUtgåttJobTest {
                                         ),
                                 ),
                                 Tilstandsendring(
-                                    tilstand = Oppgave.Tilstand.Type.OPPRETTET,
+                                    tilstand = UNDER_BEHANDLING,
+                                    hendelse =
+                                        SettOppgaveAnsvarHendelse(
+                                            oppgaveId = behandling2.behandlingId,
+                                            ansvarligIdent = TestHelper.saksbehandler.navIdent,
+                                            utførtAv = TestHelper.saksbehandler,
+                                        ),
+                                ),
+                                Tilstandsendring(
+                                    tilstand = OPPRETTET,
                                     hendelse =
                                         OpprettOppfølgingHendelse(
                                             ident = TestHelper.personIdent,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/frist/OppgaveFristUtgåttJobTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/frist/OppgaveFristUtgåttJobTest.kt
@@ -151,7 +151,7 @@ class OppgaveFristUtgåttJobTest {
                 oppgave.behandlerIdent shouldBe TestHelper.saksbehandler.navIdent
                 oppgave.tilstandslogg.first().tilstand shouldBe UNDER_BEHANDLING
                 oppgave.utsattTil() shouldBe null
-                oppgave.sisteSaksbehandler() shouldBe TestHelper.saksbehandler.navIdent
+                oppgave.sisteSaksbehandlerIdent shouldBe TestHelper.saksbehandler.navIdent
             }
 
             repo.hentOppgave(oppgave3.oppgaveId).let { oppgave ->

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediatorTest.kt
@@ -171,9 +171,9 @@ class OppfølgingMediatorTest {
             oppgaver.first().emneknagger shouldBe setOf("MeldekortKorrigering")
             oppgaver.first().tilstand() shouldBe Oppgave.PåVent
             oppgaver.first().behandlerIdent shouldBe saksbehandler.navIdent
-            oppgaver.first().sisteSaksbehandler() shouldBe saksbehandler.navIdent
+            oppgaver.first().sisteSaksbehandlerIdent shouldBe saksbehandler.navIdent
             oppgaver.first().utsattTil() shouldBe utsattFrist
-            oppgaver.first().tilstandslogg.size shouldBe 3
+            oppgaver.first().tilstandslogg.size shouldBe 2
         }
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/saksbehandling/oppfolging/OppfølgingMediatorTest.kt
@@ -113,6 +113,71 @@ class OppfølgingMediatorTest {
     }
 
     @Test
+    fun `E2E - opprette og sette oppfølgingsoppgave på vent`() {
+        DBTestHelper.withPerson { ds ->
+            val databaseSession = DatabaseSession(ds)
+            val oppfølgingRepository = PostgresOppfølgingRepository(databaseSession)
+            val personMediator = PersonMediator(PostgresPersonRepository(databaseSession), mockk())
+            val sakMediator =
+                SakMediator(
+                    personMediator = personMediator,
+                    sakRepository = PostgresSakRepository(databaseSession),
+                    rapidsConnection = mockk(relaxed = true),
+                )
+            val oppgaveMediator =
+                OppgaveMediator(
+                    personMediator = personMediator,
+                    oppgaveRepository = PostgresOppgaveRepository(databaseSession),
+                    behandlingKlient = mockk(),
+                    utsendingMediator = mockk(),
+                    sakMediator = sakMediator,
+                    utboks = mockk(relaxed = true),
+                    transaksjoner = Transaksjoner(databaseSession),
+                    meldekortregisterKlient = mockk(relaxed = true),
+                )
+
+            val oppfølgingBehandler = mockk<OppfølgingBehandler>()
+
+            val mediator =
+                OppfølgingMediator(
+                    transaksjoner = Transaksjoner(databaseSession),
+                    oppfølgingRepository = oppfølgingRepository,
+                    oppfølgingBehandler = oppfølgingBehandler,
+                    personMediator = personMediator,
+                    sakMediator = sakMediator,
+                    oppgaveMediator = oppgaveMediator,
+                )
+
+            val utsattFrist = LocalDate.now().plusDays(7)
+            val resultat =
+                mediator.taImot(
+                    OpprettOppfølgingHendelse(
+                        ident = testPerson.ident,
+                        aarsak = "MeldekortKorrigering",
+                        tittel = "Meldekort trenger korrigering",
+                        beskrivelse = "Se på perioden",
+                        frist = utsattFrist,
+                        beholdOppgaven = true,
+                        utførtAv = saksbehandler,
+                    ),
+                )
+
+            val oppfølging = oppfølgingRepository.hent(resultat.oppfølgingId)
+            oppfølging.tilstand() shouldBe "BEHANDLES"
+
+            val oppgaver = oppgaveMediator.finnOppgaverFor(ident = testPerson.ident)
+            oppgaver.size shouldBe 1
+            oppgaver.first().behandling.utløstAv shouldBe HendelseBehandler.Intern.Oppfølging
+            oppgaver.first().emneknagger shouldBe setOf("MeldekortKorrigering")
+            oppgaver.first().tilstand() shouldBe Oppgave.PåVent
+            oppgaver.first().behandlerIdent shouldBe saksbehandler.navIdent
+            oppgaver.first().sisteSaksbehandler() shouldBe saksbehandler.navIdent
+            oppgaver.first().utsattTil() shouldBe utsattFrist
+            oppgaver.first().tilstandslogg.size shouldBe 3
+        }
+    }
+
+    @Test
     fun `rediger oppdaterer tittel, beskrivelse og frist og persisterer i database`() {
         DBTestHelper.withPerson { ds ->
             val databaseSession = DatabaseSession(ds)

--- a/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/Oppgave.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/Oppgave.kt
@@ -338,9 +338,12 @@ data class Oppgave private constructor(
 
     fun sisteSaksbehandler(): String? =
         runCatching {
-            _tilstandslogg.firstOrNull { it.tilstand in listOf(UNDER_BEHANDLING, PAA_VENT) && it.hendelse is AnsvarHendelse }?.let {
-                (it.hendelse as AnsvarHendelse).ansvarligIdent
-            }
+            _tilstandslogg
+                .firstOrNull {
+                    it.tilstand == UNDER_BEHANDLING && it.hendelse is AnsvarHendelse
+                }?.let {
+                    (it.hendelse as AnsvarHendelse).ansvarligIdent
+                }
         }.onFailure { e -> logger.error(e) { "Feil ved henting av siste saksbehandler for oppgave:  ${this.oppgaveId}" } }
             .getOrThrow()
 
@@ -420,22 +423,32 @@ data class Oppgave private constructor(
             oppgave: Oppgave,
             hendelse: OpprettOppfølgingHendelse,
         ) {
-            when {
-                hendelse.frist != null -> {
+            if (hendelse.beholdOppgaven) {
+                requireNotNull(hendelse.ansvarligIdent) {
+                    "ansvarligIdent må være satt for å kunne beholde oppgaven ved opprettelse av oppfølging"
+                }
+                require(hendelse.utførtAv is Saksbehandler) {
+                    "Oppgave kan kun beholdes av utførende saksbehandler"
+                }
+                oppgave.behandlerIdent = hendelse.ansvarligIdent
+                oppgave.endreTilstand(
+                    nyTilstand = UnderBehandling,
+                    hendelse =
+                        SettOppgaveAnsvarHendelse(
+                            oppgaveId = oppgave.oppgaveId,
+                            ansvarligIdent = hendelse.ansvarligIdent!!,
+                            utførtAv = hendelse.utførtAv,
+                        ),
+                )
+                if (hendelse.frist != null) {
                     oppgave.utsattTil = hendelse.frist
-                    oppgave.behandlerIdent = hendelse.ansvarligIdent
-                    oppgave.endreTilstand(PåVent, hendelse)
+                    oppgave.endreTilstand(nyTilstand = PåVent, hendelse = hendelse)
                 }
-
-                hendelse.beholdOppgaven -> {
-                    requireNotNull(
-                        hendelse.ansvarligIdent,
-                    ) { "ansvarligIdent må være satt for å kunne beholde oppgaven ved opprettelse av oppfølging" }
-                    oppgave.behandlerIdent = hendelse.ansvarligIdent
-                    oppgave.endreTilstand(UnderBehandling, hendelse)
-                }
-
-                else -> {
+            } else {
+                if (hendelse.frist != null) {
+                    oppgave.utsattTil = hendelse.frist
+                    oppgave.endreTilstand(nyTilstand = PåVent, hendelse = hendelse)
+                } else {
                     oppgave.endreTilstand(KlarTilBehandling, hendelse)
                 }
             }

--- a/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/Oppgave.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/saksbehandling/Oppgave.kt
@@ -19,7 +19,6 @@ import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.Type.PAA_VENT
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.Type.UNDER_BEHANDLING
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.Type.UNDER_KONTROLL
 import no.nav.dagpenger.saksbehandling.TilgangType.BESLUTTER
-import no.nav.dagpenger.saksbehandling.hendelser.AnsvarHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.AvbruttHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.AvbrytOppgaveHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.BehandlingAvbruttHendelse
@@ -56,6 +55,8 @@ data class Oppgave private constructor(
     val oppgaveId: UUID,
     val opprettet: LocalDateTime,
     var behandlerIdent: String? = null,
+    var sisteSaksbehandlerIdent: String? = null,
+    var sisteBeslutterIdent: String? = null,
     private val _emneknagger: MutableSet<String>,
     private var tilstand: Tilstand = KlarTilBehandling,
     private var utsattTil: LocalDate? = null,
@@ -68,6 +69,8 @@ data class Oppgave private constructor(
         emneknagger: Set<String> = emptySet(),
         opprettet: LocalDateTime,
         behandlerIdent: String? = null,
+        sisteSaksbehandlerIdent: String? = null,
+        sisteBeslutterIdent: String? = null,
         person: Person,
         behandling: Behandling,
         hendelse: Hendelse = TomHendelse,
@@ -75,6 +78,8 @@ data class Oppgave private constructor(
     ) : this(
         oppgaveId = UUIDv7.ny(),
         behandlerIdent = behandlerIdent,
+        sisteSaksbehandlerIdent = sisteSaksbehandlerIdent,
+        sisteBeslutterIdent = sisteBeslutterIdent,
         opprettet = opprettet,
         _emneknagger = emneknagger.toMutableSet(),
         tilstand = Opprettet,
@@ -104,6 +109,8 @@ data class Oppgave private constructor(
         fun rehydrer(
             oppgaveId: UUID,
             behandlerIdent: String?,
+            sisteSaksbehandlerIdent: String?,
+            sisteBeslutterIdent: String?,
             opprettet: LocalDateTime,
             emneknagger: Set<String>,
             tilstand: Tilstand,
@@ -117,6 +124,8 @@ data class Oppgave private constructor(
                 oppgaveId = oppgaveId,
                 opprettet = opprettet,
                 behandlerIdent = behandlerIdent,
+                sisteSaksbehandlerIdent = sisteSaksbehandlerIdent,
+                sisteBeslutterIdent = sisteBeslutterIdent,
                 _emneknagger = emneknagger.toMutableSet(),
                 tilstand = tilstand,
                 utsattTil = utsattTil,
@@ -154,11 +163,11 @@ data class Oppgave private constructor(
             beslutter: Saksbehandler,
             hendelseNavn: String,
         ) {
-            require(oppgave.sisteSaksbehandler() != beslutter.navIdent) {
+            require(oppgave.sisteSaksbehandlerIdent != beslutter.navIdent) {
                 throw Tilstand.KanIkkeBeslutteEgenSaksbehandling(
                     "Ulovlig hendelse $hendelseNavn på oppgave i tilstand ${oppgave.tilstand.type}. " +
                         "Oppgave kan ikke behandles og kontrolleres av samme person. Saksbehandler på oppgaven er " +
-                        "${oppgave.sisteSaksbehandler()} og kan derfor ikke kontrolleres av ${beslutter.navIdent}",
+                        "${oppgave.sisteSaksbehandlerIdent} og kan derfor ikke kontrolleres av ${beslutter.navIdent}",
                 )
             }
         }
@@ -298,7 +307,7 @@ data class Oppgave private constructor(
     fun behandlingTilGodkjenning(hendelse: BehandlingTilGodkjenningHendelse): Handling = tilstand.behandlingTilGodkjenning(this, hendelse)
 
     private fun returnerTilSaksbehandling(hendelse: BehandlingTilGodkjenningHendelse): Handling {
-        when (val sisteSaksbehandler = sisteSaksbehandler()) {
+        when (sisteSaksbehandlerIdent) {
             null -> {
                 logger.error {
                     "Oppgave $oppgaveId i tilstand ${tilstand.type} for behandling ${hendelse.behandlingId} " +
@@ -311,7 +320,7 @@ data class Oppgave private constructor(
 
             else -> {
                 endreTilstand(UnderBehandling, hendelse)
-                behandlerIdent = sisteSaksbehandler
+                behandlerIdent = sisteSaksbehandlerIdent
             }
         }
         _emneknagger.add(Emneknagg.Kontroll.BEHANDLING_OPPDATERT.visningsnavn)
@@ -335,25 +344,6 @@ data class Oppgave private constructor(
         this.tilstand = nyTilstand
         this._tilstandslogg.leggTil(nyTilstand.type, hendelse)
     }
-
-    fun sisteSaksbehandler(): String? =
-        runCatching {
-            _tilstandslogg
-                .firstOrNull {
-                    it.tilstand == UNDER_BEHANDLING && it.hendelse is AnsvarHendelse
-                }?.let {
-                    (it.hendelse as AnsvarHendelse).ansvarligIdent
-                }
-        }.onFailure { e -> logger.error(e) { "Feil ved henting av siste saksbehandler for oppgave:  ${this.oppgaveId}" } }
-            .getOrThrow()
-
-    fun sisteBeslutter(): String? =
-        runCatching {
-            _tilstandslogg.firstOrNull { it.tilstand == UNDER_KONTROLL && it.hendelse is AnsvarHendelse }?.let {
-                (it.hendelse as AnsvarHendelse).ansvarligIdent
-            }
-        }.onFailure { e -> logger.error(e) { "Feil ved henting av siste beslutter for oppgave:  ${this.oppgaveId}" } }
-            .getOrThrow()
 
     fun søknadId(): UUID? =
         runCatching {
@@ -431,25 +421,19 @@ data class Oppgave private constructor(
                     "Oppgave kan kun beholdes av utførende saksbehandler"
                 }
                 oppgave.behandlerIdent = hendelse.ansvarligIdent
-                oppgave.endreTilstand(
-                    nyTilstand = UnderBehandling,
-                    hendelse =
-                        SettOppgaveAnsvarHendelse(
-                            oppgaveId = oppgave.oppgaveId,
-                            ansvarligIdent = hendelse.ansvarligIdent!!,
-                            utførtAv = hendelse.utførtAv,
-                        ),
-                )
+                oppgave.sisteSaksbehandlerIdent = hendelse.ansvarligIdent
                 if (hendelse.frist != null) {
                     oppgave.utsattTil = hendelse.frist
                     oppgave.endreTilstand(nyTilstand = PåVent, hendelse = hendelse)
+                } else {
+                    oppgave.endreTilstand(nyTilstand = UnderBehandling, hendelse = hendelse)
                 }
             } else {
                 if (hendelse.frist != null) {
                     oppgave.utsattTil = hendelse.frist
                     oppgave.endreTilstand(nyTilstand = PåVent, hendelse = hendelse)
                 } else {
-                    oppgave.endreTilstand(KlarTilBehandling, hendelse)
+                    oppgave.endreTilstand(nyTilstand = KlarTilBehandling, hendelse = hendelse)
                 }
             }
         }
@@ -480,6 +464,7 @@ data class Oppgave private constructor(
         ) {
             oppgave.endreTilstand(UnderBehandling, settOppgaveAnsvarHendelse)
             oppgave.behandlerIdent = settOppgaveAnsvarHendelse.ansvarligIdent
+            oppgave.sisteSaksbehandlerIdent = settOppgaveAnsvarHendelse.ansvarligIdent
         }
 
         override fun ferdigstill(
@@ -522,11 +507,11 @@ data class Oppgave private constructor(
             if (oppgave.meldingOmVedtak.kilde == GOSYS) {
                 oppgave.meldingOmVedtak.kontrollertGosysBrev = NEI
             }
-            if (oppgave.sisteBeslutter() == null) {
+            if (oppgave.sisteBeslutterIdent == null) {
                 oppgave.behandlerIdent = null
                 oppgave.endreTilstand(KlarTilKontroll, sendTilKontrollHendelse)
             } else {
-                oppgave.behandlerIdent = oppgave.sisteBeslutter()
+                oppgave.behandlerIdent = oppgave.sisteBeslutterIdent
                 oppgave.endreTilstand(UnderKontroll(), sendTilKontrollHendelse)
                 oppgave._emneknagger.add(Emneknagg.Kontroll.TIDLIGERE_KONTROLLERT.visningsnavn)
                 oppgave._emneknagger.remove(Emneknagg.Kontroll.RETUR_FRA_KONTROLL.visningsnavn)
@@ -539,6 +524,7 @@ data class Oppgave private constructor(
         ) {
             oppgave.endreTilstand(KlarTilBehandling, fjernOppgaveAnsvarHendelse)
             oppgave.behandlerIdent = null
+            oppgave.sisteSaksbehandlerIdent = null
         }
 
         override fun avbryt(
@@ -585,6 +571,7 @@ data class Oppgave private constructor(
                     true -> utsettOppgaveHendelse.navIdent
                     false -> null
                 }
+            oppgave.sisteSaksbehandlerIdent = oppgave.behandlerIdent
             oppgave.utsattTil = utsettOppgaveHendelse.utsattTil
         }
 
@@ -616,6 +603,7 @@ data class Oppgave private constructor(
                 "Mottok vedtak fattet hendelse i tilstand $type. Automatisk = ${vedtakFattetHendelse.automatiskBehandlet}. Ferdigstiller oppgave."
             }
             oppgave.behandlerIdent = vedtakFattetHendelse.saksbehandlerIdent
+            oppgave.sisteSaksbehandlerIdent = vedtakFattetHendelse.saksbehandlerIdent
             oppgave.endreTilstand(FerdigBehandlet, vedtakFattetHendelse)
             return Handling.LAGRE_OPPGAVE
         }
@@ -772,6 +760,7 @@ data class Oppgave private constructor(
         ) {
             oppgave.endreTilstand(UnderBehandling, settOppgaveAnsvarHendelse)
             oppgave.behandlerIdent = settOppgaveAnsvarHendelse.ansvarligIdent
+            oppgave.sisteSaksbehandlerIdent = settOppgaveAnsvarHendelse.ansvarligIdent
             oppgave.utsattTil = null
         }
 
@@ -781,6 +770,7 @@ data class Oppgave private constructor(
         ) {
             oppgave.endreTilstand(KlarTilBehandling, fjernOppgaveAnsvarHendelse)
             oppgave.behandlerIdent = null
+            oppgave.sisteSaksbehandlerIdent = null
             oppgave.utsattTil = null
         }
 
@@ -851,6 +841,7 @@ data class Oppgave private constructor(
 
             oppgave.endreTilstand(UnderKontroll(), settOppgaveAnsvarHendelse)
             oppgave.behandlerIdent = settOppgaveAnsvarHendelse.ansvarligIdent
+            oppgave.sisteBeslutterIdent = settOppgaveAnsvarHendelse.ansvarligIdent
         }
 
         override fun behandlingTilGodkjenning(
@@ -895,6 +886,7 @@ data class Oppgave private constructor(
                 "Mottok vedtak fattet hendelse i tilstand $type. Automatisk = ${vedtakFattetHendelse.automatiskBehandlet}. Ferdigstiller oppgave."
             }
             oppgave.behandlerIdent = vedtakFattetHendelse.beslutterIdent
+            oppgave.sisteBeslutterIdent = vedtakFattetHendelse.beslutterIdent
             oppgave.endreTilstand(FerdigBehandlet, vedtakFattetHendelse)
             return Handling.LAGRE_OPPGAVE
         }
@@ -990,7 +982,7 @@ data class Oppgave private constructor(
             )
 
             oppgave.endreTilstand(UnderBehandling, returnerTilSaksbehandlingHendelse)
-            oppgave.behandlerIdent = oppgave.sisteSaksbehandler()
+            oppgave.behandlerIdent = oppgave.sisteSaksbehandlerIdent
             oppgave._emneknagger.add(Emneknagg.Kontroll.RETUR_FRA_KONTROLL.visningsnavn)
             oppgave._emneknagger.remove(Emneknagg.Kontroll.TIDLIGERE_KONTROLLERT.visningsnavn)
             if (oppgave.meldingOmVedtak.kilde == GOSYS) {
@@ -1004,6 +996,7 @@ data class Oppgave private constructor(
         ) {
             oppgave.endreTilstand(KlarTilKontroll, fjernOppgaveAnsvarHendelse)
             oppgave.behandlerIdent = null
+            oppgave.sisteBeslutterIdent = null
         }
 
         override fun behandlingTilGodkjenning(

--- a/modell/src/test/kotlin/no/nav/dagpenger/saksbehandling/LagreBrevKvitteringTest.kt
+++ b/modell/src/test/kotlin/no/nav/dagpenger/saksbehandling/LagreBrevKvitteringTest.kt
@@ -12,6 +12,7 @@ import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.Type
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.Type.UNDER_KONTROLL
 import no.nav.dagpenger.saksbehandling.Oppgave.Tilstand.UlovligKvitteringAvKontrollertBrev
 import no.nav.dagpenger.saksbehandling.TilgangType.BESLUTTER
+import no.nav.dagpenger.saksbehandling.TilgangType.SAKSBEHANDLER
 import no.nav.dagpenger.saksbehandling.hendelser.LagreBrevKvitteringHendelse
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -20,12 +21,13 @@ import org.junit.jupiter.params.provider.EnumSource
 class LagreBrevKvitteringTest {
     val oppgaveId = UUIDv7.ny()
 
-    private val saksbehandler = Saksbehandler("saksbehandler", grupper = emptySet(), tilganger = setOf(BESLUTTER))
+    private val saksbehandler = Saksbehandler("saksbehandler", grupper = emptySet(), tilganger = setOf(SAKSBEHANDLER))
+    private val beslutter = Saksbehandler("beslutter", grupper = emptySet(), tilganger = setOf(BESLUTTER))
 
     @ParameterizedTest
     @EnumSource(Type::class)
     fun `Ulovlig endring av brevkontroll for melding om vedtak`(tilstandstype: Type) {
-        val oppgave = lagOppgave(tilstandType = tilstandstype, saksbehandler)
+        val oppgave = lagOppgave(tilstandType = tilstandstype, saksbehandler = saksbehandler, beslutter = beslutter)
 
         if (tilstandstype != UNDER_KONTROLL) {
             shouldThrow<UlovligKvitteringAvKontrollertBrev> {
@@ -45,8 +47,9 @@ class LagreBrevKvitteringTest {
     fun `Skal kunne endre brevkontroll for melding om vedtak i tilstand UNDER_KONTROLL`() {
         val oppgave =
             lagOppgave(
-                UNDER_KONTROLL,
-                saksbehandler,
+                tilstandType = UNDER_KONTROLL,
+                saksbehandler = saksbehandler,
+                beslutter = beslutter,
                 meldingOmVedtakKilde =
                     Oppgave.MeldingOmVedtak(
                         kilde = GOSYS,
@@ -60,7 +63,7 @@ class LagreBrevKvitteringTest {
                     LagreBrevKvitteringHendelse(
                         oppgaveId = oppgaveId,
                         kontrollertBrev = JA,
-                        utførtAv = saksbehandler,
+                        utførtAv = beslutter,
                     ),
             )
         }
@@ -72,7 +75,7 @@ class LagreBrevKvitteringTest {
                     LagreBrevKvitteringHendelse(
                         oppgaveId = oppgaveId,
                         kontrollertBrev = IKKE_RELEVANT,
-                        utførtAv = saksbehandler,
+                        utførtAv = beslutter,
                     ),
             )
         }

--- a/modell/src/test/kotlin/no/nav/dagpenger/saksbehandling/ModellTestHelper.kt
+++ b/modell/src/test/kotlin/no/nav/dagpenger/saksbehandling/ModellTestHelper.kt
@@ -24,7 +24,8 @@ object ModellTestHelper {
 
     internal fun lagOppgave(
         tilstandType: Type = KLAR_TIL_BEHANDLING,
-        behandler: Saksbehandler? = null,
+        saksbehandler: Saksbehandler? = null,
+        beslutter: Saksbehandler? = null,
         skjermesSomEgneAnsatte: Boolean = false,
         adressebeskyttelseGradering: AdressebeskyttelseGradering = UGRADERT,
         inhabileSaksbehandlerIdenter: List<String> = emptyList(),
@@ -66,7 +67,13 @@ object ModellTestHelper {
             )
         return Oppgave.rehydrer(
             oppgaveId = UUIDv7.ny(),
-            behandlerIdent = behandler?.navIdent,
+            behandlerIdent =
+                when (tilstand) {
+                    is Oppgave.UnderKontroll -> beslutter?.navIdent
+                    else -> saksbehandler?.navIdent
+                },
+            sisteSaksbehandlerIdent = saksbehandler?.navIdent,
+            sisteBeslutterIdent = beslutter?.navIdent,
             opprettet = LocalDateTime.now(),
             emneknagger = emneknagger,
             tilstand = tilstand,

--- a/modell/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveTilgangTest.kt
+++ b/modell/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveTilgangTest.kt
@@ -323,7 +323,7 @@ class OppgaveTilgangTest {
         val egneAnsatteOppgave =
             lagOppgave(
                 UNDER_BEHANDLING,
-                behandler = saksbehandlerUtenEkstraTilganger,
+                saksbehandler = saksbehandlerUtenEkstraTilganger,
                 skjermesSomEgneAnsatte = true,
             )
 
@@ -435,7 +435,7 @@ class OppgaveTilgangTest {
         shouldThrow<ManglendeTilgang> {
             lagOppgave(
                 tilstandType = UNDER_BEHANDLING,
-                behandler = saksbehandlerUtenEkstraTilganger,
+                saksbehandler = saksbehandlerUtenEkstraTilganger,
                 skjermesSomEgneAnsatte = true,
             ).let {
                 it.sendTilKontroll(
@@ -450,7 +450,7 @@ class OppgaveTilgangTest {
         shouldNotThrow<ManglendeTilgang> {
             lagOppgave(
                 tilstandType = UNDER_BEHANDLING,
-                behandler = saksbehandlerMedTilgangTilEgneAnsatte,
+                saksbehandler = saksbehandlerMedTilgangTilEgneAnsatte,
                 skjermesSomEgneAnsatte = true,
             ).let {
                 it.sendTilKontroll(
@@ -475,7 +475,7 @@ class OppgaveTilgangTest {
             lagOppgave(
                 tilstandType = UNDER_BEHANDLING,
                 adressebeskyttelseGradering = adressebeskyttelseGradering,
-                behandler = saksbehandler,
+                saksbehandler = saksbehandler,
             )
 
         if (forventetTilgang) {
@@ -508,7 +508,7 @@ class OppgaveTilgangTest {
         shouldThrow<ManglendeTilgang> {
             lagOppgave(
                 tilstandType = UNDER_BEHANDLING,
-                behandler = saksbehandlerUtenEkstraTilganger,
+                saksbehandler = saksbehandlerUtenEkstraTilganger,
                 skjermesSomEgneAnsatte = true,
             ).let { oppgave ->
                 oppgave.avbryt(
@@ -525,7 +525,7 @@ class OppgaveTilgangTest {
         shouldNotThrow<ManglendeTilgang> {
             lagOppgave(
                 tilstandType = UNDER_BEHANDLING,
-                behandler = saksbehandlerMedTilgangTilEgneAnsatte,
+                saksbehandler = saksbehandlerMedTilgangTilEgneAnsatte,
                 skjermesSomEgneAnsatte = true,
             ).let { oppgave ->
                 oppgave.avbryt(
@@ -542,7 +542,7 @@ class OppgaveTilgangTest {
 
     @Test
     fun `Avbryting av oppgave under behandling krever at utførende saksbehandler også eier oppgaven`() {
-        val oppgave = lagOppgave(tilstandType = UNDER_BEHANDLING, behandler = saksbehandlerUtenEkstraTilganger)
+        val oppgave = lagOppgave(tilstandType = UNDER_BEHANDLING, saksbehandler = saksbehandlerUtenEkstraTilganger)
         shouldThrow<ManglendeTilgang> {
             oppgave.avbryt(
                 AvbrytOppgaveHendelse(
@@ -568,7 +568,7 @@ class OppgaveTilgangTest {
 
     @Test
     fun `Ferdigstilling av oppgave under behandling med brev krever at utførende saksbehandler også eier oppgaven`() {
-        val oppgave = lagOppgave(tilstandType = UNDER_BEHANDLING, behandler = saksbehandlerUtenEkstraTilganger)
+        val oppgave = lagOppgave(tilstandType = UNDER_BEHANDLING, saksbehandler = saksbehandlerUtenEkstraTilganger)
         shouldThrow<ManglendeTilgang> {
             oppgave.ferdigstill(
                 GodkjentBehandlingHendelse(
@@ -591,11 +591,11 @@ class OppgaveTilgangTest {
     }
 
     @Test
-    fun `Ferdigstilling av oppgave under kontroll krever at utførende eier oppgaven og er beslutter`() {
-        val beslutterSomEierOppgaven = Saksbehandler("eier", setOf(), setOf(BESLUTTER))
+    fun `Ferdigstilling av oppgave under kontroll krever at utførende behandler eier oppgaven og er beslutter`() {
+        val beslutter = Saksbehandler("eier", setOf(), setOf(BESLUTTER))
         val saksbehandler = Saksbehandler("saksbehandler", setOf(), setOf(SAKSBEHANDLER))
+        val oppgave = lagOppgave(tilstandType = UNDER_KONTROLL, saksbehandler = saksbehandler, beslutter = beslutter)
 
-        val oppgave = lagOppgave(tilstandType = UNDER_KONTROLL, behandler = beslutterSomEierOppgaven)
         shouldThrow<ManglendeTilgang> {
             oppgave.ferdigstill(
                 GodkjentBehandlingHendelse(
@@ -620,7 +620,7 @@ class OppgaveTilgangTest {
         val saksbehandlerSomVarBeslutter =
             Saksbehandler("saksbehandler som var beslutter", setOf(), setOf(SAKSBEHANDLER))
         val oppgaveUnderKontrollUtenBeslutter =
-            lagOppgave(tilstandType = UNDER_KONTROLL, behandler = saksbehandlerSomVarBeslutter)
+            lagOppgave(tilstandType = UNDER_KONTROLL, saksbehandler = saksbehandlerSomVarBeslutter)
         shouldThrow<ManglendeTilgang> {
             oppgaveUnderKontrollUtenBeslutter.ferdigstill(
                 GodkjentBehandlingHendelse(
@@ -636,7 +636,7 @@ class OppgaveTilgangTest {
                 GodkjentBehandlingHendelse(
                     oppgaveId = oppgave.oppgaveId,
                     meldingOmVedtak = "<HTML>en melding</HTML>",
-                    utførtAv = beslutterSomEierOppgaven,
+                    utførtAv = beslutter,
                 ),
             )
         }
@@ -646,15 +646,7 @@ class OppgaveTilgangTest {
     fun `Oppgave klar til kontroll kan ikke tildeles samme behandler som saksbehandlet, selv om hen er beslutter`() {
         val beslutterSomSaksbehandlet =
             Saksbehandler("beslutterSomSaksbehandlet", setOf(), setOf(SAKSBEHANDLER, BESLUTTER))
-        val oppgave = lagOppgave(tilstandType = KLAR_TIL_KONTROLL)
-        oppgave.tilstandslogg.leggTil(
-            UNDER_BEHANDLING,
-            SettOppgaveAnsvarHendelse(
-                oppgaveId = oppgave.oppgaveId,
-                ansvarligIdent = beslutterSomSaksbehandlet.navIdent,
-                utførtAv = beslutterSomSaksbehandlet,
-            ),
-        )
+        val oppgave = lagOppgave(tilstandType = KLAR_TIL_KONTROLL, saksbehandler = beslutterSomSaksbehandlet)
 
         shouldThrow<ManglendeTilgang> {
             oppgave.tildel(
@@ -680,40 +672,24 @@ class OppgaveTilgangTest {
 
     @Test
     fun `Oppgave under kontroll kan ikke ferdigstilles av samme behandler som saksbehandlet, selv om hen er beslutter`() {
-        val beslutterSomSaksbehandlet = Saksbehandler("eier", setOf(), setOf(SAKSBEHANDLER, BESLUTTER))
-        val oppgave1 = lagOppgave(tilstandType = UNDER_KONTROLL, behandler = beslutterSomSaksbehandlet)
-        oppgave1.tilstandslogg.leggTil(
-            UNDER_BEHANDLING,
-            SettOppgaveAnsvarHendelse(
-                oppgaveId = oppgave1.oppgaveId,
-                ansvarligIdent = beslutterSomSaksbehandlet.navIdent,
-                utførtAv = beslutterSomSaksbehandlet,
-            ),
-        )
+        val beslutterSomSaksbehandlet = Saksbehandler("beslutter", setOf(), setOf(SAKSBEHANDLER, BESLUTTER))
+        val enAnnenBeslutter = Saksbehandler("enAnnenBeslutter", setOf(), setOf(SAKSBEHANDLER, BESLUTTER))
+        val oppgave = lagOppgave(tilstandType = UNDER_KONTROLL, saksbehandler = beslutterSomSaksbehandlet, beslutter = enAnnenBeslutter)
+
         shouldThrow<ManglendeTilgang> {
-            oppgave1.ferdigstill(
+            oppgave.ferdigstill(
                 GodkjentBehandlingHendelse(
-                    oppgaveId = oppgave1.oppgaveId,
+                    oppgaveId = oppgave.oppgaveId,
                     meldingOmVedtak = "<HTML>en melding</HTML>",
                     utførtAv = beslutterSomSaksbehandlet,
                 ),
             )
         }
 
-        val enAnnenBeslutter = Saksbehandler("enAnnenBeslutter", setOf(), setOf(SAKSBEHANDLER, BESLUTTER))
-        val oppgave2 = lagOppgave(tilstandType = UNDER_KONTROLL, behandler = enAnnenBeslutter)
-        oppgave2.tilstandslogg.leggTil(
-            UNDER_BEHANDLING,
-            SettOppgaveAnsvarHendelse(
-                oppgaveId = oppgave2.oppgaveId,
-                ansvarligIdent = beslutterSomSaksbehandlet.navIdent,
-                utførtAv = beslutterSomSaksbehandlet,
-            ),
-        )
         shouldNotThrow<ManglendeTilgang> {
-            oppgave2.ferdigstill(
+            oppgave.ferdigstill(
                 GodkjentBehandlingHendelse(
-                    oppgaveId = oppgave2.oppgaveId,
+                    oppgaveId = oppgave.oppgaveId,
                     meldingOmVedtak = "<HTML>en melding</HTML>",
                     utførtAv = enAnnenBeslutter,
                 ),
@@ -723,40 +699,26 @@ class OppgaveTilgangTest {
 
     @Test
     fun `Oppgave under kontroll kan ikke retureres til saksbehandling av samme behandler som saksbehandlet`() {
-        val beslutterSomSaksbehandlet = Saksbehandler("eier", setOf(), setOf(SAKSBEHANDLER, BESLUTTER))
-        val oppgave1 = lagOppgave(tilstandType = UNDER_KONTROLL, behandler = beslutterSomSaksbehandlet)
-        oppgave1.tilstandslogg.leggTil(
-            UNDER_BEHANDLING,
-            SettOppgaveAnsvarHendelse(
-                oppgaveId = oppgave1.oppgaveId,
-                ansvarligIdent = beslutterSomSaksbehandlet.navIdent,
-                utførtAv = beslutterSomSaksbehandlet,
-            ),
-        )
+        val beslutter1 = Saksbehandler("beslutter 1", setOf(), setOf(SAKSBEHANDLER, BESLUTTER))
+        val oppgave1 = lagOppgave(tilstandType = UNDER_KONTROLL, saksbehandler = beslutter1, beslutter = beslutter1)
+
         shouldThrow<ManglendeTilgang> {
             oppgave1.returnerTilSaksbehandling(
                 ReturnerTilSaksbehandlingHendelse(
                     oppgaveId = oppgave1.oppgaveId,
-                    utførtAv = beslutterSomSaksbehandlet,
+                    utførtAv = beslutter1,
                 ),
             )
         }
 
-        val enAnnenBeslutter = Saksbehandler("beslutter 2", setOf(), setOf(SAKSBEHANDLER, BESLUTTER))
-        val oppgave2 = lagOppgave(tilstandType = UNDER_KONTROLL, behandler = enAnnenBeslutter)
-        oppgave2.tilstandslogg.leggTil(
-            UNDER_BEHANDLING,
-            SettOppgaveAnsvarHendelse(
-                oppgaveId = oppgave2.oppgaveId,
-                ansvarligIdent = beslutterSomSaksbehandlet.navIdent,
-                utførtAv = beslutterSomSaksbehandlet,
-            ),
-        )
+        val beslutter2 = Saksbehandler("beslutter 2", setOf(), setOf(SAKSBEHANDLER, BESLUTTER))
+        val oppgave2 = lagOppgave(tilstandType = UNDER_KONTROLL, saksbehandler = beslutter1, beslutter = beslutter2)
+
         shouldNotThrow<ManglendeTilgang> {
             oppgave2.returnerTilSaksbehandling(
                 ReturnerTilSaksbehandlingHendelse(
                     oppgaveId = oppgave2.oppgaveId,
-                    utførtAv = enAnnenBeslutter,
+                    utførtAv = beslutter2,
                 ),
             )
         }
@@ -774,7 +736,7 @@ class OppgaveTilgangTest {
             lagOppgave(
                 adressebeskyttelseGradering = adressebeskyttelseGradering,
                 tilstandType = UNDER_BEHANDLING,
-                behandler = saksbehandler,
+                saksbehandler = saksbehandler,
             )
 
         if (forventetTilgang) {
@@ -810,7 +772,7 @@ class OppgaveTilgangTest {
                 lagOppgave(
                     tilstandType = UNDER_BEHANDLING,
                     skjermesSomEgneAnsatte = true,
-                    behandler = saksbehandler,
+                    saksbehandler = saksbehandler,
                 )
             oppgave.ferdigstill(
                 GodkjentBehandlingHendelse(
@@ -826,7 +788,7 @@ class OppgaveTilgangTest {
                 lagOppgave(
                     tilstandType = UNDER_BEHANDLING,
                     skjermesSomEgneAnsatte = true,
-                    behandler = saksbehandlerMedEgneAnsatteTilgang,
+                    saksbehandler = saksbehandlerMedEgneAnsatteTilgang,
                 )
             oppgave.ferdigstill(
                 GodkjentBehandlingHendelse(
@@ -842,7 +804,7 @@ class OppgaveTilgangTest {
                 lagOppgave(
                     tilstandType = UNDER_BEHANDLING,
                     skjermesSomEgneAnsatte = true,
-                    behandler = saksbehandler,
+                    saksbehandler = saksbehandler,
                 )
             oppgave.ferdigstill(
                 GodkjentBehandlingHendelse(
@@ -858,7 +820,7 @@ class OppgaveTilgangTest {
                 lagOppgave(
                     tilstandType = UNDER_BEHANDLING,
                     skjermesSomEgneAnsatte = true,
-                    behandler = saksbehandlerMedEgneAnsatteTilgang,
+                    saksbehandler = saksbehandlerMedEgneAnsatteTilgang,
                 )
             oppgave.ferdigstill(
                 GodkjentBehandlingHendelse(

--- a/modell/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveTilstandTest.kt
+++ b/modell/src/test/kotlin/no/nav/dagpenger/saksbehandling/OppgaveTilstandTest.kt
@@ -33,7 +33,6 @@ import no.nav.dagpenger.saksbehandling.hendelser.ForslagTilVedtakHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.GodkjentBehandlingHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.InnsendingMottattHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.Kategori
-import no.nav.dagpenger.saksbehandling.hendelser.NesteOppgaveHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.OpprettOppfølgingHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.ReturnerTilSaksbehandlingHendelse
 import no.nav.dagpenger.saksbehandling.hendelser.SendTilKontrollHendelse
@@ -68,8 +67,9 @@ class OppgaveTilstandTest {
 
     @Test
     fun `Skal på nytt kunne tildele en oppgave UnderKontroll til samme beslutter`() {
+        val saksbehandler = Saksbehandler("saksbehandler", emptySet(), setOf(SAKSBEHANDLER))
         val beslutter = Saksbehandler("beslutter", emptySet(), setOf(BESLUTTER))
-        val oppgave = lagOppgave(tilstandType = UNDER_KONTROLL, beslutter)
+        val oppgave = lagOppgave(tilstandType = UNDER_KONTROLL, saksbehandler = saksbehandler, beslutter = beslutter)
         shouldNotThrow<AlleredeTildeltException> {
             oppgave.tildel(
                 SettOppgaveAnsvarHendelse(
@@ -214,7 +214,7 @@ class OppgaveTilstandTest {
             setOf(UNDER_BEHANDLING)
 
         lovligeTilstander.forEach { tilstand ->
-            val oppgave = lagOppgave(tilstand, behandler = saksbehandler)
+            val oppgave = lagOppgave(tilstand, saksbehandler = saksbehandler)
             shouldNotThrowAny {
                 oppgave.ferdigstill(
                     avbruttHendelse =
@@ -228,7 +228,7 @@ class OppgaveTilstandTest {
         }
 
         (Type.values.toMutableSet() - lovligeTilstander).forEach { tilstand ->
-            val oppgave = lagOppgave(tilstand, behandler = saksbehandler)
+            val oppgave = lagOppgave(tilstand, saksbehandler = saksbehandler)
             shouldThrow<UlovligTilstandsendringException> {
                 oppgave.ferdigstill(
                     avbruttHendelse =
@@ -256,7 +256,7 @@ class OppgaveTilstandTest {
             )
 
         lovligeTilstander.forEach { tilstand ->
-            val oppgave = lagOppgave(tilstand, behandler = null)
+            val oppgave = lagOppgave(tilstand, saksbehandler = null)
             shouldNotThrowAny {
                 oppgave.avbryt(
                     BehandlingAvbruttHendelse(
@@ -294,7 +294,7 @@ class OppgaveTilstandTest {
         val lovligeTilstander = setOf(UNDER_BEHANDLING)
 
         lovligeTilstander.forEach { tilstand ->
-            val oppgave = lagOppgave(tilstandType = tilstand, behandler = saksbehandler)
+            val oppgave = lagOppgave(tilstandType = tilstand, saksbehandler = saksbehandler)
             shouldNotThrowAny {
                 oppgave.avbryt(
                     AvbrytOppgaveHendelse(
@@ -336,7 +336,7 @@ class OppgaveTilstandTest {
             )
 
         lovligeTilstander.forEach { tilstand ->
-            val oppgave = lagOppgave(tilstand, behandler = null)
+            val oppgave = lagOppgave(tilstand, saksbehandler = null)
             shouldNotThrowAny {
                 oppgave.oppgaveKlarTilBehandling(
                     ForslagTilVedtakHendelse(
@@ -379,7 +379,7 @@ class OppgaveTilstandTest {
 
     @Test
     fun `Skal gå fra UnderBehandling til KlarTilBehandling når oppgaveansvar fjernes`() {
-        val oppgave = lagOppgave(tilstandType = UNDER_BEHANDLING, behandler = saksbehandler)
+        val oppgave = lagOppgave(tilstandType = UNDER_BEHANDLING, saksbehandler = saksbehandler)
 
         shouldNotThrowAny {
             oppgave.fjernAnsvar(
@@ -396,7 +396,7 @@ class OppgaveTilstandTest {
 
     @Test
     fun `Skal gå fra UnderBehandling til Avbrutt når oppgaven avbrytes`() {
-        val oppgave = lagOppgave(tilstandType = UNDER_BEHANDLING, behandler = saksbehandler)
+        val oppgave = lagOppgave(tilstandType = UNDER_BEHANDLING, saksbehandler = saksbehandler)
 
         shouldNotThrowAny {
             oppgave.avbryt(
@@ -413,7 +413,7 @@ class OppgaveTilstandTest {
 
     @Test
     fun `Skal gå fra UnderKontroll til KlarTilKontroll når oppgaveansvar fjernes`() {
-        val oppgave = lagOppgave(tilstandType = UNDER_KONTROLL, behandler = saksbehandler)
+        val oppgave = lagOppgave(tilstandType = UNDER_KONTROLL, saksbehandler = saksbehandler)
 
         shouldNotThrowAny {
             oppgave.fjernAnsvar(
@@ -435,22 +435,8 @@ class OppgaveTilstandTest {
         val oppgave =
             lagOppgave(
                 tilstandType = UNDER_KONTROLL,
-                behandler = beslutter,
-                tilstandslogg =
-                    OppgaveTilstandslogg(
-                        tilstandsendringer =
-                            mutableListOf(
-                                Tilstandsendring(
-                                    tilstand = UNDER_BEHANDLING,
-                                    hendelse =
-                                        NesteOppgaveHendelse(
-                                            ansvarligIdent = saksbehandler.navIdent,
-                                            utførtAv = saksbehandler,
-                                        ),
-                                    tidspunkt = LocalDateTime.now().minusDays(1),
-                                ),
-                            ),
-                    ),
+                saksbehandler = saksbehandler,
+                beslutter = beslutter,
             )
 
         shouldNotThrowAny {
@@ -470,7 +456,7 @@ class OppgaveTilstandTest {
     @Test
     fun `Skal gå fra UnderBehandling til FerdigBehandlet når saksbehandler godkjenner en behandling`() {
         val saksbehandler = Saksbehandler("sIdent", emptySet())
-        val oppgave = lagOppgave(tilstandType = UNDER_BEHANDLING, behandler = saksbehandler)
+        val oppgave = lagOppgave(tilstandType = UNDER_BEHANDLING, saksbehandler = saksbehandler)
 
         oppgave.ferdigstill(
             godkjentBehandlingHendelse =
@@ -758,7 +744,7 @@ class OppgaveTilstandTest {
 
     @Test
     fun `Skal gå fra KlarTilBehandling til Avbrutt når oppgaven avbrytes`() {
-        val oppgave = lagOppgave(tilstandType = KLAR_TIL_BEHANDLING, behandler = saksbehandler)
+        val oppgave = lagOppgave(tilstandType = KLAR_TIL_BEHANDLING, saksbehandler = saksbehandler)
 
         shouldNotThrowAny {
             oppgave.avbryt(
@@ -816,8 +802,9 @@ class OppgaveTilstandTest {
 
     @Test
     fun `Skal ferdigstille med brev i ny løsning fra UnderKontroll`() {
-        val beslutter = Saksbehandler("Z080808", emptySet(), setOf(BESLUTTER))
-        val oppgave = lagOppgave(UNDER_KONTROLL, beslutter)
+        val saksbehandler = Saksbehandler("saksbehandler", emptySet(), setOf(SAKSBEHANDLER))
+        val beslutter = Saksbehandler("beslutter", emptySet(), setOf(BESLUTTER))
+        val oppgave = lagOppgave(tilstandType = UNDER_KONTROLL, saksbehandler = saksbehandler, beslutter = beslutter)
         oppgave.ferdigstill(
             godkjentBehandlingHendelse =
                 GodkjentBehandlingHendelse(
@@ -829,38 +816,6 @@ class OppgaveTilstandTest {
 
         oppgave.tilstand() shouldBe Oppgave.FerdigBehandlet
         oppgave.behandlerIdent shouldBe beslutter.navIdent
-    }
-
-    @Test
-    fun `Finn siste saksbehandler når oppgave er tildelt via neste-oppgave funksjon`() {
-        val saksbehandler = Saksbehandler("Z080808", emptySet())
-        val oppgave =
-            lagOppgave(
-                tilstandType = UNDER_BEHANDLING,
-                tilstandslogg =
-                    OppgaveTilstandslogg().also {
-                        it.leggTil(
-                            nyTilstand = KLAR_TIL_BEHANDLING,
-                            hendelse =
-                                ForslagTilVedtakHendelse(
-                                    ident = "11111155555",
-                                    behandlingId = UUIDv7.ny(),
-                                    behandletHendelseId = UUIDv7.ny().toString(),
-                                    behandletHendelseType = "Søknad",
-                                    emneknagger = emptySet(),
-                                ),
-                        )
-                        it.leggTil(
-                            nyTilstand = UNDER_BEHANDLING,
-                            hendelse =
-                                NesteOppgaveHendelse(
-                                    ansvarligIdent = saksbehandler.navIdent,
-                                    utførtAv = saksbehandler,
-                                ),
-                        )
-                    },
-            )
-        oppgave.sisteSaksbehandler() shouldBe saksbehandler.navIdent
     }
 
     @Test
@@ -877,11 +832,11 @@ class OppgaveTilstandTest {
             ),
         )
 
-        oppgave.sisteSaksbehandler() shouldBe null
+        oppgave.sisteSaksbehandlerIdent shouldBe null
 
         val saksbehandler1 = Saksbehandler("saksbehandler 1", emptySet())
         oppgave.tildel(SettOppgaveAnsvarHendelse(oppgaveId, saksbehandler1.navIdent, saksbehandler1))
-        oppgave.sisteSaksbehandler() shouldBe saksbehandler1.navIdent
+        oppgave.sisteSaksbehandlerIdent shouldBe saksbehandler1.navIdent
 
         oppgave.fjernAnsvar(
             FjernOppgaveAnsvarHendelse(
@@ -889,14 +844,14 @@ class OppgaveTilstandTest {
                 utførtAv = saksbehandler1,
             ),
         )
-        oppgave.sisteSaksbehandler() shouldBe saksbehandler1.navIdent
+        oppgave.sisteSaksbehandlerIdent shouldBe null
 
         val saksbehandler2 = Saksbehandler("saksbehandler 2", emptySet())
         oppgave.tildel(SettOppgaveAnsvarHendelse(oppgaveId, saksbehandler2.navIdent, saksbehandler2))
-        oppgave.sisteSaksbehandler() shouldBe saksbehandler2.navIdent
+        oppgave.sisteSaksbehandlerIdent shouldBe saksbehandler2.navIdent
 
         oppgave.sendTilKontroll(SendTilKontrollHendelse(oppgaveId = oppgaveId, utførtAv = saksbehandler2))
-        oppgave.sisteSaksbehandler() shouldBe saksbehandler2.navIdent
+        oppgave.sisteSaksbehandlerIdent shouldBe saksbehandler2.navIdent
 
         val beslutter1 = Saksbehandler("beslutter 1", emptySet(), setOf(BESLUTTER))
         oppgave.tildel(
@@ -906,18 +861,18 @@ class OppgaveTilstandTest {
                 utførtAv = beslutter1,
             ),
         )
-        oppgave.sisteBeslutter() shouldBe beslutter1.navIdent
+        oppgave.sisteBeslutterIdent shouldBe beslutter1.navIdent
 
         oppgave.returnerTilSaksbehandling(ReturnerTilSaksbehandlingHendelse(oppgaveId = oppgaveId, utførtAv = beslutter1))
 
-        oppgave.sisteBeslutter() shouldBe beslutter1.navIdent
-        oppgave.sisteSaksbehandler() shouldBe saksbehandler2.navIdent
+        oppgave.sisteBeslutterIdent shouldBe beslutter1.navIdent
+        oppgave.sisteSaksbehandlerIdent shouldBe saksbehandler2.navIdent
 
         val beslutter2 = Saksbehandler("beslutter 2", emptySet(), setOf(BESLUTTER))
         oppgave.sendTilKontroll(SendTilKontrollHendelse(oppgaveId = oppgave.oppgaveId, utførtAv = saksbehandler2))
 
-        oppgave.sisteBeslutter() shouldBe beslutter1.navIdent
-        oppgave.sisteSaksbehandler() shouldBe saksbehandler2.navIdent
+        oppgave.sisteBeslutterIdent shouldBe beslutter1.navIdent
+        oppgave.sisteSaksbehandlerIdent shouldBe saksbehandler2.navIdent
         oppgave.tilstand().type shouldBe UNDER_KONTROLL
 
         oppgave.fjernAnsvar(FjernOppgaveAnsvarHendelse(oppgaveId = oppgaveId, utførtAv = beslutter1))
@@ -928,8 +883,8 @@ class OppgaveTilstandTest {
                 utførtAv = beslutter2,
             ),
         )
-        oppgave.sisteBeslutter() shouldBe beslutter2.navIdent
-        oppgave.sisteSaksbehandler() shouldBe saksbehandler2.navIdent
+        oppgave.sisteBeslutterIdent shouldBe beslutter2.navIdent
+        oppgave.sisteSaksbehandlerIdent shouldBe saksbehandler2.navIdent
 
         oppgave.ferdigstill(
             godkjentBehandlingHendelse =
@@ -998,7 +953,7 @@ class OppgaveTilstandTest {
 
         lagOppgave(
             tilstandType = PAA_VENT,
-            behandler = saksbehandler,
+            saksbehandler = saksbehandler,
         ).let {
             it.settEmneknagg(innsendingMottattHendelse)
             it.tilstand() shouldBe Oppgave.UnderBehandling
@@ -1030,7 +985,7 @@ class OppgaveTilstandTest {
         oppgave.tilstand() shouldBe Oppgave.UnderBehandling
         oppgave.behandlerIdent shouldBe saksbehandler.navIdent
         oppgave.utsattTil() shouldBe null
-        oppgave.sisteSaksbehandler() shouldBe saksbehandler.navIdent
+        oppgave.sisteSaksbehandlerIdent shouldBe saksbehandler.navIdent
     }
 
     @Test
@@ -1078,23 +1033,9 @@ class OppgaveTilstandTest {
         val oppgave =
             lagOppgave(
                 tilstandType = UNDER_KONTROLL,
-                behandler = beslutter,
+                saksbehandler = saksbehandler,
+                beslutter = beslutter,
                 emneknagger = setOf(Emneknagg.Kontroll.TIDLIGERE_KONTROLLERT.visningsnavn),
-                tilstandslogg =
-                    OppgaveTilstandslogg(
-                        tilstandsendringer =
-                            mutableListOf(
-                                Tilstandsendring(
-                                    tilstand = UNDER_BEHANDLING,
-                                    hendelse =
-                                        NesteOppgaveHendelse(
-                                            ansvarligIdent = saksbehandler.navIdent,
-                                            utførtAv = saksbehandler,
-                                        ),
-                                    tidspunkt = LocalDateTime.now().minusDays(1),
-                                ),
-                            ),
-                    ),
             )
 
         shouldNotThrowAny {
@@ -1118,7 +1059,7 @@ class OppgaveTilstandTest {
         val oppgave =
             lagOppgave(
                 tilstandType = UNDER_KONTROLL,
-                behandler = beslutter,
+                beslutter = beslutter,
             )
 
         shouldNotThrowAny {
@@ -1163,22 +1104,7 @@ class OppgaveTilstandTest {
         val oppgave =
             lagOppgave(
                 tilstandType = KLAR_TIL_KONTROLL,
-                behandler = null,
-                tilstandslogg =
-                    OppgaveTilstandslogg(
-                        tilstandsendringer =
-                            mutableListOf(
-                                Tilstandsendring(
-                                    tilstand = UNDER_BEHANDLING,
-                                    hendelse =
-                                        NesteOppgaveHendelse(
-                                            ansvarligIdent = saksbehandler.navIdent,
-                                            utførtAv = saksbehandler,
-                                        ),
-                                    tidspunkt = LocalDateTime.now().minusDays(1),
-                                ),
-                            ),
-                    ),
+                saksbehandler = saksbehandler,
             )
 
         shouldNotThrowAny {


### PR DESCRIPTION
- **OpprettOppfølging: Legger inn en under behandling hendelse i tilstandsloggen for å sette ansvar til saksbehandler på samme måte som ved tildeling av oppgave når den settes på vent.**
- **WIP: Egne felter for saksbehandler og beslutter på oppgave.**
- **Migrering av verdier til siste_saksbehandler_ident og siste_beslutter_ident. Deploy til dev.**
- **Ved søk på en bestemt saksbehandler-ident, søker vi både på siste saksbehandler og siste beslutter. Index opprettes på disse kolonnene.**
- **Slå sammen migreringsskriptene for siste saksbehandler/beslutter på oppgave og gjør skriptet rekjørbart, slik at det kan kjøres på nytt i dev (etter sletting av de to aktuelle radene i flyway history tabellen).**
